### PR TITLE
iOS Text Input Refactoring

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -16,12 +16,10 @@
 
 #import <UIKit/UIKit.h>
 #import "CMPEditMenuCustomAction.h"
-#import "CMPTextInputView.h"
 
-@interface CMPEditMenuView : CMPTextInputView
+@interface CMPEditMenuView : UIView
 
 @property (readonly) BOOL isEditMenuShown;
-@property (readonly) BOOL shouldUseNonComposeMenuActions;
 
 - (void)showEditMenuAtRect:(CGRect)targetRect
                       copy:(void (^)(void))copyBlock
@@ -43,9 +41,5 @@
 - (UIView *)inputView;
 
 - (UIView *)inputAccessoryView;
-
-- (void)activateTextInputInteractionIfNeeded;
-
-- (void)deactivateTextInputInteractionIfNeeded;
 
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -74,7 +74,6 @@
 
 @property (assign, nonatomic) CGRect targetRect;
 @property (assign, nonatomic) BOOL isEditMenuShown;
-@property (assign, nonatomic) BOOL shouldUseNonComposeMenuActions;
 
 @property (readwrite) UIEditMenuInteraction* editInteraction API_AVAILABLE(ios(16.0));
 
@@ -325,9 +324,7 @@ id _editInteraction;
     if (@selector(customAction8:) == action) return self.customActions.count > 8;
     if (@selector(customAction9:) == action) return self.customActions.count > 9;
 
-    if (self.shouldUseNonComposeMenuActions) {
-        return [super canPerformAction:action withSender:sender];
-    } else { return NO; }
+    return NO;
 }
 
 - (void)copy:(id)sender {
@@ -439,26 +436,6 @@ willPresentMenuForConfiguration:(UIEditMenuConfiguration *)configuration
     NSArray *allActions = [suggestedActions arrayByAddingObjectsFromArray:[self makeCustomMenuElements]];
     
     return [UIMenu menuWithTitle:@"" children:allActions];
-}
-
-- (void)activateTextInputInteractionIfNeeded {
-    if (@available(iOS 17, *)) {
-        for (id<UIInteraction> interaction in self.interactions) {
-            if ([interaction isKindOfClass:[UITextSelectionDisplayInteraction class]]) {
-                [((UITextSelectionDisplayInteraction *)interaction) setActivated:YES];
-            }
-        }
-    }
-}
-
-- (void)deactivateTextInputInteractionIfNeeded {
-    if (@available(iOS 17, *)) {
-        for (id<UIInteraction> interaction in self.interactions) {
-            if ([interaction isKindOfClass:[UITextSelectionDisplayInteraction class]]) {
-                [((UITextSelectionDisplayInteraction *)interaction) setActivated:NO];
-            }
-        }
-    }
 }
 
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextInputView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextInputView.h
@@ -26,4 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                 atCharacterOffset:(NSInteger)offset CMP_ABSTRACT_FUNCTION;
 NS_ASSUME_NONNULL_END
 
+- (void)activateTextInputInteractionIfNeeded;
+
+- (void)deactivateTextInputInteractionIfNeeded;
+
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextInputView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextInputView.m
@@ -125,4 +125,24 @@
     CMP_ABSTRACT_FUNCTION_CALLED
 }
 
+- (void)activateTextInputInteractionIfNeeded {
+    if (@available(iOS 17, *)) {
+        for (id<UIInteraction> interaction in self.interactions) {
+            if ([interaction isKindOfClass:[UITextSelectionDisplayInteraction class]]) {
+                [((UITextSelectionDisplayInteraction *)interaction) setActivated:YES];
+            }
+        }
+    }
+}
+
+- (void)deactivateTextInputInteractionIfNeeded {
+    if (@available(iOS 17, *)) {
+        for (id<UIInteraction> interaction in self.interactions) {
+            if ([interaction isKindOfClass:[UITextSelectionDisplayInteraction class]]) {
+                [((UITextSelectionDisplayInteraction *)interaction) setActivated:NO];
+            }
+        }
+    }
+}
+
 @end

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -160,6 +160,13 @@ internal interface TextInputDelegate {
      */
     fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int?
 
+}
+
+/**
+ * Extension of [TextInputDelegate] for the Native iOS Text Input path.
+ */
+internal interface NativeTextInputDelegate : TextInputDelegate {
+
     /**
      * Returns the caret rectangle for a given text position.
      * https://developer.apple.com/documentation/uikit/uitextinput/caretrect(for:)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -238,7 +238,7 @@ internal fun TextEditingDelegate.withDeferredEditBatch(
     }
 }
 
-internal class IntermediateTextPosition(val position: Int = 0) : UITextPosition() {
+internal class TextInputPosition(val position: Int = 0) : UITextPosition() {
     override fun description(): String {
         return "IntermediateTextPosition($position)"
     }
@@ -248,15 +248,15 @@ internal class IntermediateTextPosition(val position: Int = 0) : UITextPosition(
     }
 }
 
-internal fun IntermediateTextRange(start: Int, end: Int) =
-    IntermediateTextRange(
-        _start = IntermediateTextPosition(start),
-        _end = IntermediateTextPosition(end)
+internal fun TextInputRange(start: Int, end: Int) =
+    TextInputRange(
+        _start = TextInputPosition(start),
+        _end = TextInputPosition(end)
     )
 
-internal class IntermediateTextRange(
-    val _start: IntermediateTextPosition,
-    val _end: IntermediateTextPosition
+internal class TextInputRange(
+    val _start: TextInputPosition,
+    val _end: TextInputPosition
 ) : UITextRange() {
     override fun isEmpty() = (_end.position - _start.position) <= 0
     override fun start(): UITextPosition = _start
@@ -269,13 +269,13 @@ internal class IntermediateTextRange(
 
 // Despite UITextRange being declared as non-null, iOS can still pass null to methods that take a UITextRange parameter.
 internal fun UITextRange.toTextRange(): TextRange? {
-    val start = (start() as? IntermediateTextPosition)?.position ?: return null
-    val end = (end() as? IntermediateTextPosition)?.position ?: return null
+    val start = (start() as? TextInputPosition)?.position ?: return null
+    val end = (end() as? TextInputPosition)?.position ?: return null
     return TextRange(start, end)
 }
 
 internal fun TextRange.toUITextRange(): UITextRange =
-    IntermediateTextRange(start = start, end = end)
+    TextInputRange(start = start, end = end)
 
 internal class IntermediateTextSelectionRect(
     private var _rect: CValue<CGRect>,
@@ -300,7 +300,7 @@ internal class IntermediateTextSelectionRect(
     override fun isVertical(): Boolean = _isVertical
 }
 
-internal class IntermediateTextTokenizer(
+internal class TextInputStringTokenizer(
     textInput: UIResponder,
     val getString: () -> String?
 ): CMPTextInputStringTokenizer(textInput) {
@@ -311,7 +311,7 @@ internal class IntermediateTextTokenizer(
         toBoundary: UITextGranularity,
         inDirection: UITextDirection
     ): UITextPosition? {
-        val textPosition = position as? IntermediateTextPosition ?: return null
+        val textPosition = position as? TextInputPosition ?: return null
         val isForward = inDirection == UITextStorageDirectionForward ||
             inDirection == UITextLayoutDirectionRight ||
             inDirection == UITextLayoutDirectionDown
@@ -344,7 +344,7 @@ internal class IntermediateTextTokenizer(
             }
         }
 
-        return IntermediateTextPosition(iteratorResult)
+        return TextInputPosition(iteratorResult)
     }
 
     override fun isPositionAtBoundary(
@@ -352,7 +352,7 @@ internal class IntermediateTextTokenizer(
         atBoundary: UITextGranularity,
         inDirection: UITextDirection
     ): Boolean {
-        val textPosition = position as? IntermediateTextPosition ?: return false
+        val textPosition = position as? TextInputPosition ?: return false
 
         val iterator = when (atBoundary) {
             UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
@@ -373,7 +373,7 @@ internal class IntermediateTextTokenizer(
         position: UITextPosition,
         isForward: Boolean
     ): UITextPosition? {
-        val textPosition = position as? IntermediateTextPosition ?: return null
+        val textPosition = position as? TextInputPosition ?: return null
 
         val string = getString() ?: ""
         var location = textPosition.position
@@ -391,7 +391,7 @@ internal class IntermediateTextTokenizer(
                 location--
             }
         }
-        return IntermediateTextPosition(location)
+        return TextInputPosition(location)
     }
 
     private fun isAtParagraphBoundary(text: String, position: Int): Boolean {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRect
+import platform.Foundation.NSCharacterSet
 import platform.UIKit.NSWritingDirection
 import platform.UIKit.NSWritingDirectionLeftToRight
 import platform.UIKit.NSWritingDirectionNatural
@@ -318,11 +319,13 @@ private fun TextDirection.toUITextWritingDirection(): UITextWritingDirection = w
     else -> NSWritingDirectionNatural
 }
 
+private fun Char.isNewLineCharacter(): Boolean =
+    NSCharacterSet.newlineCharacterSet.characterIsMember(code.toUShort())
+
 internal class TextInputStringTokenizer(
     textInput: UIResponder,
     val getString: () -> String?
 ): CMPTextInputStringTokenizer(textInput) {
-    private val newLineCharacters = setOf('\n', '\r', '\u2029')
 
     override fun positionFromPosition(
         position: UITextPosition,
@@ -395,14 +398,16 @@ internal class TextInputStringTokenizer(
 
         val string = getString() ?: ""
         var location = textPosition.position
-        while (isForward && location < string.length || !isForward && location > 0) {
-            if (isForward) {
-                if (string[location] in newLineCharacters) {
+        if (isForward) {
+            while (location < string.length) {
+                if (string[location].isNewLineCharacter()) {
                     break
                 }
                 location++
-            } else {
-                if (string[location] in newLineCharacters) {
+            }
+        } else {
+            while (location > 0) {
+                if (string[location].isNewLineCharacter()) {
                     location++
                     break
                 }
@@ -414,7 +419,7 @@ internal class TextInputStringTokenizer(
 
     private fun isAtParagraphBoundary(text: String, position: Int): Boolean {
         if (position == 0 || position == text.length) return true
-        return text[position] in newLineCharacters || text[position - 1] in newLineCharacters
+        return text[position].isNewLineCharacter() || text[position - 1].isNewLineCharacter()
     }
 }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -44,7 +44,7 @@ import platform.UIKit.UITextSelectionRect
 import platform.UIKit.UITextStorageDirectionForward
 import platform.UIKit.UITextWritingDirection
 
-internal interface TextInputDelegate {
+internal interface TextEditingDelegate {
 
     fun onResignFocus()
 
@@ -163,9 +163,9 @@ internal interface TextInputDelegate {
 }
 
 /**
- * Extension of [TextInputDelegate] for the Native iOS Text Input path.
+ * Extension of [TextEditingDelegate] for the Native iOS Text Input path.
  */
-internal interface NativeTextInputDelegate : TextInputDelegate {
+internal interface NativeTextEditingDelegate : TextEditingDelegate {
 
     /**
      * Returns the caret rectangle for a given text position.
@@ -227,9 +227,9 @@ internal interface NativeTextInputDelegate : TextInputDelegate {
     fun positionWithinRange(range: TextRange, farthestInDirection: PlatformTextLayoutDirection): Int?
 }
 
-internal fun TextInputDelegate.withDeferredEditBatch(
+internal fun TextEditingDelegate.withDeferredEditBatch(
     withScope: CoroutineScope,
-    update: TextInputDelegate.() -> Unit
+    update: TextEditingDelegate.() -> Unit
 ) {
     beginEditBatch()
     update()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -45,6 +45,13 @@ import platform.UIKit.UITextStorageDirectionForward
 import platform.UIKit.UITextWritingDirection
 
 internal interface TextEditingDelegate {
+    var inputTraits: SkikoUITextInputTraits
+    
+    /**
+     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
+     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
+     */
+    var onKeyboardPresses: (Set<*>) -> Unit
 
     fun onResignFocus()
 
@@ -159,14 +166,12 @@ internal interface TextEditingDelegate {
      * Returned value must be in range between 0 and length of the text (inclusive).
      */
     fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int?
-
 }
 
 /**
  * Extension of [TextEditingDelegate] for the Native iOS Text Input path.
  */
 internal interface NativeTextEditingDelegate : TextEditingDelegate {
-
     /**
      * Returns the caret rectangle for a given text position.
      * https://developer.apple.com/documentation/uikit/uitextinput/caretrect(for:)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -17,11 +17,33 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.uikit.utils.CMPTextInputStringTokenizer
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.window.PlatformTextLayoutDirection
+import androidx.compose.ui.unit.asCGRect
+import kotlinx.cinterop.CValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.skia.BreakIterator
+import platform.CoreGraphics.CGRect
+import platform.UIKit.NSWritingDirection
+import platform.UIKit.NSWritingDirectionNatural
+import platform.UIKit.UIResponder
+import platform.UIKit.UITextDirection
+import platform.UIKit.UITextGranularity
+import platform.UIKit.UITextLayoutDirection
+import platform.UIKit.UITextLayoutDirectionDown
+import platform.UIKit.UITextLayoutDirectionLeft
+import platform.UIKit.UITextLayoutDirectionRight
+import platform.UIKit.UITextLayoutDirectionUp
+import platform.UIKit.UITextPosition
+import platform.UIKit.UITextRange
+import platform.UIKit.UITextSelectionRect
+import platform.UIKit.UITextStorageDirectionForward
+import platform.UIKit.UITextWritingDirection
 
-internal interface IOSSkikoInput {
+internal interface TextInputDelegate {
 
     fun onResignFocus()
 
@@ -195,4 +217,199 @@ internal interface IOSSkikoInput {
      * @return The farthest position within the range in the given direction, or `null` if none.
      */
     fun positionWithinRange(range: TextRange, farthestInDirection: PlatformTextLayoutDirection): Int?
+}
+
+internal fun TextInputDelegate.withDeferredEditBatch(
+    withScope: CoroutineScope,
+    update: TextInputDelegate.() -> Unit
+) {
+    beginEditBatch()
+    update()
+    withScope.launch {
+        endEditBatch()
+    }
+}
+
+internal class IntermediateTextPosition(val position: Int = 0) : UITextPosition() {
+    override fun description(): String {
+        return "IntermediateTextPosition($position)"
+    }
+
+    init {
+        assert(position >= 0) { "position should be >= 0" }
+    }
+}
+
+internal fun IntermediateTextRange(start: Int, end: Int) =
+    IntermediateTextRange(
+        _start = IntermediateTextPosition(start),
+        _end = IntermediateTextPosition(end)
+    )
+
+internal class IntermediateTextRange(
+    val _start: IntermediateTextPosition,
+    val _end: IntermediateTextPosition
+) : UITextRange() {
+    override fun isEmpty() = (_end.position - _start.position) <= 0
+    override fun start(): UITextPosition = _start
+    override fun end(): UITextPosition = _end
+
+    override fun description(): String {
+        return "IntermediateTextRange(start=$_start, end=$_end)"
+    }
+}
+
+// Despite UITextRange being declared as non-null, iOS can still pass null to methods that take a UITextRange parameter.
+internal fun UITextRange.toTextRange(): TextRange? {
+    val start = (start() as? IntermediateTextPosition)?.position ?: return null
+    val end = (end() as? IntermediateTextPosition)?.position ?: return null
+    return TextRange(start, end)
+}
+
+internal fun TextRange.toUITextRange(): UITextRange =
+    IntermediateTextRange(start = start, end = end)
+
+internal class IntermediateTextSelectionRect(
+    private var _rect: CValue<CGRect>,
+    private val _writingDirection: UITextWritingDirection,
+    private val _containsStart: Boolean,
+    private val _containsEnd: Boolean,
+    private val _isVertical: Boolean
+
+) : UITextSelectionRect() {
+    constructor(textSelectionRect: TextSelectionRect) : this(
+        textSelectionRect.dpRect.asCGRect(),
+        NSWritingDirectionNatural,
+        textSelectionRect.containsStart,
+        textSelectionRect.containsEnd,
+        textSelectionRect.isVertical
+    )
+
+    override fun rect(): CValue<CGRect> = _rect
+    override fun writingDirection(): NSWritingDirection = _writingDirection
+    override fun containsStart(): Boolean = _containsStart
+    override fun containsEnd(): Boolean = _containsEnd
+    override fun isVertical(): Boolean = _isVertical
+}
+
+internal class IntermediateTextTokenizer(
+    textInput: UIResponder,
+    val getString: () -> String?
+): CMPTextInputStringTokenizer(textInput) {
+    private val newLineCharacters = setOf('\n', '\r', '\u2029')
+
+    override fun positionFromPosition(
+        position: UITextPosition,
+        toBoundary: UITextGranularity,
+        inDirection: UITextDirection
+    ): UITextPosition? {
+        val textPosition = position as? IntermediateTextPosition ?: return null
+        val isForward = inDirection == UITextStorageDirectionForward ||
+            inDirection == UITextLayoutDirectionRight ||
+            inDirection == UITextLayoutDirectionDown
+
+        val iterator = when (toBoundary) {
+            UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
+            UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
+            UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
+            UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
+            UITextGranularity.UITextGranularityParagraph ->
+                return positionFromPositionToParagraphBoundary(position, isForward)
+
+            else -> return super.positionFromPosition(position, toBoundary, inDirection)
+        }
+
+        val string = getString() ?: ""
+        iterator.setText(string)
+
+        val iteratorResult = if (isForward) {
+            if (textPosition.position >= string.length - 1) {
+                string.length
+            } else {
+                iterator.following(textPosition.position)
+            }
+        } else {
+            if (textPosition.position <= 0) {
+                0
+            } else {
+                iterator.preceding(textPosition.position)
+            }
+        }
+
+        return IntermediateTextPosition(iteratorResult)
+    }
+
+    override fun isPositionAtBoundary(
+        position: UITextPosition,
+        atBoundary: UITextGranularity,
+        inDirection: UITextDirection
+    ): Boolean {
+        val textPosition = position as? IntermediateTextPosition ?: return false
+
+        val iterator = when (atBoundary) {
+            UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
+            UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
+            UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
+            UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
+            UITextGranularity.UITextGranularityParagraph -> {
+                return isAtParagraphBoundary(getString() ?: "", textPosition.position)
+            }
+            else -> return super.isPositionAtBoundary(position, atBoundary, inDirection)
+        }
+
+        iterator.setText(getString() ?: "")
+        return iterator.isBoundary(textPosition.position)
+    }
+
+    private fun positionFromPositionToParagraphBoundary(
+        position: UITextPosition,
+        isForward: Boolean
+    ): UITextPosition? {
+        val textPosition = position as? IntermediateTextPosition ?: return null
+
+        val string = getString() ?: ""
+        var location = textPosition.position
+        while (isForward && location < string.length || !isForward && location > 0) {
+            if (isForward) {
+                if (string[location] in newLineCharacters) {
+                    break
+                }
+                location++
+            } else {
+                if (string[location] in newLineCharacters) {
+                    location++
+                    break
+                }
+                location--
+            }
+        }
+        return IntermediateTextPosition(location)
+    }
+
+    private fun isAtParagraphBoundary(text: String, position: Int): Boolean {
+        if (position == 0 || position == text.length) return true
+        return text[position] in newLineCharacters || text[position - 1] in newLineCharacters
+    }
+}
+
+internal data class TextSelectionRect(
+    val dpRect: DpRect,
+    val writingDirection: TextDirection,
+    val containsStart: Boolean,
+    val containsEnd: Boolean,
+    val isVertical: Boolean
+)
+
+// Kotlin wrapper for UITextLayoutDirection
+internal enum class PlatformTextLayoutDirection(val platform: UITextLayoutDirection) {
+    Left(UITextLayoutDirectionLeft),
+    Right(UITextLayoutDirectionRight),
+    Up(UITextLayoutDirectionUp),
+    Down(UITextLayoutDirectionDown);
+
+    companion object {
+        operator fun invoke(platform: UITextLayoutDirection): PlatformTextLayoutDirection? {
+            return entries.find { it.platform == platform }
+        }
+    }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.platform
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.uikit.utils.CMPTextInputStringTokenizer
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.asCGRect
@@ -413,3 +414,6 @@ internal enum class PlatformTextLayoutDirection(val platform: UITextLayoutDirect
         }
     }
 }
+
+// Insets in DP
+internal data class DpInsets(val left: Dp, val top: Dp, val right: Dp, val bottom: Dp)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -282,7 +282,7 @@ internal fun UITextRange.toTextRange(): TextRange? {
 internal fun TextRange.toUITextRange(): UITextRange =
     TextInputRange(start = start, end = end)
 
-internal class IntermediateTextSelectionRect(
+internal class TextInputSelectionRect(
     private var _rect: CValue<CGRect>,
     private val _writingDirection: UITextWritingDirection,
     private val _containsStart: Boolean,
@@ -405,6 +405,10 @@ internal class TextInputStringTokenizer(
     }
 }
 
+/**
+ * Compose-side representation of a selection rectangle, using Compose types ([DpRect], [TextDirection]).
+ * Converted to [TextInputSelectionRect] (a [UITextSelectionRect] subclass) when passed to UIKit.
+ */
 internal data class TextSelectionRect(
     val dpRect: DpRect,
     val writingDirection: TextDirection,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -29,7 +29,9 @@ import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRect
 import platform.UIKit.NSWritingDirection
+import platform.UIKit.NSWritingDirectionLeftToRight
 import platform.UIKit.NSWritingDirectionNatural
+import platform.UIKit.NSWritingDirectionRightToLeft
 import platform.UIKit.UIResponder
 import platform.UIKit.UITextDirection
 import platform.UIKit.UITextGranularity
@@ -187,7 +189,7 @@ internal interface NativeTextEditingDelegate : TextEditingDelegate {
      * @param range A range of text in the document.
      * @return A list of rectangles, in dp, that tightly bound the visual selection for the range.
      */
-    fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect>
+    fun selectionDpRectsForRange(range: TextRange): List<TextInputSelectionRect>
 
     /**
      * Returns the first rectangle that encloses a range of text.
@@ -288,14 +290,19 @@ internal class TextInputSelectionRect(
     private val _containsStart: Boolean,
     private val _containsEnd: Boolean,
     private val _isVertical: Boolean
-
 ) : UITextSelectionRect() {
-    constructor(textSelectionRect: TextSelectionRect) : this(
-        textSelectionRect.dpRect.asCGRect(),
-        NSWritingDirectionNatural,
-        textSelectionRect.containsStart,
-        textSelectionRect.containsEnd,
-        textSelectionRect.isVertical
+    constructor(
+        dpRect: DpRect,
+        writingDirection: TextDirection,
+        containsStart: Boolean,
+        containsEnd: Boolean,
+        isVertical: Boolean
+    ) : this(
+        dpRect.asCGRect(),
+        writingDirection.toUITextWritingDirection(),
+        containsStart,
+        containsEnd,
+        isVertical
     )
 
     override fun rect(): CValue<CGRect> = _rect
@@ -303,6 +310,12 @@ internal class TextInputSelectionRect(
     override fun containsStart(): Boolean = _containsStart
     override fun containsEnd(): Boolean = _containsEnd
     override fun isVertical(): Boolean = _isVertical
+}
+
+private fun TextDirection.toUITextWritingDirection(): UITextWritingDirection = when (this) {
+    TextDirection.Ltr, TextDirection.ContentOrLtr -> NSWritingDirectionLeftToRight
+    TextDirection.Rtl, TextDirection.ContentOrRtl -> NSWritingDirectionRightToLeft
+    else -> NSWritingDirectionNatural
 }
 
 internal class TextInputStringTokenizer(
@@ -404,18 +417,6 @@ internal class TextInputStringTokenizer(
         return text[position] in newLineCharacters || text[position - 1] in newLineCharacters
     }
 }
-
-/**
- * Compose-side representation of a selection rectangle, using Compose types ([DpRect], [TextDirection]).
- * Converted to [TextInputSelectionRect] (a [UITextSelectionRect] subclass) when passed to UIKit.
- */
-internal data class TextSelectionRect(
-    val dpRect: DpRect,
-    val writingDirection: TextDirection,
-    val containsStart: Boolean,
-    val containsEnd: Boolean,
-    val isVertical: Boolean
-)
 
 // Kotlin wrapper for UITextLayoutDirection
 internal enum class PlatformTextLayoutDirection(val platform: UITextLayoutDirection) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -136,7 +136,7 @@ internal class UIKitTextInputService(
         currentInputConnection?.flushEditCommandsIfNeeded(force)
     }
 
-    val toolbarHandler: TextToolbar = object : TextToolbar {
+    val textToolbar: TextToolbar = object : TextToolbar {
 
         override val status: TextToolbarStatus
             get() = (currentInputConnection as? TextToolbar)?.status ?: TextToolbarStatus.Hidden

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -22,66 +22,28 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.CommitTextCommand
-import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
+import androidx.compose.ui.text.input.ComposeTextInputConnection
 import androidx.compose.ui.text.input.EditCommand
-import androidx.compose.ui.text.input.EditProcessor
-import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.SetComposingRegionCommand
-import androidx.compose.ui.text.input.SetComposingTextCommand
-import androidx.compose.ui.text.input.SetSelectionCommand
+import androidx.compose.ui.text.input.NativeTextInputConnection
+import androidx.compose.ui.text.input.PlatformTextInputService
+import androidx.compose.ui.text.input.SelectionContainerConnection
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextInputConnection
 import androidx.compose.ui.text.input.usingNativeTextInput
-import androidx.compose.ui.text.style.TextDirection
-import androidx.compose.ui.uikit.density
-import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.asCGRect
-import androidx.compose.ui.unit.asDpOffset
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toDpRect
-import androidx.compose.ui.unit.toOffset
-import androidx.compose.ui.unit.toSize
-import androidx.compose.ui.window.BackgroundInputView
 import androidx.compose.ui.window.FocusedViewsList
-import androidx.compose.ui.window.IntermediateTextInputUIView
-import androidx.compose.ui.window.IntermediateTextScrollView
-import androidx.compose.ui.window.OverlayInputView
-import androidx.compose.ui.window.PlatformTextLayoutDirection
-import kotlin.math.absoluteValue
-import kotlin.math.max
-import kotlin.math.min
-import kotlinx.cinterop.useContents
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import org.jetbrains.skia.BreakIterator
-import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIPress
 import platform.UIKit.UIView
-import platform.UIKit.UIViewAutoresizingFlexibleHeight
-import platform.UIKit.UIViewAutoresizingFlexibleWidth
-
-// Due to unexpected delays between the commands to show/hide the keyboard,
-// it may jump when switching between text fields.
-// Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
-private val CLEAR_FOCUS_DELAY: Long = 10L
 
 @Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
 internal class UIKitTextInputService(
-    private val updateView: UIKitTextInputService.() -> Unit,
+    private val updateView: (usingNativeTextInput: Boolean) -> Unit,
     private val view: UIView,
     private val viewConfiguration: ViewConfiguration,
     private val focusedViewsList: FocusedViewsList?,
@@ -92,76 +54,15 @@ internal class UIKitTextInputService(
      */
     private var onKeyboardPresses: (Set<*>) -> Unit,
     private var focusManager: () -> ComposeSceneFocusManager?,
-    coroutineContext: kotlin.coroutines.CoroutineContext
-) : androidx.compose.ui.text.input.PlatformTextInputService, TextToolbar, UIKitNativeTextInputContext {
+    coroutineContext: CoroutineContext
+) : PlatformTextInputService {
 
     private val coroutineScope = CoroutineScope(coroutineContext)
 
-    var usingNativeTextInput by mutableStateOf(false)
-        private set
+    private var currentInputConnection: TextInputConnection? by mutableStateOf(null)
 
-    private var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
-    private var currentImeOptions: ImeOptions? = null
-    private var currentImeActionHandler: ((ImeAction) -> Unit)? = null
-    private var textUIView: IntermediateTextInputUIView? = null
-    private val scrollView by lazy { IntermediateTextScrollView() }
-    private var textLayoutResult: TextLayoutResult? = null
-
-    private var currentFocusedRect: Rect? = null
-
-    /**
-     * Matches DefaultCursorThickness
-     *
-     * Must be at least 1.dp to make caret interactable
-     */
-    private val cursorThickness = 2.dp
-
-    /**
-     * Workaround to prevent calling textWillChange, textDidChange, selectionWillChange, and
-     * selectionDidChange when the value of the current input is changed by the system (i.e., by the user
-     * input) not by the state change of the Compose side. These 4 functions call methods of
-     * UITextInputDelegateProtocol, which notifies the system that the text or the selection of the
-     * current input has changed.
-     *
-     * This is to properly handle multi-stage input methods that depend on text selection, required by
-     * languages such as Korean (Chinese and Japanese input methods depend on text marking). The writing
-     * system of these languages contains letters that can be broken into multiple parts, and each keyboard
-     * key corresponds to those parts. Therefore, the input system holds an internal state to combine these
-     * parts correctly. However, the methods of UITextInputDelegateProtocol reset this state, resulting in
-     * incorrect input. (e.g., 컴포즈 becomes ㅋㅓㅁㅍㅗㅈㅡ when not handled properly)
-     *
-     * @see sessionEditProcessor holds the same text and selection of the current input. It is used
-     * instead of the old value passed to updateState. When the current value change is due to the
-     * user input, updateState is not effective because _tempCurrentInputSession holds the same value.
-     * However, when the current value change is due to the change of the user selection or to the
-     * state change in the Compose side, updateState calls the 4 methods because the new value holds
-     * these changes.
-     */
-    private var sessionEditProcessor: EditProcessor? = null
-
-    /**
-     * Workaround to prevent IME action from being called multiple times with hardware keyboards.
-     * When the hardware return key is held down, iOS sends multiple newline characters to the application,
-     * which makes UIKitTextInputService call the current IME action multiple times without an additional
-     * debouncing logic.
-     *
-     * @see _tempHardwareReturnKeyPressed is set to true when the return key is pressed with a
-     * hardware keyboard.
-     * @see _tempImeActionIsCalledWithHardwareReturnKey is set to true when the
-     * current IME action has been called within the current hardware return key press.
-     */
-    private var _tempHardwareReturnKeyPressed: Boolean = false
-    private var _tempImeActionIsCalledWithHardwareReturnKey: Boolean = false
-
-    /**
-     * Workaround to fix voice dictation.
-     * UIKit call insertText(text) and replaceRange(range,text) immediately,
-     * but Compose recomposition happen on next draw frame.
-     * So the value of getSelectedTextRange is in the old state when the replaceRange function is called.
-     * @see _tempCursorPos helps to fix this behaviour. Permanently update _tempCursorPos in function insertText.
-     * And after clear in updateState function.
-     */
-    private var _tempCursorPos: Int? = null
+    val hasInvalidations: Boolean
+        get() = currentInputConnection?.hasInvalidations ?: false
 
     override fun startInput(
         value: TextFieldValue,
@@ -169,467 +70,128 @@ internal class UIKitTextInputService(
         onEditCommand: (List<EditCommand>) -> Unit,
         onImeActionPerformed: (ImeAction) -> Unit
     ) {
-        sessionEditProcessor = EditProcessor().apply {
-            reset(value, null)
-        }
-        currentOnEditCommand = onEditCommand
-        currentImeOptions = imeOptions
-        usingNativeTextInput = imeOptions.platformImeOptions?.usingNativeTextInput ?: false
-        currentImeActionHandler = onImeActionPerformed
+        val usingNativeTextInput = imeOptions.platformImeOptions?.usingNativeTextInput ?: false
 
-        attachIntermediateTextInputView()
-        textUIView?.input = createSkikoInput()
-        textUIView?.inputTraits = getUITextInputTraits(imeOptions)
+        currentInputConnection = if (usingNativeTextInput) NativeTextInputConnection(
+            updateView = { updateView(true) },
+            view = view,
+            coroutineScope = coroutineScope,
+            focusedViewsList = focusedViewsList,
+            onKeyboardPresses = onKeyboardPresses,
+            focusManager = focusManager
+        ) else ComposeTextInputConnection(
+            updateView = { updateView(false) },
+            view = view,
+            coroutineScope = coroutineScope,
+            viewConfiguration = viewConfiguration,
+            focusedViewsList = focusedViewsList,
+            onKeyboardPresses = onKeyboardPresses,
+            focusManager = focusManager
+        )
+        currentInputConnection?.open(value, imeOptions, onEditCommand, onImeActionPerformed)
 
-        showSoftwareKeyboard()
         onInputStarted()
     }
 
     override fun stopInput() {
-        flushEditCommandsIfNeeded(force = true)
-        sessionEditProcessor = null
-        currentImeOptions = null
-        currentImeActionHandler = null
-        textLayoutResult = null
-
-        hideSoftwareKeyboard()
-
-        textUIView?.inputTraits = EmptyInputTraits
-        textUIView?.input = null
-
-        detachIntermediateTextInputView()
-        usingNativeTextInput = false
-
-        selectionTintColor = null
+        currentInputConnection?.close()
     }
 
     override fun showSoftwareKeyboard() {
-        textUIView?.let {
-            focusedViewsList?.addAndFocus(it)
-        }
+        currentInputConnection?.showKeyboard()
     }
 
     override fun hideSoftwareKeyboard() {
-        textUIView?.let {
-            focusedViewsList?.remove(it, delayMillis = CLEAR_FOCUS_DELAY)
-        }
+        currentInputConnection?.dismissKeyboard()
     }
 
     override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {
-        val internalOldValue = sessionEditProcessor?.toTextFieldValue()
-        val textChanged = internalOldValue == null || internalOldValue.text != newValue.text
-        val selectionChanged = textChanged || internalOldValue.selection != newValue.selection
-        if (textChanged) {
-            textUIView?.textWillChange()
-        }
-        if (selectionChanged) {
-            textUIView?.selectionWillChange()
-        }
-        sessionEditProcessor?.let {
-            it.reset(newValue, null)
-            _tempCursorPos = null
-        }
-
-        if (textChanged) {
-            textUIView?.textDidChange()
-        }
-        if (selectionChanged) {
-            textUIView?.selectionDidChange()
-        }
-        if (!usingNativeTextInput && (textChanged || selectionChanged)) {
-            updateView()
-        }
+        currentInputConnection?.updateState(newValue)
     }
 
-    fun onPreviewKeyEvent(event: KeyEvent): Boolean {
-        return when (event.key) {
-            Key.Enter -> handleEnterKey(event)
-            Key.Backspace -> handleBackspace(event)
-            Key.Escape -> handleEscape(event)
-            else -> false
-        }
-    }
-
-    private fun calculateContentBounds(textLayoutResult: TextLayoutResult, textFieldFrame: Rect, unclippedTextPosition: Offset): Rect {
-        val textSize = textLayoutResult.size.toSize()
-        val contentBounds = Rect(
-            offset = Offset(x = textFieldFrame.left - unclippedTextPosition.x, y = textFieldFrame.top - unclippedTextPosition.y),
-            size = textSize
-        )
-        return contentBounds
-    }
-
-    private fun calculateContentInsets(textFieldFrame: Rect, contentBounds: Rect): DpInsets = with(view.density) {
-        return DpInsets(
-            left = max(0f, -contentBounds.left).toDp(),
-            top = max(0f, -contentBounds.top).toDp(),
-            right = max(0f, textFieldFrame.width - contentBounds.width + contentBounds.left).toDp(),
-            bottom = max(0f, textFieldFrame.height - contentBounds.height + contentBounds.top).toDp()
-        )
+    fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {
+        currentInputConnection?.updateTextLayoutResult(textLayoutResult)
     }
 
     fun updateFocusedRect(rect: Rect) {
-        currentFocusedRect = rect
+        currentInputConnection?.updateFocusedRect(rect)
     }
-
-    private var textFieldFrameInRoot: Rect? = null
-    private var clippingTextFrame: Rect? = null
-    private var currentContentBounds: Rect? = null
-    private var currentContentInsets: DpInsets? = null
-    private var unclippedTextPosition: Offset? = null
 
     fun updateTextFieldGeometry(
         textFieldFrame: Rect,
         clippingTextFrame: Rect,
         unclippedTextPosition: Offset
     ) {
-        textFieldFrameInRoot = textFieldFrame
-        this.clippingTextFrame = clippingTextFrame
-        this.unclippedTextPosition = unclippedTextPosition
-
-        updateTextViewPosition()
-
-        showMenuOrUpdatePosition()
+        currentInputConnection?.updateViewGeometry(
+            textFieldFrame,
+            clippingTextFrame,
+            unclippedTextPosition
+        )
     }
 
-    private fun updateTextViewPosition() {
-        val rect = textFieldFrameInRoot ?: return
-
-        if (usingNativeTextInput) {
-            // Since Compose content is rendered on a MetalView and the UITextInput-implementing
-            // view is overlayed on top of it, we need to synchronize the Compose text
-            // field with the IntermediateTextScrollView (which contains IntermediateUITextView)
-            // to ensure native iOS text input controls
-            // align correctly with the rendered text.
-            val layoutResult = textLayoutResult ?: return
-            val unclippedTextPosition = unclippedTextPosition ?: return
-
-            val contentBounds = calculateContentBounds(
-                layoutResult,
-                rect,
-                unclippedTextPosition
-            )
-            currentContentBounds = contentBounds
-            val contentInsets = calculateContentInsets(rect, contentBounds)
-            currentContentInsets = contentInsets
-            scrollView.setFrame(
-                rect.toDpRect(view.density),
-                contentBounds.toDpRect(view.density),
-                contentInsets
-            )
-        } else {
-            textUIView?.setFrame(rect.toDpRect(view.density).asCGRect())
-        }
-    }
-
-    fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {
-        this.textLayoutResult = textLayoutResult
-    }
-
-    private fun handleEnterKey(event: KeyEvent): Boolean {
-        _tempImeActionIsCalledWithHardwareReturnKey = false
-        return when (event.type) {
-            KeyEventType.KeyUp -> {
-                _tempHardwareReturnKeyPressed = false
-                false
-            }
-
-            KeyEventType.KeyDown -> {
-                _tempHardwareReturnKeyPressed = true
-                // This prevents two new line characters from being added for one hardware return key press.
-                true
-            }
-
-            else -> false
-        }
-    }
-
-    private fun handleBackspace(event: KeyEvent): Boolean {
-        // This prevents two characters from being removed for one hardware backspace key press.
-        return event.type == KeyEventType.KeyDown
-    }
-
-    private fun handleEscape(event: KeyEvent): Boolean {
-        return if (sessionEditProcessor != null) {
-            if (event.type == KeyEventType.KeyDown) {
-                focusManager()?.releaseFocus()
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    private val editCommandsBatch = mutableListOf<EditCommand>()
-    private var editBatchDepth: Int = 0
-        set(value) {
-            field = value
-            flushEditCommandsIfNeeded()
-        }
-
-    private fun sendEditCommand(vararg commands: EditCommand) {
-        sessionEditProcessor?.apply(commands.toList())
-
-        editCommandsBatch.addAll(commands)
-        flushEditCommandsIfNeeded()
-
-        if (usingNativeTextInput) {
-            // For Native Text Input it's essential to trigger view update right after send edit command,
-            // otherwise UIKit calls may use an invalid layout state
-            coroutineScope.launch {
-                updateView()
-            }
-        }
-    }
+    fun onPreviewKeyEvent(event: KeyEvent): Boolean =
+        currentInputConnection?.onPreviewKeyEvent(event) ?: false
 
     fun flushEditCommandsIfNeeded(force: Boolean = false) {
-        if ((force || editBatchDepth == 0) && editCommandsBatch.isNotEmpty()) {
-            val commandList = editCommandsBatch.toList()
-            editCommandsBatch.clear()
-
-            currentOnEditCommand?.invoke(commandList)
-        }
+        currentInputConnection?.flushEditCommandsIfNeeded(force)
     }
 
-    private fun getCursorPos(): Int? {
-        if (_tempCursorPos != null) {
-            return _tempCursorPos
-        }
-        val selection = getState()?.selection
-        if (selection != null && selection.start == selection.end) {
-            return selection.start
-        }
-        return null
-    }
+    val toolbarHandler: TextToolbar = object : TextToolbar {
 
-    private fun imeActionRequired(): Boolean =
-        currentImeOptions?.run {
-            singleLine || (
-                imeAction != ImeAction.None
-                    && imeAction != ImeAction.Default
-                    && !(imeAction == ImeAction.Search && _tempHardwareReturnKeyPressed)
+        override val status: TextToolbarStatus
+            get() = (currentInputConnection as? TextToolbar)?.status ?: TextToolbarStatus.Hidden
+
+        override fun showMenu(
+            rect: Rect,
+            onCopyRequested: (() -> Unit)?,
+            onPasteRequested: (() -> Unit)?,
+            onCutRequested: (() -> Unit)?,
+            onSelectAllRequested: (() -> Unit)?
+        ) {
+            if (currentInputConnection == null) {
+                currentInputConnection = SelectionContainerConnection(
+                    view, coroutineScope, viewConfiguration, focusManager
                 )
-        } ?: false
-
-    private fun runImeActionIfRequired(): Boolean {
-        val imeAction = currentImeOptions?.imeAction ?: return false
-        val imeActionHandler = currentImeActionHandler ?: return false
-        if (!imeActionRequired()) {
-            return false
-        }
-        if (!_tempImeActionIsCalledWithHardwareReturnKey) {
-            if (imeAction == ImeAction.Default) {
-                imeActionHandler(ImeAction.Done)
-            } else {
-                imeActionHandler(imeAction)
             }
+            (currentInputConnection as? TextToolbar)?.showMenu(
+                rect, onCopyRequested, onPasteRequested, onCutRequested, onSelectAllRequested
+            )
         }
-        if (_tempHardwareReturnKeyPressed) {
-            _tempImeActionIsCalledWithHardwareReturnKey = true
-        }
-        return true
-    }
 
-    private var textInputServiceInvalidationsCount = 0
-    private fun textMenuAppearanceChanged() {
-        textInputServiceInvalidationsCount++
-        coroutineScope.launch {
-            // Time to show, hide or update state of context menu
-            delay(500)
-            textInputServiceInvalidationsCount--
-        }
-    }
+        override fun hide() {
+            (currentInputConnection as? TextToolbar)?.hide()
 
-    val hasInvalidations: Boolean get() = textInputServiceInvalidationsCount > 0
-
-    private fun getState(): TextFieldValue? = sessionEditProcessor?.toTextFieldValue()
-
-    // Fixes a problem where the menu is shown before the textUIView gets its final layout.
-    private var showMenuOrUpdatePosition = {}
-
-    override fun showMenu(
-        rect: Rect,
-        onCopyRequested: (() -> Unit)?,
-        onPasteRequested: (() -> Unit)?,
-        onCutRequested: (() -> Unit)?,
-        onSelectAllRequested: (() -> Unit)?
-    ) {
-        showMenu(
-            rect = rect,
-            onCopyRequested = onCopyRequested,
-            onPasteRequested = onPasteRequested,
-            onCutRequested = onCutRequested,
-            onSelectAllRequested = onSelectAllRequested,
-            onAutofillRequested = null
-        )
-    }
-
-    override fun showMenu(
-        rect: Rect,
-        onCopyRequested: (() -> Unit)?,
-        onPasteRequested: (() -> Unit)?,
-        onCutRequested: (() -> Unit)?,
-        onSelectAllRequested: (() -> Unit)?,
-        onAutofillRequested: (() -> Unit)?
-    ) {
-        if (!usingNativeTextInput) {
-            if (textUIView == null) {
-                // If showMenu() is called and textUIView is not created,
-                // then it means that showMenu() called in SelectionContainer without any textfields,
-                // and IntermediateTextInputView must be created to show an editing menu
-                attachIntermediateTextInputView()
-                updateView()
+            if (currentInputConnection is SelectionContainerConnection) {
+                currentInputConnection?.close()
+                currentInputConnection = null
             }
-            showMenuOrUpdatePosition = {
-                textUIView?.let { textUIView ->
-                    val density = view.density
-                    val offset = textUIView.frame.useContents { origin.asDpOffset().toOffset(density) }
-                    val target = rect.translate(-offset).toDpRect(density).asCGRect()
-                    textUIView.showEditMenuAtRect(
-                        targetRect = target,
-                        copy = onCopyRequested,
-                        cut = onCutRequested,
-                        paste = onPasteRequested,
-                        selectAll = onSelectAllRequested,
-                        customActions = emptyList<CMPEditMenuCustomAction>()
-                    )
-                    textMenuAppearanceChanged()
-                }
-            }
-            showMenuOrUpdatePosition()
+
         }
     }
 
-    override fun hide() {
-        showMenuOrUpdatePosition = {}
-        textUIView?.let {
-            it.hideTextMenu()
-            textMenuAppearanceChanged()
-        }
-        if ((textUIView != null) && (sessionEditProcessor == null)) { // means that editing context menu shown in selection container
-            textUIView?.resignFirstResponder()
-            detachIntermediateTextInputView()
-        }
-    }
+    val nativeTextInputContext = object : UIKitNativeTextInputContext {
+        override fun usingNativeTextInput(): Boolean =
+            (currentInputConnection as? UIKitNativeTextInputContext)?.usingNativeTextInput()
+                ?: false
 
-    override fun updateNativeTextInputEditMenuState(
-        copy: (() -> Unit)?,
-        paste: (() -> Unit)?,
-        cut: (() -> Unit)?,
-        selectAll: (() -> Unit)?,
-        customActions: List<UIKitNativeTextInputContextMenuCustomAction>?
-    ) {
-        // This path is native text input only, shouldn't be called elsewhere
-        textUIView?.updateMenuActions(
-            copy,
-            paste,
-            cut,
-            selectAll,
-            customActions?.map { action ->
-                CMPEditMenuCustomAction(action.title, action.action)
-            } ?: emptyList()
-        )
-    }
-
-    override fun usingNativeTextInput(): Boolean = usingNativeTextInput
-
-    // If not specified, iOS would use the default system tint color
-    private var selectionTintColor: Color? = null
-    private fun setupTintColor() {
-        textUIView?.let {
-            val uiColor = selectionTintColor?.toUIColor()
-            it.setTintColor(uiColor)
-        }
-    }
-
-    override fun updateNativeTextInputTintColor(color: Color?) {
-        selectionTintColor = color
-        setupTintColor()
-    }
-
-    override val status: TextToolbarStatus
-        get() = if (usingNativeTextInput) {
-            // In this case the menu is controlled by UIKit.
-            TextToolbarStatus.Hidden
-        } else {
-            if (textUIView?.isTextMenuShown() == true)
-                TextToolbarStatus.Shown
-            else
-                TextToolbarStatus.Hidden
+        override fun updateNativeTextInputEditMenuState(
+            copy: (() -> Unit)?,
+            paste: (() -> Unit)?,
+            cut: (() -> Unit)?,
+            selectAll: (() -> Unit)?,
+            customActions: List<UIKitNativeTextInputContextMenuCustomAction>?
+        ) {
+            (currentInputConnection as? UIKitNativeTextInputContext)?.updateNativeTextInputEditMenuState(
+                copy, paste, cut, selectAll, customActions
+            )
         }
 
-    private fun attachIntermediateTextInputView() {
-        detachIntermediateTextInputView()
-        if (usingNativeTextInput) {
-            textUIView = IntermediateTextInputUIView(
-                doubleTapTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis,
-                usingNativeTextInput = usingNativeTextInput,
-                coroutineScope = coroutineScope
-            ).also {
-                view.addSubview(scrollView)
-                scrollView.textView = it
-
-                it.onKeyboardPresses = onKeyboardPresses
-                it.clipsToBounds = false
-                it.input = createSkikoInput()
-                it.inputTraits = getUITextInputTraits(currentImeOptions)
-
-                // Resizing should be done later
-                it.resignFirstResponder()
-                it.becomeFirstResponder()
-            }
-            setupTintColor()
-        } else {
-            textUIView = IntermediateTextInputUIView(
-                doubleTapTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis,
-                usingNativeTextInput = usingNativeTextInput,
-                coroutineScope = coroutineScope
-            ).also {
-                it.setAutoresizingMask(
-                    UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
-                )
-                it.onKeyboardPresses = onKeyboardPresses
-                view.addSubview(it)
-                it.setFrame(view.bounds)
-            }
+        override fun updateNativeTextInputTintColor(color: Color?) {
+            (currentInputConnection as? UIKitNativeTextInputContext)?.updateNativeTextInputTintColor(
+                color
+            )
         }
-    }
 
-    private fun detachIntermediateTextInputView() {
-        // Out-of-bounds non-empty frame is required to hide text keyboard focus frame
-        val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
-
-        if (usingNativeTextInput) {
-            textUIView?.input = null
-            textUIView?.inputTraits = EmptyInputTraits
-
-            textUIView?.let { textView ->
-                textView.setFrame(outOfBoundsFrame)
-
-                textView.resetOnKeyboardPressesCallback()
-                coroutineScope.launch {
-                    delay(CLEAR_FOCUS_DELAY)
-                    if (scrollView.textView == textView) {
-                        scrollView.textView = null
-                        textView.removeFromSuperview()
-                    }
-                }
-            }
-            textUIView = null
-            scrollView.removeFromSuperview()
-        } else {
-            showMenuOrUpdatePosition = {}
-            textUIView?.let { view ->
-                view.setFrame(outOfBoundsFrame)
-
-                view.resetOnKeyboardPressesCallback()
-                coroutineScope.launch {
-                    delay(CLEAR_FOCUS_DELAY)
-                    view.removeFromSuperview()
-                }
-            }
-            textUIView = null
-        }
     }
 
     fun dispose() {
@@ -638,468 +200,5 @@ internal class UIKitTextInputService(
         onKeyboardPresses = { }
         focusManager = { null }
     }
-
-    private fun hasFocusedNonComposeInputViewInWindowHierarchy(): Boolean {
-        fun hasFocusedNonComposeInputView(view: UIView): Boolean {
-            if (view.isFirstResponder) {
-                return view !is IntermediateTextInputUIView &&
-                    view !is OverlayInputView &&
-                    view !is BackgroundInputView
-            }
-            return view.subviews.any { it is UIView && hasFocusedNonComposeInputView(it) }
-        }
-        return view.window?.let { hasFocusedNonComposeInputView(it) } ?: false
-    }
-
-    private fun createSkikoInput() = object : IOSSkikoInput {
-
-        private var floatingCursorTranslation : Offset? = null
-
-        override fun onResignFocus() {
-            textInputServiceInvalidationsCount++
-            coroutineScope.launch {
-                if (hasFocusedNonComposeInputViewInWindowHierarchy()) {
-                    focusManager()?.releaseFocus()
-                }
-                textInputServiceInvalidationsCount--
-            }
-        }
-
-        override fun beginFloatingCursor(offset: DpOffset) {
-            val cursorPos = if (usingNativeTextInput) {
-                getState()?.selection?.start ?: return
-            } else getCursorPos() ?: getState()?.selection?.start ?: return
-            val cursorRect = textLayoutResult?.getCursorRect(cursorPos) ?: return
-            floatingCursorTranslation = cursorRect.center - offset.toOffset(view.density)
-        }
-
-        override fun updateFloatingCursor(offset: DpOffset) {
-            val translation = floatingCursorTranslation ?: return
-            val offsetPx = offset.toOffset(view.density)
-            val pos = textLayoutResult
-                ?.getOffsetForPosition(offsetPx + translation) ?: return
-
-            sendEditCommand(SetSelectionCommand(pos, pos))
-        }
-
-        override fun endFloatingCursor() {
-            floatingCursorTranslation = null
-        }
-
-        override fun beginEditBatch() {
-            editBatchDepth++
-        }
-
-        override fun endEditBatch() {
-            editBatchDepth--
-        }
-
-        /**
-         * A Boolean value that indicates whether the text-entry object has any text.
-         * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
-         */
-        override fun hasText(): Boolean = getState()?.text?.isNotEmpty() ?: false
-
-        /**
-         * Inserts a character into the displayed text.
-         * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
-         * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
-         * @param text A string object representing the character typed on the system keyboard.
-         */
-        override fun insertText(text: String) {
-            if (text == "\n") {
-                if (runImeActionIfRequired()) {
-                    return
-                }
-            }
-            getCursorPos()?.let {
-                _tempCursorPos = it + text.length
-            }
-            sendEditCommand(CommitTextCommand(text, 1))
-        }
-
-        /**
-         * Deletes a character from the displayed text.
-         * Remove the character just before the cursor from your class’s backing store and redisplay the text.
-         * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
-         */
-        override fun deleteBackward() {
-            val deleteCommand = if (getState()?.selection?.collapsed == true) {
-                DeleteSurroundingTextCommand(lengthBeforeCursor = 1, lengthAfterCursor = 0)
-            } else {
-                CommitTextCommand("", 0)
-            }
-            sendEditCommand(deleteCommand)
-        }
-
-        /**
-         * The text position for the end of a document.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
-         */
-        override fun endOfDocument(): Int = getState()?.text?.length ?: 0
-
-        /**
-         * The range of selected text in a document.
-         * If the text range has a length, it indicates the currently selected text.
-         * If it has zero length, it indicates the caret (insertion point).
-         * If the text-range object is nil, it indicates that there is no current selection.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
-         */
-        override fun getSelectedTextRange(): TextRange? = getState()?.selection
-
-        override fun setSelectedTextRange(range: TextRange?) {
-            if (range != null) {
-                sendEditCommand(
-                    SetSelectionCommand(range.start, range.end)
-                )
-            } else {
-                sendEditCommand(
-                    SetSelectionCommand(endOfDocument(), endOfDocument())
-                )
-            }
-        }
-
-        override fun selectAll() {
-            sendEditCommand(
-                SetSelectionCommand(0, endOfDocument())
-            )
-        }
-
-        /**
-         * Returns the text in the specified range.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
-         * @param range A range of text in a document.
-         * @return A substring of a document that falls within the specified range.
-         */
-        override fun textInRange(range: TextRange): String? {
-            if (isIncorrect(range)) {
-                return null
-            }
-            val text = getState()?.text ?: return null
-            return text.substring(range.start, range.end)
-        }
-
-        /**
-         * Replaces the text in a document that is in the specified range.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
-         * @param range A range of text in a document.
-         * @param text A string to replace the text in range.
-         */
-        override fun replaceRange(range: TextRange, text: String) {
-            sendEditCommand(
-                SetComposingRegionCommand(range.start, range.end),
-                SetComposingTextCommand(text, 1),
-                FinishComposingTextCommand(),
-            )
-        }
-
-        /**
-         * Inserts the provided text and marks it to indicate that it is part of an active input session.
-         * Setting marked text either replaces the existing marked text or,
-         * if none is present, inserts it in place of the current selection.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
-         * @param markedText The text to be marked.
-         * @param selectedRange A range within markedText that indicates the current selection.
-         * This range is always relative to markedText.
-         */
-        override fun setMarkedText(markedText: String?, selectedRange: TextRange) {
-            if (markedText != null) {
-                sendEditCommand(
-                    SetComposingTextCommand(markedText, 1)
-                )
-            }
-        }
-
-        /**
-         * The range of currently marked text in a document.
-         * If there is no marked text, the value of the property is nil.
-         * Marked text is provisionally inserted text that requires user confirmation;
-         * it occurs in multistage text input.
-         * The current selection, which can be a caret or an extended range, always occurs within the marked text.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
-         */
-        override fun markedTextRange(): TextRange? {
-            return getState()?.composition
-        }
-
-        /**
-         * Unmarks the currently marked text.
-         * After this method is called, the value of markedTextRange is nil.
-         * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
-         */
-        override fun unmarkText() {
-            sendEditCommand(FinishComposingTextCommand())
-        }
-
-        /**
-         * Returns the text position at a specified offset from another text position.
-         * Returned value must be in range between 0 and length of text (inclusive).
-         */
-        override fun positionFromPosition(position: Int, offset: Int): Int? {
-            val text = getState()?.text ?: return null
-
-            val newPosition = position + offset
-            if (newPosition == text.length || newPosition == 0) {
-                return newPosition
-            }
-            if (newPosition < 0 || newPosition > text.length) {
-                return null
-            }
-            var resultPosition = position
-            val iterator = BreakIterator.makeCharacterInstance()
-            iterator.setText(text)
-
-            repeat(offset.absoluteValue) {
-                val iteratorResult = if (offset > 0) {
-                    iterator.following(resultPosition)
-                } else {
-                    iterator.preceding(resultPosition)
-                }
-
-                if (iteratorResult == BreakIterator.DONE) {
-                    return resultPosition
-                } else {
-                    resultPosition = iteratorResult
-                }
-            }
-
-            return resultPosition
-        }
-
-        /**
-         * Returns the text position at a specified offset from another text position.
-         * Returned value must be in range between 0 and length of text (inclusive).
-         */
-        override fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int? {
-            val text = getState()?.text ?: return null
-            val layoutResult = textLayoutResult ?: return null
-
-            val line = layoutResult.getLineForOffset(position)
-            val lineStartOffset = layoutResult.getLineStart(line)
-            val offsetInLine = position - lineStartOffset
-            val targetLine = line + verticalOffset
-            return when {
-                targetLine < 0 -> 0
-                targetLine >= layoutResult.lineCount -> text.length
-                else -> {
-                    val targetLineEnd = layoutResult.getLineEnd(targetLine)
-                    val lineStart = layoutResult.getLineStart(targetLine)
-                    positionFromPosition(
-                        lineStart, min(offsetInLine, targetLineEnd - lineStart)
-                    )
-                }
-            }
-        }
-
-        override fun caretDpRectForPosition(position: Int): DpRect? {
-            val text = getState()?.text ?: return null
-            if (position < 0 || position > text.length) {
-                return null
-            }
-            val currentTextLayoutResult = textLayoutResult ?: return null
-            if (position > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) {
-                return null
-            }
-            val rect = currentTextLayoutResult.getCursorRect(position)
-            return rect.toDpRect(view.density).let {
-                val hafWidth = cursorThickness / 2
-                val center = (it.left + it.right) / 2
-                it.copy(left = center - hafWidth, right = center + hafWidth)
-            }
-        }
-
-        override fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect> {
-            // Native selection rects are required for correct work of the text editing menu
-            // Without them, it will be impossible to call the text editing menu by tapping on the selected area
-            if (range.collapsed || isIncorrect(range)) {
-                return emptyList()
-            }
-            val currentTextLayoutResult = textLayoutResult ?: return emptyList()
-
-            // Layout in native text input mode may be outdated, so not checking this may cause OOB error
-            // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
-            if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return emptyList()
-
-            val startSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.start)
-            val endSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.end)
-
-            val firstLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-            val lastLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
-
-            return if (firstLineNumber == lastLineNumber) {
-                listOf(
-                    TextSelectionRect(
-                        dpRect = Rect(
-                            topLeft = startSelectionHandleRect.topLeft,
-                            bottomRight = endSelectionHandleRect.bottomRight
-                        ).toDpRect(view.density),
-                        writingDirection = TextDirection.Content,
-                        containsStart = true,
-                        containsEnd = true,
-                        isVertical = false
-                    )
-                )
-            } else {
-                // TODO Consider RTL Layout
-                // We require separate rects for start line, end line and everything in between them
-                val contentInsets = currentContentInsets ?: return emptyList()
-                val contentRect = currentContentBounds?.let {
-                    with(view.density) {
-                        Rect(
-                            top = it.top + contentInsets.top.toPx(),
-                            left = it.left + contentInsets.left.toPx(),
-                            right = it.right + contentInsets.right.toPx(),
-                            bottom = it.bottom + contentInsets.bottom.toPx()
-                        )
-                    }
-                } ?: return emptyList()
-
-                val firstLineSelectionRect = TextSelectionRect(
-                    dpRect = Rect(
-                        top = startSelectionHandleRect.top,
-                        left = startSelectionHandleRect.left,
-                        right = contentRect.right,
-                        bottom = startSelectionHandleRect.bottom
-                    ).toDpRect(view.density),
-                    writingDirection = TextDirection.Content,
-                    containsStart = true,
-                    containsEnd = false,
-                    isVertical = false
-                )
-
-                val middleAreaSelectionRect = TextSelectionRect(
-                    dpRect = Rect(
-                        top = startSelectionHandleRect.bottom,
-                        left = contentRect.left,
-                        right = contentRect.right,
-                        bottom = endSelectionHandleRect.top
-                    ).toDpRect(view.density),
-                    writingDirection = TextDirection.Content,
-                    containsStart = false,
-                    containsEnd = false,
-                    isVertical = false
-                )
-
-                val lastLineStartRect = currentTextLayoutResult.getCursorRect(
-                    currentTextLayoutResult.getLineStart(lastLineNumber)
-                )
-                val lastLineRect = TextSelectionRect(
-                    dpRect = Rect(
-                        topLeft = lastLineStartRect.topLeft,
-                        bottomRight = endSelectionHandleRect.bottomRight
-                    ).toDpRect(view.density),
-                    writingDirection = TextDirection.Content,
-                    containsStart = false,
-                    containsEnd = true,
-                    isVertical = false
-                )
-
-                listOf(
-                    firstLineSelectionRect,
-                    middleAreaSelectionRect,
-                    lastLineRect
-                )
-            }
-        }
-
-        override fun firstSelectionRectForRange(range: TextRange): DpRect? {
-            if (range.collapsed || isIncorrect(range)) {
-                return null
-            }
-            val currentTextLayoutResult = textLayoutResult ?: return null
-
-            // Layout in native text input mode may be outdated, so not checking this may cause OOB error
-            // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
-            if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return null
-
-            val startHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-            val endHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
-
-            val startHandleRect = currentTextLayoutResult.getCursorRect(range.start)
-
-            return if (startHandleLineNumber == endHandleLineNumber) {
-                Rect(
-                    topLeft = startHandleRect.topLeft,
-                    bottomRight = currentTextLayoutResult.getCursorRect(range.end).bottomRight
-                ).toDpRect(view.density)
-            } else {
-                val startLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-                val startLineRight = currentTextLayoutResult.getLineRight(startLineNumber)
-                Rect(
-                    startHandleRect.left,
-                    startHandleRect.top,
-                    startLineRight,
-                    startHandleRect.bottom
-                ).toDpRect(view.density)
-            }
-        }
-
-        override fun closestPositionToPoint(point: DpOffset): Int? {
-            return textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-        }
-
-        override fun closestPositionToPoint(point: DpOffset, withinRange: TextRange): Int? {
-            val pointOffset =
-                textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-                    ?: return null
-            return pointOffset.coerceIn(withinRange.start, withinRange.end)
-        }
-
-        override fun characterRangeAtPoint(point: DpOffset): TextRange? {
-            val pointOffset =
-                textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-                    ?: return null
-            return textLayoutResult?.getWordBoundary(pointOffset)
-        }
-
-        override fun positionWithinRange(
-            range: TextRange,
-            farthestInDirection: PlatformTextLayoutDirection
-        ): Int? {
-            if (isIncorrect(range)) return null
-            return when (farthestInDirection) {
-                PlatformTextLayoutDirection.Up -> range.start
-                PlatformTextLayoutDirection.Down -> range.end
-                else -> {
-                    val layout = textLayoutResult ?: return null
-                    val startLine = layout.getLineForOffset(range.start)
-                    val endLine = layout.getLineForOffset(range.end)
-
-                    val candidateOffsets = buildSet {
-                        add(range.start)
-                        add(range.end)
-
-                        for (line in startLine..endLine) {
-                            add(max(range.start, layout.getLineStart(line)))
-                            add(min(range.end, layout.getLineEnd(line)))
-                        }
-                    }
-
-                    when (farthestInDirection) {
-                        PlatformTextLayoutDirection.Left ->
-                            candidateOffsets.minByOrNull { layout.getHorizontalPosition(it, true) }
-                        PlatformTextLayoutDirection.Right ->
-                            candidateOffsets.maxByOrNull { layout.getHorizontalPosition(it, true) }
-                        else -> null
-                    }
-                }
-            }
-        }
-
-        private fun isIncorrect(range: TextRange): Boolean {
-            return range.start < 0 || range.end > endOfDocument() || range.start > range.end
-        }
-    }
 }
-
-internal data class TextSelectionRect(
-    val dpRect: DpRect,
-    val writingDirection: TextDirection,
-    val containsStart: Boolean,
-    val containsEnd: Boolean,
-    val isVertical: Boolean
-)
-
-// Insets in DP
-internal data class DpInsets(val left: Dp, val top: Dp, val right: Dp, val bottom: Dp)
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -73,22 +73,26 @@ internal class UIKitTextInputService(
         val usingNativeTextInput = imeOptions.platformImeOptions?.usingNativeTextInput ?: false
 
         currentInputConnection?.stop()
-        currentInputConnection = if (usingNativeTextInput) NativeTextInputConnection(
-            updateView = { updateView(true) },
-            view = view,
-            coroutineScope = coroutineScope,
-            focusedViewsList = focusedViewsList,
-            onKeyboardPresses = onKeyboardPresses,
-            focusManager = focusManager
-        ) else ComposeTextInputConnection(
-            updateView = { updateView(false) },
-            view = view,
-            coroutineScope = coroutineScope,
-            viewConfiguration = viewConfiguration,
-            focusedViewsList = focusedViewsList,
-            onKeyboardPresses = onKeyboardPresses,
-            focusManager = focusManager
-        )
+        currentInputConnection = if (usingNativeTextInput) {
+            NativeTextInputConnection(
+                updateView = { updateView(true) },
+                view = view,
+                coroutineScope = coroutineScope,
+                focusedViewsList = focusedViewsList,
+                onKeyboardPresses = onKeyboardPresses,
+                focusManager = focusManager
+            )
+        } else {
+            ComposeTextInputConnection(
+                updateView = { updateView(false) },
+                view = view,
+                coroutineScope = coroutineScope,
+                viewConfiguration = viewConfiguration,
+                focusedViewsList = focusedViewsList,
+                onKeyboardPresses = onKeyboardPresses,
+                focusManager = focusManager
+            )
+        }
         currentInputConnection?.start(value, imeOptions, onEditCommand, onImeActionPerformed)
 
         onInputStarted()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -153,7 +153,7 @@ internal class UIKitTextInputService(
                 // there is no active text input session. iOS requires a UIView that can become first
                 // responder in order to host the context menu, so we create a dedicated connection
                 // backed by a hidden view for this purpose.
-                // Note: open() is intentionally not called here — it establishes a text editing
+                // Note: start() is intentionally not called here — it establishes a text editing
                 // session (requiring TextFieldValue, ImeOptions, etc.) which is not applicable for
                 // SelectionContainer.
                 currentInputConnection = SelectionContainerConnection(
@@ -170,7 +170,7 @@ internal class UIKitTextInputService(
 
             if (currentInputConnection is SelectionContainerConnection) {
                 // stop() removes the view from the hierarchy and resigns first responder,
-                // without requiring a prior open() call.
+                // without requiring a prior start() call.
                 currentInputConnection?.stop()
                 currentInputConnection = null
             }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -115,18 +115,12 @@ internal class UIKitTextInputService(
         currentInputConnection?.updateTextLayoutResult(textLayoutResult)
     }
 
-    fun updateFocusedRect(rect: Rect) {
-        currentInputConnection?.updateFocusedRect(rect)
-    }
-
     fun updateTextFieldGeometry(
         textFieldFrame: Rect,
-        clippingTextFrame: Rect,
         unclippedTextPosition: Offset
     ) {
         currentInputConnection?.updateViewGeometry(
             textFieldFrame,
-            clippingTextFrame,
             unclippedTextPosition
         )
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -169,7 +169,7 @@ internal class UIKitTextInputService(
             (currentInputConnection as? TextToolbar)?.hide()
 
             if (currentInputConnection is SelectionContainerConnection) {
-                // close() removes the view from the hierarchy and resigns first responder,
+                // stop() removes the view from the hierarchy and resigns first responder,
                 // without requiring a prior open() call.
                 currentInputConnection?.stop()
                 currentInputConnection = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -144,11 +144,14 @@ internal class UIKitTextInputService(
             onCutRequested: (() -> Unit)?,
             onSelectAllRequested: (() -> Unit)?
         ) {
-            // Entry point for showing the context menu in SelectionContainer scenarios, where
-            // there is no active text input session. iOS requires a UIView that can become first
-            // responder in order to host the context menu, so we create a dedicated connection
-            // backed by a hidden view for this purpose.
             if (currentInputConnection == null) {
+                // Entry point for showing the context menu in SelectionContainer scenarios, where
+                // there is no active text input session. iOS requires a UIView that can become first
+                // responder in order to host the context menu, so we create a dedicated connection
+                // backed by a hidden view for this purpose.
+                // Note: open() is intentionally not called here — it establishes a text editing
+                // session (requiring TextFieldValue, ImeOptions, etc.) which is not applicable for
+                // SelectionContainer.
                 currentInputConnection = SelectionContainerConnection(
                     view, coroutineScope, viewConfiguration, focusManager
                 )
@@ -162,10 +165,11 @@ internal class UIKitTextInputService(
             (currentInputConnection as? TextToolbar)?.hide()
 
             if (currentInputConnection is SelectionContainerConnection) {
+                // close() removes the view from the hierarchy and resigns first responder,
+                // without requiring a prior open() call.
                 currentInputConnection?.close()
                 currentInputConnection = null
             }
-
         }
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -72,6 +72,7 @@ internal class UIKitTextInputService(
     ) {
         val usingNativeTextInput = imeOptions.platformImeOptions?.usingNativeTextInput ?: false
 
+        currentInputConnection?.close()
         currentInputConnection = if (usingNativeTextInput) NativeTextInputConnection(
             updateView = { updateView(true) },
             view = view,
@@ -95,6 +96,7 @@ internal class UIKitTextInputService(
 
     override fun stopInput() {
         currentInputConnection?.close()
+        currentInputConnection = null
     }
 
     override fun showSoftwareKeyboard() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -72,7 +72,7 @@ internal class UIKitTextInputService(
     ) {
         val usingNativeTextInput = imeOptions.platformImeOptions?.usingNativeTextInput ?: false
 
-        currentInputConnection?.close()
+        currentInputConnection?.stop()
         currentInputConnection = if (usingNativeTextInput) NativeTextInputConnection(
             updateView = { updateView(true) },
             view = view,
@@ -89,13 +89,13 @@ internal class UIKitTextInputService(
             onKeyboardPresses = onKeyboardPresses,
             focusManager = focusManager
         )
-        currentInputConnection?.open(value, imeOptions, onEditCommand, onImeActionPerformed)
+        currentInputConnection?.start(value, imeOptions, onEditCommand, onImeActionPerformed)
 
         onInputStarted()
     }
 
     override fun stopInput() {
-        currentInputConnection?.close()
+        currentInputConnection?.stop()
         currentInputConnection = null
     }
 
@@ -167,7 +167,7 @@ internal class UIKitTextInputService(
             if (currentInputConnection is SelectionContainerConnection) {
                 // close() removes the view from the hierarchy and resigns first responder,
                 // without requiring a prior open() call.
-                currentInputConnection?.close()
+                currentInputConnection?.stop()
                 currentInputConnection = null
             }
         }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -150,6 +150,10 @@ internal class UIKitTextInputService(
             onCutRequested: (() -> Unit)?,
             onSelectAllRequested: (() -> Unit)?
         ) {
+            // Entry point for showing the context menu in SelectionContainer scenarios, where
+            // there is no active text input session. iOS requires a UIView that can become first
+            // responder in order to host the context menu, so we create a dedicated connection
+            // backed by a hidden view for this purpose.
             if (currentInputConnection == null) {
                 currentInputConnection = SelectionContainerConnection(
                     view, coroutineScope, viewConfiguration, focusManager

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -171,8 +171,7 @@ internal class UIKitTextInputService(
 
     val nativeTextInputContext = object : UIKitNativeTextInputContext {
         override fun usingNativeTextInput(): Boolean =
-            (currentInputConnection as? UIKitNativeTextInputContext)?.usingNativeTextInput()
-                ?: false
+            currentInputConnection is NativeTextInputConnection
 
         override fun updateNativeTextInputEditMenuState(
             copy: (() -> Unit)?,
@@ -181,17 +180,16 @@ internal class UIKitTextInputService(
             selectAll: (() -> Unit)?,
             customActions: List<UIKitNativeTextInputContextMenuCustomAction>?
         ) {
-            (currentInputConnection as? UIKitNativeTextInputContext)?.updateNativeTextInputEditMenuState(
+            (currentInputConnection as? NativeTextInputConnection)?.updateNativeTextInputEditMenuState(
                 copy, paste, cut, selectAll, customActions
             )
         }
 
         override fun updateNativeTextInputTintColor(color: Color?) {
-            (currentInputConnection as? UIKitNativeTextInputContext)?.updateNativeTextInputTintColor(
+            (currentInputConnection as? NativeTextInputConnection)?.updateNativeTextInputTintColor(
                 color
             )
         }
-
     }
 
     fun dispose() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -366,7 +366,7 @@ internal class ComposeSceneMediator(
 
     private val textInputService: UIKitTextInputService by lazy {
         UIKitTextInputService(
-            updateView = {
+            updateView = { usingNativeTextInput ->
                 if (usingNativeTextInput) {
                     // Too heavy method for this purpose
                     // we actually do not need to re-render the scene -
@@ -611,7 +611,7 @@ internal class ComposeSceneMediator(
         CompositionLocalProvider(
             LocalInteropContainer provides interopContainer,
             LocalUIView provides _overlayView,
-            LocalNativeTextInputContext provides textInputService,
+            LocalNativeTextInputContext provides textInputService.nativeTextInputContext,
             content = content
         )
 
@@ -729,7 +729,7 @@ internal class ComposeSceneMediator(
         override val viewConfiguration get() = this@ComposeSceneMediator.viewConfiguration
         override val inputModeManager = DefaultInputModeManager(InputMode.Touch)
         override val textInputService get() = this@ComposeSceneMediator.textInputService
-        override val textToolbar get() = this@ComposeSceneMediator.textInputService
+        override val textToolbar get() = this@ComposeSceneMediator.textInputService.toolbarHandler
         override val semanticsOwnerListener get() = this@ComposeSceneMediator.semanticsOwnerListener
         override val dragAndDropManager get() = this@ComposeSceneMediator.dragAndDropManager
         override val windowInsets get() = this@ComposeSceneMediator.windowInsetsManager.windowInsets

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -729,7 +729,7 @@ internal class ComposeSceneMediator(
         override val viewConfiguration get() = this@ComposeSceneMediator.viewConfiguration
         override val inputModeManager = DefaultInputModeManager(InputMode.Touch)
         override val textInputService get() = this@ComposeSceneMediator.textInputService
-        override val textToolbar get() = this@ComposeSceneMediator.textInputService.toolbarHandler
+        override val textToolbar get() = this@ComposeSceneMediator.textInputService.textToolbar
         override val semanticsOwnerListener get() = this@ComposeSceneMediator.semanticsOwnerListener
         override val dragAndDropManager get() = this@ComposeSceneMediator.dragAndDropManager
         override val windowInsets get() = this@ComposeSceneMediator.windowInsetsManager.windowInsets

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -759,24 +759,17 @@ internal class ComposeSceneMediator(
                 }
                 launch {
                     snapshotFlow {
-                        Triple(
+                        Pair(
                             request.textFieldRectInRoot(),
-                            request.textClippingRectInRoot(),
                             request.unclippedTextOffsetInRoot()
                         )
-                    }.collect { (textFieldRect, clippingRect, unclippedTextOffset) ->
-                        if (textFieldRect != null && clippingRect != null && unclippedTextOffset != null) {
+                    }.collect { (textFieldRect, unclippedTextOffset) ->
+                        if (textFieldRect != null && unclippedTextOffset != null) {
                             textInputService.updateTextFieldGeometry(
                                 textFieldFrame = textFieldRect,
-                                clippingTextFrame = clippingRect,
                                 unclippedTextPosition = unclippedTextOffset
                             )
                         }
-                    }
-                }
-                launch {
-                    snapshotFlow { request.focusedRectInRoot() }.filterNotNull().collect {
-                        textInputService.updateFocusedRect(it)
                     }
                 }
                 suspendCancellableCoroutine<Nothing> { continuation ->

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -98,7 +98,7 @@ internal open class ComposeTextInputConnection(
         showMenuOrUpdatePosition = {}
         textUIView.let { view ->
             view.setFrame(outOfBoundsFrame)
-            textUIView.onKeyboardPresses = NoOpOnKeyboardPresses
+            view.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
                 delay(CLEAR_FOCUS_DELAY)
                 view.removeFromSuperview()
@@ -122,7 +122,7 @@ internal open class ComposeTextInputConnection(
         if (selectionChanged) {
             textUIView.selectionDidChange()
         }
-        if ((textChanged || selectionChanged)) {
+        if (textChanged || selectionChanged) {
             updateView()
         }
     }
@@ -217,4 +217,9 @@ internal class SelectionContainerConnection(
     null,
     {},
     focusManager
-) {}
+) {
+    override fun close() {
+        textUIView.resignFirstResponder()
+        super.close()
+    }
+}

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -73,18 +73,9 @@ internal open class ComposeTextInputConnection(
             it.setFrame(view.bounds)
         }
 
-    override fun open(
-        value: TextFieldValue,
-        imeOptions: ImeOptions,
-        onEditCommand: (List<EditCommand>) -> Unit,
-        onImeActionPerformed: (ImeAction) -> Unit
-    ) {
-        super.open(value, imeOptions, onEditCommand, onImeActionPerformed)
-
+    override fun attachInputToView(imeOptions: ImeOptions) {
         textUIView.input = this
         textUIView.inputTraits = getUITextInputTraits(imeOptions)
-
-        showKeyboard()
     }
 
     override fun detachView() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -128,10 +128,9 @@ internal open class ComposeTextInputConnection(
 
     override fun updateViewGeometry(
         textFieldFrame: Rect,
-        clippingTextFrame: Rect,
         unclippedTextPosition: Offset
     ) {
-        super.updateViewGeometry(textFieldFrame, clippingTextFrame, unclippedTextPosition)
+        super.updateViewGeometry(textFieldFrame, unclippedTextPosition)
         showMenuOrUpdatePosition()
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.asCGRect
 import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.toDpRect
@@ -136,7 +135,7 @@ internal open class ComposeTextInputConnection(
         showMenuOrUpdatePosition()
     }
 
-    override fun updateTextViewPosition() {
+    override fun updateTextViewPosition(unclippedTextPosition: Offset) {
         val rect = textFieldFrameInRoot ?: return
         textUIView.setFrame(rect.toDpRect(view.density).asCGRect())
     }
@@ -146,10 +145,6 @@ internal open class ComposeTextInputConnection(
         val cursorRect = textLayoutResult?.getCursorRect(cursorPos) ?: return
         floatingCursorTranslation = cursorRect.center - offset.toOffset(view.density)
     }
-
-    override fun caretDpRectForPosition(position: Int): DpRect? =
-        null
-
 
     private fun textMenuAppearanceChanged() {
         textInputServiceInvalidationsCount++

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -69,11 +69,12 @@ internal open class ComposeTextInputConnection(
                 UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
             )
             it.onKeyboardPresses = onKeyboardPresses
-            view.addSubview(it)
-            it.setFrame(view.bounds)
         }
 
     override fun attachInputToView(imeOptions: ImeOptions) {
+        view.addSubview(textInputView)
+        textInputView.setFrame(view.bounds)
+
         textInputView.input = this
         textInputView.inputTraits = getUITextInputTraits(imeOptions)
     }
@@ -148,10 +149,11 @@ internal open class ComposeTextInputConnection(
     private var showMenuOrUpdatePosition = {}
 
     override val status: TextToolbarStatus
-        get() = if (textInputView.isTextMenuShown())
+        get() = if (textInputView.isTextMenuShown()) {
             TextToolbarStatus.Shown
-        else
+        } else {
             TextToolbarStatus.Hidden
+        }
 
     override fun showMenu(
         rect: Rect,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -18,11 +18,9 @@ package androidx.compose.ui.text.input
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.TextToolbarStatus
 import androidx.compose.ui.platform.ViewConfiguration
-import androidx.compose.ui.platform.getUITextInputTraits
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
@@ -68,15 +66,13 @@ internal open class ComposeTextInputConnection(
             it.setAutoresizingMask(
                 UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
             )
-            it.onKeyboardPresses = onKeyboardPresses
         }
 
-    override fun attachInputToView(imeOptions: ImeOptions) {
+    override fun attachInputToView() {
         view.addSubview(textInputView)
         textInputView.setFrame(view.bounds)
 
         textInputView.input = this
-        textInputView.inputTraits = getUITextInputTraits(imeOptions)
     }
 
     override fun detachView() {
@@ -84,12 +80,10 @@ internal open class ComposeTextInputConnection(
         val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
 
         textInputView.input = null
-        textInputView.inputTraits = EmptyInputTraits
 
         showMenuOrUpdatePosition = {}
         textInputView.let { view ->
             view.setFrame(outOfBoundsFrame)
-            view.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
                 delay(CLEAR_FOCUS_DELAY)
                 view.removeFromSuperview()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.EmptyInputTraits
+import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.TextToolbarStatus
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.platform.getUITextInputTraits
+import androidx.compose.ui.scene.ComposeSceneFocusManager
+import androidx.compose.ui.uikit.density
+import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.asCGRect
+import androidx.compose.ui.unit.asDpOffset
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.FocusedViewsList
+import androidx.compose.ui.window.ComposeTextInputView
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIView
+import platform.UIKit.UIViewAutoresizingFlexibleHeight
+import platform.UIKit.UIViewAutoresizingFlexibleWidth
+
+internal open class ComposeTextInputConnection(
+    updateView: () -> Unit,
+    view: UIView,
+    coroutineScope: CoroutineScope,
+    viewConfiguration: ViewConfiguration,
+    focusedViewsList: FocusedViewsList?,
+    onKeyboardPresses: (Set<*>) -> Unit,
+    focusManager: () -> ComposeSceneFocusManager?
+) : BaseTextInputConnection(
+    updateView,
+    view,
+    coroutineScope,
+    focusedViewsList,
+    onKeyboardPresses,
+    focusManager
+), TextToolbar {
+
+    override val textUIView =
+        ComposeTextInputView(
+            doubleTapTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis,
+            coroutineScope = coroutineScope
+        ).also {
+            it.setAutoresizingMask(
+                UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
+            )
+            it.onKeyboardPresses = onKeyboardPresses
+            view.addSubview(it)
+            it.setFrame(view.bounds)
+        }
+
+    override fun open(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    ) {
+        super.open(value, imeOptions, onEditCommand, onImeActionPerformed)
+
+        textUIView.input = this
+        textUIView.inputTraits = getUITextInputTraits(imeOptions)
+
+        showKeyboard()
+    }
+
+    override fun detachView() {
+        // Out-of-bounds non-empty frame is required to hide text keyboard focus frame
+        val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
+
+        textUIView.input = null
+        textUIView.inputTraits = EmptyInputTraits
+
+        showMenuOrUpdatePosition = {}
+        textUIView.let { view ->
+            view.setFrame(outOfBoundsFrame)
+            textUIView.onKeyboardPresses = NoOpOnKeyboardPresses
+            coroutineScope.launch {
+                delay(CLEAR_FOCUS_DELAY)
+                view.removeFromSuperview()
+            }
+        }
+    }
+
+    override fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean) {
+        if (textChanged) {
+            textUIView.textWillChange()
+        }
+        if (selectionChanged) {
+            textUIView.selectionWillChange()
+        }
+    }
+
+    override fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean) {
+        if (textChanged) {
+            textUIView.textDidChange()
+        }
+        if (selectionChanged) {
+            textUIView.selectionDidChange()
+        }
+        if ((textChanged || selectionChanged)) {
+            updateView()
+        }
+    }
+
+    override fun updateViewGeometry(
+        textFieldFrame: Rect,
+        clippingTextFrame: Rect,
+        unclippedTextPosition: Offset
+    ) {
+        super.updateViewGeometry(textFieldFrame, clippingTextFrame, unclippedTextPosition)
+        showMenuOrUpdatePosition()
+    }
+
+    override fun updateTextViewPosition() {
+        val rect = textFieldFrameInRoot ?: return
+        textUIView.setFrame(rect.toDpRect(view.density).asCGRect())
+    }
+
+    override fun beginFloatingCursor(offset: DpOffset) {
+        val cursorPos = getCursorPos() ?: getState()?.selection?.start ?: return
+        val cursorRect = textLayoutResult?.getCursorRect(cursorPos) ?: return
+        floatingCursorTranslation = cursorRect.center - offset.toOffset(view.density)
+    }
+
+    override fun caretDpRectForPosition(position: Int): DpRect? =
+        null
+
+
+    private fun textMenuAppearanceChanged() {
+        textInputServiceInvalidationsCount++
+        coroutineScope.launch {
+            // Time to show, hide or update state of context menu
+            delay(500.milliseconds)
+            textInputServiceInvalidationsCount--
+        }
+    }
+    // Fixes a problem where the menu is shown before the textUIView gets its final layout.
+    private var showMenuOrUpdatePosition = {}
+
+    override val status: TextToolbarStatus
+        get() = if (textUIView.isTextMenuShown())
+            TextToolbarStatus.Shown
+        else
+            TextToolbarStatus.Hidden
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?
+    ) {
+        showMenuOrUpdatePosition = {
+            textUIView.let { textUIView ->
+                val density = view.density
+                val offset = textUIView.frame.useContents { origin.asDpOffset().toOffset(density) }
+                val target = rect.translate(-offset).toDpRect(density).asCGRect()
+                textUIView.showEditMenuAtRect(
+                    targetRect = target,
+                    copy = onCopyRequested,
+                    cut = onCutRequested,
+                    paste = onPasteRequested,
+                    selectAll = onSelectAllRequested,
+                    customActions = emptyList<CMPEditMenuCustomAction>()
+                )
+                textMenuAppearanceChanged()
+            }
+        }
+        showMenuOrUpdatePosition()
+    }
+
+
+    override fun hide() {
+        showMenuOrUpdatePosition = {}
+        textUIView.let {
+            it.hideTextMenu()
+            textMenuAppearanceChanged()
+        }
+    }
+}
+
+internal class SelectionContainerConnection(
+    view: UIView,
+    coroutineScope: CoroutineScope,
+    viewConfiguration: ViewConfiguration,
+    focusManager: () -> ComposeSceneFocusManager?
+) : ComposeTextInputConnection(
+    {},
+    view,
+    coroutineScope,
+    viewConfiguration,
+    null,
+    {},
+    focusManager
+) {}

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -60,7 +60,7 @@ internal open class ComposeTextInputConnection(
     focusManager
 ), TextToolbar {
 
-    override val textUIView =
+    override val textInputView =
         ComposeTextInputView(
             doubleTapTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis,
             coroutineScope = coroutineScope
@@ -74,19 +74,19 @@ internal open class ComposeTextInputConnection(
         }
 
     override fun attachInputToView(imeOptions: ImeOptions) {
-        textUIView.input = this
-        textUIView.inputTraits = getUITextInputTraits(imeOptions)
+        textInputView.input = this
+        textInputView.inputTraits = getUITextInputTraits(imeOptions)
     }
 
     override fun detachView() {
         // Out-of-bounds non-empty frame is required to hide text keyboard focus frame
         val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
 
-        textUIView.input = null
-        textUIView.inputTraits = EmptyInputTraits
+        textInputView.input = null
+        textInputView.inputTraits = EmptyInputTraits
 
         showMenuOrUpdatePosition = {}
-        textUIView.let { view ->
+        textInputView.let { view ->
             view.setFrame(outOfBoundsFrame)
             view.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
@@ -98,19 +98,19 @@ internal open class ComposeTextInputConnection(
 
     override fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean) {
         if (textChanged) {
-            textUIView.textWillChange()
+            textInputView.textWillChange()
         }
         if (selectionChanged) {
-            textUIView.selectionWillChange()
+            textInputView.selectionWillChange()
         }
     }
 
     override fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean) {
         if (textChanged) {
-            textUIView.textDidChange()
+            textInputView.textDidChange()
         }
         if (selectionChanged) {
-            textUIView.selectionDidChange()
+            textInputView.selectionDidChange()
         }
         if (textChanged || selectionChanged) {
             updateView()
@@ -127,7 +127,7 @@ internal open class ComposeTextInputConnection(
 
     override fun updateTextViewPosition(unclippedTextPosition: Offset) {
         val rect = textFieldFrameInRoot ?: return
-        textUIView.setFrame(rect.toDpRect(view.density).asCGRect())
+        textInputView.setFrame(rect.toDpRect(view.density).asCGRect())
     }
 
     override fun beginFloatingCursor(offset: DpOffset) {
@@ -144,11 +144,11 @@ internal open class ComposeTextInputConnection(
             textInputServiceInvalidationsCount--
         }
     }
-    // Fixes a problem where the menu is shown before the textUIView gets its final layout.
+    // Fixes a problem where the menu is shown before the textInputView gets its final layout.
     private var showMenuOrUpdatePosition = {}
 
     override val status: TextToolbarStatus
-        get() = if (textUIView.isTextMenuShown())
+        get() = if (textInputView.isTextMenuShown())
             TextToolbarStatus.Shown
         else
             TextToolbarStatus.Hidden
@@ -161,11 +161,11 @@ internal open class ComposeTextInputConnection(
         onSelectAllRequested: (() -> Unit)?
     ) {
         showMenuOrUpdatePosition = {
-            textUIView.let { textUIView ->
+            textInputView.let { textInputView ->
                 val density = view.density
-                val offset = textUIView.frame.useContents { origin.asDpOffset().toOffset(density) }
+                val offset = textInputView.frame.useContents { origin.asDpOffset().toOffset(density) }
                 val target = rect.translate(-offset).toDpRect(density).asCGRect()
-                textUIView.showEditMenuAtRect(
+                textInputView.showEditMenuAtRect(
                     targetRect = target,
                     copy = onCopyRequested,
                     cut = onCutRequested,
@@ -182,7 +182,7 @@ internal open class ComposeTextInputConnection(
 
     override fun hide() {
         showMenuOrUpdatePosition = {}
-        textUIView.let {
+        textInputView.let {
             it.hideTextMenu()
             textMenuAppearanceChanged()
         }
@@ -204,7 +204,7 @@ internal class SelectionContainerConnection(
     focusManager
 ) {
     override fun close() {
-        textUIView.resignFirstResponder()
+        textInputView.resignFirstResponder()
         super.close()
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -51,7 +51,7 @@ internal open class ComposeTextInputConnection(
     focusedViewsList: FocusedViewsList?,
     onKeyboardPresses: (Set<*>) -> Unit,
     focusManager: () -> ComposeSceneFocusManager?
-) : BaseTextInputConnection(
+) : TextInputConnection(
     updateView,
     view,
     coroutineScope,
@@ -186,25 +186,5 @@ internal open class ComposeTextInputConnection(
             it.hideTextMenu()
             textMenuAppearanceChanged()
         }
-    }
-}
-
-internal class SelectionContainerConnection(
-    view: UIView,
-    coroutineScope: CoroutineScope,
-    viewConfiguration: ViewConfiguration,
-    focusManager: () -> ComposeSceneFocusManager?
-) : ComposeTextInputConnection(
-    {},
-    view,
-    coroutineScope,
-    viewConfiguration,
-    null,
-    {},
-    focusManager
-) {
-    override fun close() {
-        textInputView.resignFirstResponder()
-        super.close()
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
-import androidx.compose.ui.platform.NativeTextInputDelegate
+import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.TextSelectionRect
 import androidx.compose.ui.platform.UIKitNativeTextInputContext
@@ -65,7 +65,7 @@ internal class NativeTextInputConnection(
     focusedViewsList,
     onKeyboardPresses,
     focusManager
-), NativeTextInputDelegate, UIKitNativeTextInputContext {
+), NativeTextEditingDelegate, UIKitNativeTextInputContext {
     private val scrollView by lazy { IntermediateTextScrollView() }
 
     override val textUIView = NativeTextInputView(

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -99,10 +99,8 @@ internal class NativeTextInputConnection(
             textView.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
                 delay(CLEAR_FOCUS_DELAY)
-                if (scrollView.textView == textView) {
-                    scrollView.textView = null
-                    textView.removeFromSuperview()
-                }
+                scrollView.textView = null
+                textView.removeFromSuperview()
             }
         }
         scrollView.removeFromSuperview()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.TextSelectionRect
-import androidx.compose.ui.platform.UIKitNativeTextInputContext
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
 import androidx.compose.ui.platform.getUITextInputTraits
 import androidx.compose.ui.platform.toUIColor
@@ -65,7 +64,7 @@ internal class NativeTextInputConnection(
     focusedViewsList,
     onKeyboardPresses,
     focusManager
-), NativeTextEditingDelegate, UIKitNativeTextInputContext {
+), NativeTextEditingDelegate {
     private val scrollView by lazy { IntermediateTextScrollView() }
 
     override val textUIView = NativeTextInputView(
@@ -81,7 +80,7 @@ internal class NativeTextInputConnection(
     override fun attachInputToView(imeOptions: ImeOptions) {
         textUIView.input = this
         textUIView.inputTraits = getUITextInputTraits(imeOptions)
-        // Resizing should be done later
+        // The view frame will be set later via updateTextViewPosition;
         textUIView.resignFirstResponder()
         textUIView.becomeFirstResponder()
         setupTintColor()
@@ -194,9 +193,9 @@ internal class NativeTextInputConnection(
         }
         val rect = currentTextLayoutResult.getCursorRect(position)
         return rect.toDpRect(view.density).let {
-            val hafWidth = cursorThickness / 2
+            val halfWidth = cursorThickness / 2
             val center = (it.left + it.right) / 2
-            it.copy(left = center - hafWidth, right = center + hafWidth)
+            it.copy(left = center - halfWidth, right = center + halfWidth)
         }
     }
 
@@ -387,9 +386,7 @@ internal class NativeTextInputConnection(
         }
     }
 
-    override fun usingNativeTextInput(): Boolean = true
-
-    override fun updateNativeTextInputEditMenuState(
+    fun updateNativeTextInputEditMenuState(
         copy: (() -> Unit)?,
         paste: (() -> Unit)?,
         cut: (() -> Unit)?,
@@ -407,7 +404,7 @@ internal class NativeTextInputConnection(
         )
     }
 
-    override fun updateNativeTextInputTintColor(color: Color?) {
+    fun updateNativeTextInputTintColor(color: Color?) {
         selectionTintColor = color
         setupTintColor()
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -22,13 +22,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
-import androidx.compose.ui.platform.TextSelectionRect
+import androidx.compose.ui.platform.TextInputSelectionRect
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.platform.toUIColor
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
 import androidx.compose.ui.unit.DpOffset
@@ -194,7 +194,7 @@ internal class NativeTextInputConnection(
         }
     }
 
-    override fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect> {
+    override fun selectionDpRectsForRange(range: TextRange): List<TextInputSelectionRect> {
         // Native selection rects are required for correct work of the text editing menu
         // Without them, it will be impossible to call the text editing menu by tapping on the selected area
         if (range.collapsed || isIncorrect(range)) {
@@ -214,7 +214,7 @@ internal class NativeTextInputConnection(
 
         return if (firstLineNumber == lastLineNumber) {
             listOf(
-                TextSelectionRect(
+                TextInputSelectionRect(
                     dpRect = Rect(
                         topLeft = startSelectionHandleRect.topLeft,
                         bottomRight = endSelectionHandleRect.bottomRight
@@ -240,7 +240,7 @@ internal class NativeTextInputConnection(
                 }
             } ?: return emptyList()
 
-            val firstLineSelectionRect = TextSelectionRect(
+            val firstLineSelectionRect = TextInputSelectionRect(
                 dpRect = Rect(
                     top = startSelectionHandleRect.top,
                     left = startSelectionHandleRect.left,
@@ -253,7 +253,7 @@ internal class NativeTextInputConnection(
                 isVertical = false
             )
 
-            val middleAreaSelectionRect = TextSelectionRect(
+            val middleAreaSelectionRect = TextInputSelectionRect(
                 dpRect = Rect(
                     top = startSelectionHandleRect.bottom,
                     left = contentRect.left,
@@ -269,7 +269,7 @@ internal class NativeTextInputConnection(
             val lastLineStartRect = currentTextLayoutResult.getCursorRect(
                 currentTextLayoutResult.getLineStart(lastLineNumber)
             )
-            val lastLineRect = TextSelectionRect(
+            val lastLineRect = TextInputSelectionRect(
                 dpRect = Rect(
                     topLeft = lastLineStartRect.topLeft,
                     bottomRight = endSelectionHandleRect.bottomRight

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.text.input
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.UIKitNativeTextInputContext
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
@@ -70,14 +71,7 @@ internal class NativeTextInputConnection(
 
         it.onKeyboardPresses = onKeyboardPresses
         it.clipsToBounds = false
-
-        // Resizing should be done later
-        it.resignFirstResponder()
-        it.becomeFirstResponder()
-
-        setupTintColor() // TODO: onAttach?
     }
-
 
     override fun open(
         value: TextFieldValue,
@@ -89,6 +83,11 @@ internal class NativeTextInputConnection(
 
         textUIView.input = this
         textUIView.inputTraits = getUITextInputTraits(imeOptions)
+
+        // Resizing should be done later
+        textUIView.resignFirstResponder()
+        textUIView.becomeFirstResponder()
+        setupTintColor()
 
         showKeyboard()
     }
@@ -102,7 +101,7 @@ internal class NativeTextInputConnection(
 
         textUIView.let { textView ->
             textView.setFrame(outOfBoundsFrame)
-            textUIView.onKeyboardPresses = NoOpOnKeyboardPresses
+            textView.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
                 delay(CLEAR_FOCUS_DELAY)
                 if (scrollView.textView == textView) {
@@ -171,7 +170,10 @@ internal class NativeTextInputConnection(
             left = max(0f, -contentBounds.left).toDp(),
             top = max(0f, -contentBounds.top).toDp(),
             right = max(0f, textFieldFrame.width - contentBounds.width + contentBounds.left).toDp(),
-            bottom = max(0f, textFieldFrame.height - contentBounds.height + contentBounds.top).toDp()
+            bottom = max(
+                0f,
+                textFieldFrame.height - contentBounds.height + contentBounds.top
+            ).toDp()
         )
     }
 
@@ -250,6 +252,3 @@ internal class NativeTextInputConnection(
      */
     private val cursorThickness = 2.dp
 }
-
-// Insets in DP
-internal data class DpInsets(val left: Dp, val top: Dp, val right: Dp, val bottom: Dp)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.EmptyInputTraits
+import androidx.compose.ui.platform.UIKitNativeTextInputContext
+import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
+import androidx.compose.ui.platform.getUITextInputTraits
+import androidx.compose.ui.platform.toUIColor
+import androidx.compose.ui.scene.ComposeSceneFocusManager
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.uikit.density
+import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.unit.toSize
+import androidx.compose.ui.window.FocusedViewsList
+import androidx.compose.ui.window.IntermediateTextScrollView
+import androidx.compose.ui.window.NativeTextInputView
+import kotlin.math.max
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIView
+
+internal class NativeTextInputConnection(
+    updateView: () -> Unit,
+    view: UIView,
+    coroutineScope: CoroutineScope,
+    focusedViewsList: FocusedViewsList?,
+    onKeyboardPresses: (Set<*>) -> Unit,
+    focusManager: () -> ComposeSceneFocusManager?
+) : BaseTextInputConnection(
+    updateView,
+    view,
+    coroutineScope,
+    focusedViewsList,
+    onKeyboardPresses,
+    focusManager
+), UIKitNativeTextInputContext {
+    private val scrollView by lazy { IntermediateTextScrollView() }
+
+    override val textUIView = NativeTextInputView(
+        coroutineScope = coroutineScope
+    ).also {
+        view.addSubview(scrollView)
+        scrollView.textView = it
+
+        it.onKeyboardPresses = onKeyboardPresses
+        it.clipsToBounds = false
+
+        // Resizing should be done later
+        it.resignFirstResponder()
+        it.becomeFirstResponder()
+
+        setupTintColor() // TODO: onAttach?
+    }
+
+
+    override fun open(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    ) {
+        super.open(value, imeOptions, onEditCommand, onImeActionPerformed)
+
+        textUIView.input = this
+        textUIView.inputTraits = getUITextInputTraits(imeOptions)
+
+        showKeyboard()
+    }
+
+    override fun detachView() {
+        // Out-of-bounds non-empty frame is required to hide text keyboard focus frame
+        val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
+
+        textUIView.input = null
+        textUIView.inputTraits = EmptyInputTraits
+
+        textUIView.let { textView ->
+            textView.setFrame(outOfBoundsFrame)
+            textUIView.onKeyboardPresses = NoOpOnKeyboardPresses
+            coroutineScope.launch {
+                delay(CLEAR_FOCUS_DELAY)
+                if (scrollView.textView == textView) {
+                    scrollView.textView = null
+                    textView.removeFromSuperview()
+                }
+            }
+        }
+        scrollView.removeFromSuperview()
+    }
+
+    override fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean) {
+        if (textChanged) {
+            textUIView.textWillChange()
+        }
+        if (selectionChanged) {
+            textUIView.selectionWillChange()
+        }
+    }
+
+    override fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean) {
+        if (textChanged) {
+            textUIView.textDidChange()
+        }
+        if (selectionChanged) {
+            textUIView.selectionDidChange()
+        }
+    }
+
+    override fun updateTextViewPosition() {
+        val rect = textFieldFrameInRoot ?: return
+        // Since Compose content is rendered on a MetalView and the UITextInput-implementing
+        // view is overlayed on top of it, we need to synchronize the Compose text
+        // field with the IntermediateTextScrollView (which contains IntermediateUITextView)
+        // to ensure native iOS text input controls
+        // align correctly with the rendered text.
+        val layoutResult = textLayoutResult ?: return
+        val unclippedTextPosition = unclippedTextPosition ?: return
+
+        val contentBounds = calculateContentBounds(
+            layoutResult,
+            rect,
+            unclippedTextPosition
+        )
+        currentContentBounds = contentBounds
+        val contentInsets = calculateContentInsets(rect, contentBounds)
+        currentContentInsets = contentInsets
+        scrollView.setFrame(
+            rect.toDpRect(view.density),
+            contentBounds.toDpRect(view.density),
+            contentInsets
+        )
+    }
+
+    private fun calculateContentBounds(textLayoutResult: TextLayoutResult, textFieldFrame: Rect, unclippedTextPosition: Offset): Rect {
+        val textSize = textLayoutResult.size.toSize()
+        val contentBounds = Rect(
+            offset = Offset(x = textFieldFrame.left - unclippedTextPosition.x, y = textFieldFrame.top - unclippedTextPosition.y),
+            size = textSize
+        )
+        return contentBounds
+    }
+
+    private fun calculateContentInsets(textFieldFrame: Rect, contentBounds: Rect): DpInsets = with(view.density) {
+        return DpInsets(
+            left = max(0f, -contentBounds.left).toDp(),
+            top = max(0f, -contentBounds.top).toDp(),
+            right = max(0f, textFieldFrame.width - contentBounds.width + contentBounds.left).toDp(),
+            bottom = max(0f, textFieldFrame.height - contentBounds.height + contentBounds.top).toDp()
+        )
+    }
+
+    override fun sendEditCommand(vararg commands: EditCommand) {
+        super.sendEditCommand(*commands)
+        // For Native Text Input it's essential to trigger view update right after send edit command,
+        // otherwise UIKit calls may use an invalid layout state
+        coroutineScope.launch {
+            updateView()
+        }
+    }
+
+    override fun beginFloatingCursor(offset: DpOffset) {
+        val cursorPos = getState()?.selection?.start ?: return
+        val cursorRect = textLayoutResult?.getCursorRect(cursorPos) ?: return
+        floatingCursorTranslation = cursorRect.center - offset.toOffset(view.density)
+    }
+
+    override fun caretDpRectForPosition(position: Int): DpRect? {
+        val text = getState()?.text ?: return null
+        if (position < 0 || position > text.length) {
+            return null
+        }
+        val currentTextLayoutResult = textLayoutResult ?: return null
+        if (position > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) {
+            return null
+        }
+        val rect = currentTextLayoutResult.getCursorRect(position)
+        return rect.toDpRect(view.density).let {
+            val hafWidth = cursorThickness / 2
+            val center = (it.left + it.right) / 2
+            it.copy(left = center - hafWidth, right = center + hafWidth)
+        }
+    }
+
+
+
+    // If not specified, iOS would use the default system tint color
+    private var selectionTintColor: Color? = null
+    private fun setupTintColor() {
+        textUIView.let {
+            val uiColor = selectionTintColor?.toUIColor()
+            it.setTintColor(uiColor)
+        }
+    }
+
+    override fun usingNativeTextInput(): Boolean = true
+
+    override fun updateNativeTextInputEditMenuState(
+        copy: (() -> Unit)?,
+        paste: (() -> Unit)?,
+        cut: (() -> Unit)?,
+        selectAll: (() -> Unit)?,
+        customActions: List<UIKitNativeTextInputContextMenuCustomAction>?
+    ) {
+        textUIView.updateMenuActions(
+            copy,
+            paste,
+            cut,
+            selectAll,
+            customActions?.map { action ->
+                CMPEditMenuCustomAction(action.title, action.action)
+            } ?: emptyList()
+        )
+    }
+
+    override fun updateNativeTextInputTintColor(color: Color?) {
+        selectionTintColor = color
+        setupTintColor()
+    }
+
+    /**
+     * Matches DefaultCursorThickness
+     *
+     * Must be at least 1.dp to make caret interactable
+     */
+    private val cursorThickness = 2.dp
+}
+
+// Insets in DP
+internal data class DpInsets(val left: Dp, val top: Dp, val right: Dp, val bottom: Dp)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.window.FocusedViewsList
-import androidx.compose.ui.window.IntermediateTextScrollView
+import androidx.compose.ui.window.NativeTextInputScrollView
 import androidx.compose.ui.window.NativeTextInputView
 import kotlin.math.max
 import kotlin.math.min
@@ -57,7 +57,7 @@ internal class NativeTextInputConnection(
     focusedViewsList: FocusedViewsList?,
     onKeyboardPresses: (Set<*>) -> Unit,
     focusManager: () -> ComposeSceneFocusManager?
-) : BaseTextInputConnection(
+) : TextInputConnection(
     updateView,
     view,
     coroutineScope,
@@ -65,7 +65,7 @@ internal class NativeTextInputConnection(
     onKeyboardPresses,
     focusManager
 ), NativeTextEditingDelegate {
-    private val scrollView by lazy { IntermediateTextScrollView() }
+    private val scrollView by lazy { NativeTextInputScrollView() }
 
     override val textInputView = NativeTextInputView(
         coroutineScope = coroutineScope

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -21,15 +21,19 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
+import androidx.compose.ui.platform.NativeTextInputDelegate
+import androidx.compose.ui.platform.PlatformTextLayoutDirection
+import androidx.compose.ui.platform.TextSelectionRect
 import androidx.compose.ui.platform.UIKitNativeTextInputContext
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
 import androidx.compose.ui.platform.getUITextInputTraits
 import androidx.compose.ui.platform.toUIColor
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
@@ -40,6 +44,7 @@ import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.IntermediateTextScrollView
 import androidx.compose.ui.window.NativeTextInputView
 import kotlin.math.max
+import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -60,7 +65,7 @@ internal class NativeTextInputConnection(
     focusedViewsList,
     onKeyboardPresses,
     focusManager
-), UIKitNativeTextInputContext {
+), NativeTextInputDelegate, UIKitNativeTextInputContext {
     private val scrollView by lazy { IntermediateTextScrollView() }
 
     override val textUIView = NativeTextInputView(
@@ -131,7 +136,10 @@ internal class NativeTextInputConnection(
         }
     }
 
-    override fun updateTextViewPosition() {
+    private var currentContentBounds: Rect? = null
+    private var currentContentInsets: DpInsets? = null
+
+    override fun updateTextViewPosition(unclippedTextPosition: Offset) {
         val rect = textFieldFrameInRoot ?: return
         // Since Compose content is rendered on a MetalView and the UITextInput-implementing
         // view is overlayed on top of it, we need to synchronize the Compose text
@@ -139,13 +147,8 @@ internal class NativeTextInputConnection(
         // to ensure native iOS text input controls
         // align correctly with the rendered text.
         val layoutResult = textLayoutResult ?: return
-        val unclippedTextPosition = unclippedTextPosition ?: return
 
-        val contentBounds = calculateContentBounds(
-            layoutResult,
-            rect,
-            unclippedTextPosition
-        )
+        val contentBounds = calculateContentBounds(layoutResult, rect, unclippedTextPosition)
         currentContentBounds = contentBounds
         val contentInsets = calculateContentInsets(rect, contentBounds)
         currentContentInsets = contentInsets
@@ -209,7 +212,183 @@ internal class NativeTextInputConnection(
         }
     }
 
+    override fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect> {
+        // Native selection rects are required for correct work of the text editing menu
+        // Without them, it will be impossible to call the text editing menu by tapping on the selected area
+        if (range.collapsed || isIncorrect(range)) {
+            return emptyList()
+        }
+        val currentTextLayoutResult = textLayoutResult ?: return emptyList()
 
+        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return emptyList()
+
+        val startSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.start)
+        val endSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.end)
+
+        val firstLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+        val lastLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
+
+        return if (firstLineNumber == lastLineNumber) {
+            listOf(
+                TextSelectionRect(
+                    dpRect = Rect(
+                        topLeft = startSelectionHandleRect.topLeft,
+                        bottomRight = endSelectionHandleRect.bottomRight
+                    ).toDpRect(view.density),
+                    writingDirection = TextDirection.Content,
+                    containsStart = true,
+                    containsEnd = true,
+                    isVertical = false
+                )
+            )
+        } else {
+            // TODO Consider RTL Layout
+            // We require separate rects for start line, end line and everything in between them
+            val contentInsets = currentContentInsets ?: return emptyList()
+            val contentRect = currentContentBounds?.let {
+                with(view.density) {
+                    Rect(
+                        top = it.top + contentInsets.top.toPx(),
+                        left = it.left + contentInsets.left.toPx(),
+                        right = it.right + contentInsets.right.toPx(),
+                        bottom = it.bottom + contentInsets.bottom.toPx()
+                    )
+                }
+            } ?: return emptyList()
+
+            val firstLineSelectionRect = TextSelectionRect(
+                dpRect = Rect(
+                    top = startSelectionHandleRect.top,
+                    left = startSelectionHandleRect.left,
+                    right = contentRect.right,
+                    bottom = startSelectionHandleRect.bottom
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = true,
+                containsEnd = false,
+                isVertical = false
+            )
+
+            val middleAreaSelectionRect = TextSelectionRect(
+                dpRect = Rect(
+                    top = startSelectionHandleRect.bottom,
+                    left = contentRect.left,
+                    right = contentRect.right,
+                    bottom = endSelectionHandleRect.top
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = false,
+                containsEnd = false,
+                isVertical = false
+            )
+
+            val lastLineStartRect = currentTextLayoutResult.getCursorRect(
+                currentTextLayoutResult.getLineStart(lastLineNumber)
+            )
+            val lastLineRect = TextSelectionRect(
+                dpRect = Rect(
+                    topLeft = lastLineStartRect.topLeft,
+                    bottomRight = endSelectionHandleRect.bottomRight
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = false,
+                containsEnd = true,
+                isVertical = false
+            )
+
+            listOf(
+                firstLineSelectionRect,
+                middleAreaSelectionRect,
+                lastLineRect
+            )
+        }
+    }
+
+    override fun firstSelectionRectForRange(range: TextRange): DpRect? {
+        if (range.collapsed || isIncorrect(range)) {
+            return null
+        }
+        val currentTextLayoutResult = textLayoutResult ?: return null
+
+        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return null
+
+        val startHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+        val endHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
+
+        val startHandleRect = currentTextLayoutResult.getCursorRect(range.start)
+
+        return if (startHandleLineNumber == endHandleLineNumber) {
+            Rect(
+                topLeft = startHandleRect.topLeft,
+                bottomRight = currentTextLayoutResult.getCursorRect(range.end).bottomRight
+            ).toDpRect(view.density)
+        } else {
+            val startLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+            val startLineRight = currentTextLayoutResult.getLineRight(startLineNumber)
+            Rect(
+                startHandleRect.left,
+                startHandleRect.top,
+                startLineRight,
+                startHandleRect.bottom
+            ).toDpRect(view.density)
+        }
+    }
+
+    override fun closestPositionToPoint(point: DpOffset): Int? {
+        return textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+    }
+
+    override fun closestPositionToPoint(point: DpOffset, withinRange: TextRange): Int? {
+        val pointOffset =
+            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+                ?: return null
+        return pointOffset.coerceIn(withinRange.start, withinRange.end)
+    }
+
+    override fun characterRangeAtPoint(point: DpOffset): TextRange? {
+        val pointOffset =
+            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+                ?: return null
+        return textLayoutResult?.getWordBoundary(pointOffset)
+    }
+
+    override fun positionWithinRange(
+        range: TextRange,
+        farthestInDirection: PlatformTextLayoutDirection
+    ): Int? {
+        if (isIncorrect(range)) return null
+        return when (farthestInDirection) {
+            PlatformTextLayoutDirection.Up -> range.start
+            PlatformTextLayoutDirection.Down -> range.end
+            else -> {
+                val layout = textLayoutResult ?: return null
+                val startLine = layout.getLineForOffset(range.start)
+                val endLine = layout.getLineForOffset(range.end)
+
+                val candidateOffsets = buildSet {
+                    add(range.start)
+                    add(range.end)
+
+                    for (line in startLine..endLine) {
+                        add(max(range.start, layout.getLineStart(line)))
+                        add(min(range.end, layout.getLineEnd(line)))
+                    }
+                }
+
+                when (farthestInDirection) {
+                    PlatformTextLayoutDirection.Left ->
+                        candidateOffsets.minByOrNull { layout.getHorizontalPosition(it, true) }
+                    PlatformTextLayoutDirection.Right ->
+                        candidateOffsets.maxByOrNull { layout.getHorizontalPosition(it, true) }
+                    else -> null
+                }
+            }
+        }
+    }
 
     // If not specified, iOS would use the default system tint color
     private var selectionTintColor: Color? = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -78,23 +78,13 @@ internal class NativeTextInputConnection(
         it.clipsToBounds = false
     }
 
-    override fun open(
-        value: TextFieldValue,
-        imeOptions: ImeOptions,
-        onEditCommand: (List<EditCommand>) -> Unit,
-        onImeActionPerformed: (ImeAction) -> Unit
-    ) {
-        super.open(value, imeOptions, onEditCommand, onImeActionPerformed)
-
+    override fun attachInputToView(imeOptions: ImeOptions) {
         textUIView.input = this
         textUIView.inputTraits = getUITextInputTraits(imeOptions)
-
         // Resizing should be done later
         textUIView.resignFirstResponder()
         textUIView.becomeFirstResponder()
         setupTintColor()
-
-        showKeyboard()
     }
 
     override fun detachView() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -20,12 +20,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.DpInsets
-import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.TextSelectionRect
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
-import androidx.compose.ui.platform.getUITextInputTraits
 import androidx.compose.ui.platform.toUIColor
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
@@ -70,18 +68,16 @@ internal class NativeTextInputConnection(
     override val textInputView = NativeTextInputView(
         coroutineScope = coroutineScope
     ).also {
-        it.onKeyboardPresses = onKeyboardPresses
         it.clipsToBounds = false
     }
 
-    override fun attachInputToView(imeOptions: ImeOptions) {
+    override fun attachInputToView() {
         view.addSubview(scrollView)
         scrollView.textView = textInputView
         // The view frame will be set later via updateTextViewPosition;
 
         textInputView.input = this
-        textInputView.inputTraits = getUITextInputTraits(imeOptions)
-        
+
         textInputView.resignFirstResponder()
         textInputView.becomeFirstResponder()
         setupTintColor()
@@ -92,11 +88,9 @@ internal class NativeTextInputConnection(
         val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
 
         textInputView.input = null
-        textInputView.inputTraits = EmptyInputTraits
 
         textInputView.let { textView ->
             textView.setFrame(outOfBoundsFrame)
-            textView.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
                 delay(CLEAR_FOCUS_DELAY)
                 scrollView.textView = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -67,7 +67,7 @@ internal class NativeTextInputConnection(
 ), NativeTextEditingDelegate {
     private val scrollView by lazy { IntermediateTextScrollView() }
 
-    override val textUIView = NativeTextInputView(
+    override val textInputView = NativeTextInputView(
         coroutineScope = coroutineScope
     ).also {
         view.addSubview(scrollView)
@@ -78,11 +78,11 @@ internal class NativeTextInputConnection(
     }
 
     override fun attachInputToView(imeOptions: ImeOptions) {
-        textUIView.input = this
-        textUIView.inputTraits = getUITextInputTraits(imeOptions)
+        textInputView.input = this
+        textInputView.inputTraits = getUITextInputTraits(imeOptions)
         // The view frame will be set later via updateTextViewPosition;
-        textUIView.resignFirstResponder()
-        textUIView.becomeFirstResponder()
+        textInputView.resignFirstResponder()
+        textInputView.becomeFirstResponder()
         setupTintColor()
     }
 
@@ -90,10 +90,10 @@ internal class NativeTextInputConnection(
         // Out-of-bounds non-empty frame is required to hide text keyboard focus frame
         val outOfBoundsFrame = CGRectMake(-100000.0, 0.0, 1.0, 1.0)
 
-        textUIView.input = null
-        textUIView.inputTraits = EmptyInputTraits
+        textInputView.input = null
+        textInputView.inputTraits = EmptyInputTraits
 
-        textUIView.let { textView ->
+        textInputView.let { textView ->
             textView.setFrame(outOfBoundsFrame)
             textView.onKeyboardPresses = NoOpOnKeyboardPresses
             coroutineScope.launch {
@@ -107,19 +107,19 @@ internal class NativeTextInputConnection(
 
     override fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean) {
         if (textChanged) {
-            textUIView.textWillChange()
+            textInputView.textWillChange()
         }
         if (selectionChanged) {
-            textUIView.selectionWillChange()
+            textInputView.selectionWillChange()
         }
     }
 
     override fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean) {
         if (textChanged) {
-            textUIView.textDidChange()
+            textInputView.textDidChange()
         }
         if (selectionChanged) {
-            textUIView.selectionDidChange()
+            textInputView.selectionDidChange()
         }
     }
 
@@ -380,7 +380,7 @@ internal class NativeTextInputConnection(
     // If not specified, iOS would use the default system tint color
     private var selectionTintColor: Color? = null
     private fun setupTintColor() {
-        textUIView.let {
+        textInputView.let {
             val uiColor = selectionTintColor?.toUIColor()
             it.setTintColor(uiColor)
         }
@@ -393,7 +393,7 @@ internal class NativeTextInputConnection(
         selectAll: (() -> Unit)?,
         customActions: List<UIKitNativeTextInputContextMenuCustomAction>?
     ) {
-        textUIView.updateMenuActions(
+        textInputView.updateMenuActions(
             copy,
             paste,
             cut,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -70,17 +70,18 @@ internal class NativeTextInputConnection(
     override val textInputView = NativeTextInputView(
         coroutineScope = coroutineScope
     ).also {
-        view.addSubview(scrollView)
-        scrollView.textView = it
-
         it.onKeyboardPresses = onKeyboardPresses
         it.clipsToBounds = false
     }
 
     override fun attachInputToView(imeOptions: ImeOptions) {
+        view.addSubview(scrollView)
+        scrollView.textView = textInputView
+        // The view frame will be set later via updateTextViewPosition;
+
         textInputView.input = this
         textInputView.inputTraits = getUITextInputTraits(imeOptions)
-        // The view frame will be set later via updateTextViewPosition;
+        
         textInputView.resignFirstResponder()
         textInputView.becomeFirstResponder()
         setupTintColor()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.scene.ComposeSceneFocusManager
+import kotlinx.coroutines.CoroutineScope
+import platform.UIKit.UIView
+
+
+internal class SelectionContainerConnection(
+    view: UIView,
+    coroutineScope: CoroutineScope,
+    viewConfiguration: ViewConfiguration,
+    focusManager: () -> ComposeSceneFocusManager?
+) : ComposeTextInputConnection(
+    {},
+    view,
+    coroutineScope,
+    viewConfiguration,
+    null,
+    {},
+    focusManager
+) {
+    override fun stop() {
+        textInputView.resignFirstResponder()
+        super.stop()
+    }
+}

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.TextEditingDelegate
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
@@ -81,7 +81,7 @@ internal abstract class BaseTextInputConnection(
     @Suppress("UNUSED")
     protected var onKeyboardPresses: (Set<*>) -> Unit,
     private var focusManager: () -> ComposeSceneFocusManager?,
-): TextInputConnection, TextInputDelegate {
+): TextInputConnection, TextEditingDelegate {
     override fun open(
         value: TextFieldValue,
         imeOptions: ImeOptions,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.BackgroundInputView
+import androidx.compose.ui.window.ComposeTextInputView
 import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.NativeTextInputView
 import androidx.compose.ui.window.OverlayInputView
@@ -58,10 +59,8 @@ internal interface TextInputConnection {
     fun updateTextLayoutResult(textLayoutResult: TextLayoutResult)
     fun updateViewGeometry(
         textFieldFrame: Rect,
-        clippingTextFrame: Rect,
         unclippedTextPosition: Offset
     )
-    fun updateFocusedRect(rect: Rect)
 
     fun onPreviewKeyEvent(event: KeyEvent): Boolean
 
@@ -112,15 +111,11 @@ internal abstract class BaseTextInputConnection(
     protected abstract fun detachView()
 
     override fun showKeyboard() {
-        textUIView?.let {
-            focusedViewsList?.addAndFocus(it)
-        }
+        focusedViewsList?.addAndFocus(textUIView)
     }
 
     override fun dismissKeyboard() {
-        textUIView?.let {
-            focusedViewsList?.remove(it, delayMillis = CLEAR_FOCUS_DELAY)
-        }
+        focusedViewsList?.remove(textUIView, delayMillis = CLEAR_FOCUS_DELAY)
     }
 
     override fun updateState(newValue: TextFieldValue) {
@@ -145,18 +140,11 @@ internal abstract class BaseTextInputConnection(
         this.textLayoutResult = textLayoutResult
     }
 
-    override fun updateFocusedRect(rect: Rect) {
-        currentFocusedRect = rect
-    }
-
     override fun updateViewGeometry(
         textFieldFrame: Rect,
-        clippingTextFrame: Rect,
         unclippedTextPosition: Offset
     ) {
         textFieldFrameInRoot = textFieldFrame
-        this.clippingTextFrame = clippingTextFrame
-
         updateTextViewPosition(unclippedTextPosition)
     }
     protected abstract fun updateTextViewPosition(unclippedTextPosition: Offset)
@@ -184,14 +172,12 @@ internal abstract class BaseTextInputConnection(
 
     protected var textInputServiceInvalidationsCount = 0
 
-    protected abstract val textUIView: UIView?
+    protected abstract val textUIView: UIView
     protected var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
     protected var currentImeOptions: ImeOptions? = null
     protected var currentImeActionHandler: ((ImeAction) -> Unit)? = null
-    protected var currentFocusedRect: Rect? = null
 
     protected var textFieldFrameInRoot: Rect? = null
-    protected var clippingTextFrame: Rect? = null
 
     protected var textLayoutResult: TextLayoutResult? = null
 
@@ -332,22 +318,32 @@ internal abstract class BaseTextInputConnection(
         return true
     }
 
-    private fun hasFocusedNonComposeInputViewInWindowHierarchy(): Boolean {
-        fun hasFocusedNonComposeInputView(view: UIView): Boolean {
+    /**
+     * Returns true if there is a focused view in the window hierarchy that is an external
+     * text input — i.e. a native UITextField or UITextView inserted via interop, not one of
+     * Compose's own input views.
+     *
+     * Used to distinguish the case where the user tapped a native interop text field (in which
+     * case Compose focus should be released) from the case where focus simply moved to another
+     * Compose text field (in which case Compose handles focus internally and no action is needed).
+     */
+    private fun hasFocusedExternalInputViewInWindowHierarchy(): Boolean {
+        fun hasFocusedExternalInputView(view: UIView): Boolean {
             if (view.isFirstResponder) {
                 return view !is NativeTextInputView &&
+                    view !is ComposeTextInputView &&
                     view !is OverlayInputView &&
                     view !is BackgroundInputView
             }
-            return view.subviews.any { it is UIView && hasFocusedNonComposeInputView(it) }
+            return view.subviews.any { it is UIView && hasFocusedExternalInputView(it) }
         }
-        return view.window?.let { hasFocusedNonComposeInputView(it) } ?: false
+        return view.window?.let { hasFocusedExternalInputView(it) } ?: false
     }
 
     override fun onResignFocus() {
         textInputServiceInvalidationsCount++
         coroutineScope.launch {
-            if (hasFocusedNonComposeInputViewInWindowHierarchy()) {
+            if (hasFocusedExternalInputViewInWindowHierarchy()) {
                 focusManager()?.releaseFocus()
             }
             textInputServiceInvalidationsCount--

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -1,0 +1,778 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.PlatformTextLayoutDirection
+import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.TextSelectionRect
+import androidx.compose.ui.scene.ComposeSceneFocusManager
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.uikit.density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.BackgroundInputView
+import androidx.compose.ui.window.FocusedViewsList
+import androidx.compose.ui.window.ComposeTextInputView
+import androidx.compose.ui.window.OverlayInputView
+import kotlin.apply
+import kotlin.math.absoluteValue
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.skia.BreakIterator
+import platform.UIKit.UIPress
+import platform.UIKit.UIView
+
+internal interface TextInputConnection {
+    fun open(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    )
+
+    fun close()
+    fun showKeyboard()
+    fun dismissKeyboard()
+
+    fun updateState(newValue: TextFieldValue)
+    fun updateTextLayoutResult(textLayoutResult: TextLayoutResult)
+    fun updateViewGeometry(
+        textFieldFrame: Rect,
+        clippingTextFrame: Rect,
+        unclippedTextPosition: Offset
+    )
+    fun updateFocusedRect(rect: Rect)
+
+    fun onPreviewKeyEvent(event: KeyEvent): Boolean
+
+    fun flushEditCommandsIfNeeded(force: Boolean = false)
+
+    val hasInvalidations: Boolean
+}
+
+internal abstract class BaseTextInputConnection(
+    protected val updateView: () -> Unit,
+    protected val view: UIView,
+    protected val coroutineScope: CoroutineScope,
+    protected val focusedViewsList: FocusedViewsList?,
+    /**
+     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
+     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
+     */
+    @Suppress("UNUSED")
+    protected var onKeyboardPresses: (Set<*>) -> Unit,
+    private var focusManager: () -> ComposeSceneFocusManager?,
+): TextInputConnection, TextInputDelegate {
+    override fun open(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    ) {
+        sessionEditProcessor = EditProcessor().apply {
+            reset(value, null)
+        }
+        currentOnEditCommand = onEditCommand
+        currentImeOptions = imeOptions
+        currentImeActionHandler = onImeActionPerformed
+
+        showKeyboard()
+    }
+
+    override fun close() {
+        flushEditCommandsIfNeeded(force = true)
+        sessionEditProcessor = null
+        currentImeOptions = null
+        currentImeActionHandler = null
+        textLayoutResult = null
+
+        dismissKeyboard()
+
+        detachView()
+    }
+
+    protected abstract fun detachView()
+
+    override fun showKeyboard() {
+        textUIView?.let {
+            focusedViewsList?.addAndFocus(it)
+        }
+    }
+
+    override fun dismissKeyboard() {
+        textUIView?.let {
+            focusedViewsList?.remove(it, delayMillis = CLEAR_FOCUS_DELAY)
+        }
+    }
+
+    override fun updateState(newValue: TextFieldValue) {
+        val internalOldValue = sessionEditProcessor?.toTextFieldValue()
+        val textChanged = internalOldValue == null || internalOldValue.text != newValue.text
+        val selectionChanged = textChanged || internalOldValue.selection != newValue.selection
+
+        stateWillChange(textChanged, selectionChanged)
+
+        sessionEditProcessor?.let {
+            it.reset(newValue, null)
+            _tempCursorPos = null
+        }
+
+        stateDidChange(textChanged, selectionChanged)
+    }
+
+    protected abstract fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean)
+    protected abstract fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean)
+
+    override fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {
+        this.textLayoutResult = textLayoutResult
+    }
+
+    override fun updateFocusedRect(rect: Rect) {
+        currentFocusedRect = rect
+    }
+
+    override fun updateViewGeometry(
+        textFieldFrame: Rect,
+        clippingTextFrame: Rect,
+        unclippedTextPosition: Offset
+    ) {
+        textFieldFrameInRoot = textFieldFrame
+        this.clippingTextFrame = clippingTextFrame
+        this.unclippedTextPosition = unclippedTextPosition
+
+        updateTextViewPosition()
+    }
+    protected abstract fun updateTextViewPosition()
+
+    override fun onPreviewKeyEvent(event: KeyEvent): Boolean {
+        return when (event.key) {
+            Key.Enter -> handleEnterKey(event)
+            Key.Backspace -> handleBackspace(event)
+            Key.Escape -> handleEscape(event)
+            else -> false
+        }
+    }
+
+    override fun flushEditCommandsIfNeeded(force: Boolean) {
+        if ((force || editBatchDepth == 0) && editCommandsBatch.isNotEmpty()) {
+            val commandList = editCommandsBatch.toList()
+            editCommandsBatch.clear()
+
+            currentOnEditCommand?.invoke(commandList)
+        }
+    }
+
+    override val hasInvalidations: Boolean
+        get() = textInputServiceInvalidationsCount > 0
+
+    protected var textInputServiceInvalidationsCount = 0
+
+    protected abstract val textUIView: UIView?
+    protected var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
+    protected var currentImeOptions: ImeOptions? = null
+    protected var currentImeActionHandler: ((ImeAction) -> Unit)? = null
+    protected var currentFocusedRect: Rect? = null
+
+    protected var textFieldFrameInRoot: Rect? = null
+    protected var clippingTextFrame: Rect? = null
+    protected var currentContentBounds: Rect? = null
+    protected var currentContentInsets: DpInsets? = null
+    protected var unclippedTextPosition: Offset? = null
+
+    protected var textLayoutResult: TextLayoutResult? = null
+
+    /**
+     * Workaround to prevent calling textWillChange, textDidChange, selectionWillChange, and
+     * selectionDidChange when the value of the current input is changed by the system (i.e., by the user
+     * input) not by the state change of the Compose side. These 4 functions call methods of
+     * UITextInputDelegateProtocol, which notifies the system that the text or the selection of the
+     * current input has changed.
+     *
+     * This is to properly handle multi-stage input methods that depend on text selection, required by
+     * languages such as Korean (Chinese and Japanese input methods depend on text marking). The writing
+     * system of these languages contains letters that can be broken into multiple parts, and each keyboard
+     * key corresponds to those parts. Therefore, the input system holds an internal state to combine these
+     * parts correctly. However, the methods of UITextInputDelegateProtocol reset this state, resulting in
+     * incorrect input. (e.g., 컴포즈 becomes ㅋㅓㅁㅍㅗㅈㅡ when not handled properly)
+     *
+     * @see sessionEditProcessor holds the same text and selection of the current input. It is used
+     * instead of the old value passed to updateState. When the current value change is due to the
+     * user input, updateState is not effective because _tempCurrentInputSession holds the same value.
+     * However, when the current value change is due to the change of the user selection or to the
+     * state change in the Compose side, updateState calls the 4 methods because the new value holds
+     * these changes.
+     */
+    protected var sessionEditProcessor: EditProcessor? = null
+
+    /**
+     * Workaround to fix voice dictation.
+     * UIKit call insertText(text) and replaceRange(range,text) immediately,
+     * but Compose recomposition happen on next draw frame.
+     * So the value of getSelectedTextRange is in the old state when the replaceRange function is called.
+     * @see _tempCursorPos helps to fix this behaviour. Permanently update _tempCursorPos in function insertText.
+     * And after clear in updateState function.
+     */
+    private var _tempCursorPos: Int? = null
+
+    protected var floatingCursorTranslation : Offset? = null
+
+    /**
+     * Workaround to prevent IME action from being called multiple times with hardware keyboards.
+     * When the hardware return key is held down, iOS sends multiple newline characters to the application,
+     * which makes UIKitTextInputService call the current IME action multiple times without an additional
+     * debouncing logic.
+     *
+     * @see _tempHardwareReturnKeyPressed is set to true when the return key is pressed with a
+     * hardware keyboard.
+     * @see _tempImeActionIsCalledWithHardwareReturnKey is set to true when the
+     * current IME action has been called within the current hardware return key press.
+     */
+    private var _tempHardwareReturnKeyPressed: Boolean = false
+    private var _tempImeActionIsCalledWithHardwareReturnKey: Boolean = false
+    private fun handleEnterKey(event: KeyEvent): Boolean {
+        _tempImeActionIsCalledWithHardwareReturnKey = false
+        return when (event.type) {
+            KeyEventType.KeyUp -> {
+                _tempHardwareReturnKeyPressed = false
+                false
+            }
+
+            KeyEventType.KeyDown -> {
+                _tempHardwareReturnKeyPressed = true
+                // This prevents two new line characters from being added for one hardware return key press.
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    private fun handleBackspace(event: KeyEvent): Boolean {
+        // This prevents two characters from being removed for one hardware backspace key press.
+        return event.type == KeyEventType.KeyDown
+    }
+
+    private fun handleEscape(event: KeyEvent): Boolean {
+        return if (sessionEditProcessor != null) {
+            if (event.type == KeyEventType.KeyDown) {
+                focusManager()?.releaseFocus()
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    private val editCommandsBatch = mutableListOf<EditCommand>()
+    private var editBatchDepth: Int = 0
+        set(value) {
+            field = value
+            flushEditCommandsIfNeeded()
+        }
+
+    protected open fun sendEditCommand(vararg commands: EditCommand) {
+        sessionEditProcessor?.apply(commands.toList())
+
+        editCommandsBatch.addAll(commands)
+        flushEditCommandsIfNeeded()
+    }
+
+    protected fun getState(): TextFieldValue? = sessionEditProcessor?.toTextFieldValue()
+
+    protected fun getCursorPos(): Int? {
+        if (_tempCursorPos != null) {
+            return _tempCursorPos
+        }
+        val selection = getState()?.selection
+        if (selection != null && selection.start == selection.end) {
+            return selection.start
+        }
+        return null
+    }
+
+    private fun imeActionRequired(): Boolean =
+        currentImeOptions?.run {
+            singleLine || (
+                imeAction != ImeAction.None
+                    && imeAction != ImeAction.Default
+                    && !(imeAction == ImeAction.Search && _tempHardwareReturnKeyPressed)
+                )
+        } ?: false
+
+    private fun runImeActionIfRequired(): Boolean {
+        val imeAction = currentImeOptions?.imeAction ?: return false
+        val imeActionHandler = currentImeActionHandler ?: return false
+        if (!imeActionRequired()) {
+            return false
+        }
+        if (!_tempImeActionIsCalledWithHardwareReturnKey) {
+            if (imeAction == ImeAction.Default) {
+                imeActionHandler(ImeAction.Done)
+            } else {
+                imeActionHandler(imeAction)
+            }
+        }
+        if (_tempHardwareReturnKeyPressed) {
+            _tempImeActionIsCalledWithHardwareReturnKey = true
+        }
+        return true
+    }
+
+    private fun hasFocusedNonComposeInputViewInWindowHierarchy(): Boolean {
+        fun hasFocusedNonComposeInputView(view: UIView): Boolean {
+            if (view.isFirstResponder) {
+                return view !is ComposeTextInputView &&
+                    view !is OverlayInputView &&
+                    view !is BackgroundInputView
+            }
+            return view.subviews.any { it is UIView && hasFocusedNonComposeInputView(it) }
+        }
+        return view.window?.let { hasFocusedNonComposeInputView(it) } ?: false
+    }
+
+    override fun onResignFocus() {
+        textInputServiceInvalidationsCount++
+        coroutineScope.launch {
+            if (hasFocusedNonComposeInputViewInWindowHierarchy()) {
+                focusManager()?.releaseFocus()
+            }
+            textInputServiceInvalidationsCount--
+        }
+    }
+
+    override fun updateFloatingCursor(offset: DpOffset) {
+        val translation = floatingCursorTranslation ?: return
+        val offsetPx = offset.toOffset(view.density)
+        val pos = textLayoutResult
+            ?.getOffsetForPosition(offsetPx + translation) ?: return
+
+        sendEditCommand(SetSelectionCommand(pos, pos))
+    }
+
+    override fun endFloatingCursor() {
+        floatingCursorTranslation = null
+    }
+
+    override fun beginEditBatch() {
+        editBatchDepth++
+    }
+
+    override fun endEditBatch() {
+        editBatchDepth--
+    }
+
+    /**
+     * A Boolean value that indicates whether the text-entry object has any text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
+     */
+    override fun hasText(): Boolean = getState()?.text?.isNotEmpty() ?: false
+
+    /**
+     * Inserts a character into the displayed text.
+     * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
+     * @param text A string object representing the character typed on the system keyboard.
+     */
+    override fun insertText(text: String) {
+        if (text == "\n") {
+            if (runImeActionIfRequired()) {
+                return
+            }
+        }
+        getCursorPos()?.let {
+            _tempCursorPos = it + text.length
+        }
+        sendEditCommand(CommitTextCommand(text, 1))
+    }
+
+    /**
+     * Deletes a character from the displayed text.
+     * Remove the character just before the cursor from your class’s backing store and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
+     */
+    override fun deleteBackward() {
+        val deleteCommand = if (getState()?.selection?.collapsed == true) {
+            DeleteSurroundingTextCommand(lengthBeforeCursor = 1, lengthAfterCursor = 0)
+        } else {
+            CommitTextCommand("", 0)
+        }
+        sendEditCommand(deleteCommand)
+    }
+
+    /**
+     * The text position for the end of a document.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
+     */
+    override fun endOfDocument(): Int = getState()?.text?.length ?: 0
+
+    /**
+     * The range of selected text in a document.
+     * If the text range has a length, it indicates the currently selected text.
+     * If it has zero length, it indicates the caret (insertion point).
+     * If the text-range object is nil, it indicates that there is no current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
+     */
+    override fun getSelectedTextRange(): TextRange? = getState()?.selection
+
+    override fun setSelectedTextRange(range: TextRange?) {
+        if (range != null) {
+            sendEditCommand(
+                SetSelectionCommand(range.start, range.end)
+            )
+        } else {
+            sendEditCommand(
+                SetSelectionCommand(endOfDocument(), endOfDocument())
+            )
+        }
+    }
+
+    override fun selectAll() {
+        sendEditCommand(
+            SetSelectionCommand(0, endOfDocument())
+        )
+    }
+
+    /**
+     * Returns the text in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
+     * @param range A range of text in a document.
+     * @return A substring of a document that falls within the specified range.
+     */
+    override fun textInRange(range: TextRange): String? {
+        if (isIncorrect(range)) {
+            return null
+        }
+        val text = getState()?.text ?: return null
+        return text.substring(range.start, range.end)
+    }
+
+    /**
+     * Replaces the text in a document that is in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
+     * @param range A range of text in a document.
+     * @param text A string to replace the text in range.
+     */
+    override fun replaceRange(range: TextRange, text: String) {
+        sendEditCommand(
+            SetComposingRegionCommand(range.start, range.end),
+            SetComposingTextCommand(text, 1),
+            FinishComposingTextCommand(),
+        )
+    }
+
+    /**
+     * Inserts the provided text and marks it to indicate that it is part of an active input session.
+     * Setting marked text either replaces the existing marked text or,
+     * if none is present, inserts it in place of the current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
+     * @param markedText The text to be marked.
+     * @param selectedRange A range within markedText that indicates the current selection.
+     * This range is always relative to markedText.
+     */
+    override fun setMarkedText(markedText: String?, selectedRange: TextRange) {
+        if (markedText != null) {
+            sendEditCommand(
+                SetComposingTextCommand(markedText, 1)
+            )
+        }
+    }
+
+    /**
+     * The range of currently marked text in a document.
+     * If there is no marked text, the value of the property is nil.
+     * Marked text is provisionally inserted text that requires user confirmation;
+     * it occurs in multistage text input.
+     * The current selection, which can be a caret or an extended range, always occurs within the marked text.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
+     */
+    override fun markedTextRange(): TextRange? {
+        return getState()?.composition
+    }
+
+    /**
+     * Unmarks the currently marked text.
+     * After this method is called, the value of markedTextRange is nil.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
+     */
+    override fun unmarkText() {
+        sendEditCommand(FinishComposingTextCommand())
+    }
+
+    /**
+     * Returns the text position at a specified offset from another text position.
+     * Returned value must be in range between 0 and length of text (inclusive).
+     */
+    override fun positionFromPosition(position: Int, offset: Int): Int? {
+        val text = getState()?.text ?: return null
+
+        val newPosition = position + offset
+        if (newPosition == text.length || newPosition == 0) {
+            return newPosition
+        }
+        if (newPosition < 0 || newPosition > text.length) {
+            return null
+        }
+        var resultPosition = position
+        val iterator = BreakIterator.makeCharacterInstance()
+        iterator.setText(text)
+
+        repeat(offset.absoluteValue) {
+            val iteratorResult = if (offset > 0) {
+                iterator.following(resultPosition)
+            } else {
+                iterator.preceding(resultPosition)
+            }
+
+            if (iteratorResult == BreakIterator.DONE) {
+                return resultPosition
+            } else {
+                resultPosition = iteratorResult
+            }
+        }
+
+        return resultPosition
+    }
+
+    /**
+     * Returns the text position at a specified offset from another text position.
+     * Returned value must be in range between 0 and length of text (inclusive).
+     */
+    override fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int? {
+        val text = getState()?.text ?: return null
+        val layoutResult = textLayoutResult ?: return null
+
+        val line = layoutResult.getLineForOffset(position)
+        val lineStartOffset = layoutResult.getLineStart(line)
+        val offsetInLine = position - lineStartOffset
+        val targetLine = line + verticalOffset
+        return when {
+            targetLine < 0 -> 0
+            targetLine >= layoutResult.lineCount -> text.length
+            else -> {
+                val targetLineEnd = layoutResult.getLineEnd(targetLine)
+                val lineStart = layoutResult.getLineStart(targetLine)
+                positionFromPosition(
+                    lineStart, min(offsetInLine, targetLineEnd - lineStart)
+                )
+            }
+        }
+    }
+
+    override fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect> {
+        // Native selection rects are required for correct work of the text editing menu
+        // Without them, it will be impossible to call the text editing menu by tapping on the selected area
+        if (range.collapsed || isIncorrect(range)) {
+            return emptyList()
+        }
+        val currentTextLayoutResult = textLayoutResult ?: return emptyList()
+
+        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return emptyList()
+
+        val startSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.start)
+        val endSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.end)
+
+        val firstLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+        val lastLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
+
+        return if (firstLineNumber == lastLineNumber) {
+            listOf(
+                TextSelectionRect(
+                    dpRect = Rect(
+                        topLeft = startSelectionHandleRect.topLeft,
+                        bottomRight = endSelectionHandleRect.bottomRight
+                    ).toDpRect(view.density),
+                    writingDirection = TextDirection.Content,
+                    containsStart = true,
+                    containsEnd = true,
+                    isVertical = false
+                )
+            )
+        } else {
+            // TODO Consider RTL Layout
+            // We require separate rects for start line, end line and everything in between them
+            val contentInsets = currentContentInsets ?: return emptyList()
+            val contentRect = currentContentBounds?.let {
+                with(view.density) {
+                    Rect(
+                        top = it.top + contentInsets.top.toPx(),
+                        left = it.left + contentInsets.left.toPx(),
+                        right = it.right + contentInsets.right.toPx(),
+                        bottom = it.bottom + contentInsets.bottom.toPx()
+                    )
+                }
+            } ?: return emptyList()
+
+            val firstLineSelectionRect = TextSelectionRect(
+                dpRect = Rect(
+                    top = startSelectionHandleRect.top,
+                    left = startSelectionHandleRect.left,
+                    right = contentRect.right,
+                    bottom = startSelectionHandleRect.bottom
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = true,
+                containsEnd = false,
+                isVertical = false
+            )
+
+            val middleAreaSelectionRect = TextSelectionRect(
+                dpRect = Rect(
+                    top = startSelectionHandleRect.bottom,
+                    left = contentRect.left,
+                    right = contentRect.right,
+                    bottom = endSelectionHandleRect.top
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = false,
+                containsEnd = false,
+                isVertical = false
+            )
+
+            val lastLineStartRect = currentTextLayoutResult.getCursorRect(
+                currentTextLayoutResult.getLineStart(lastLineNumber)
+            )
+            val lastLineRect = TextSelectionRect(
+                dpRect = Rect(
+                    topLeft = lastLineStartRect.topLeft,
+                    bottomRight = endSelectionHandleRect.bottomRight
+                ).toDpRect(view.density),
+                writingDirection = TextDirection.Content,
+                containsStart = false,
+                containsEnd = true,
+                isVertical = false
+            )
+
+            listOf(
+                firstLineSelectionRect,
+                middleAreaSelectionRect,
+                lastLineRect
+            )
+        }
+    }
+
+    override fun firstSelectionRectForRange(range: TextRange): DpRect? {
+        if (range.collapsed || isIncorrect(range)) {
+            return null
+        }
+        val currentTextLayoutResult = textLayoutResult ?: return null
+
+        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return null
+
+        val startHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+        val endHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
+
+        val startHandleRect = currentTextLayoutResult.getCursorRect(range.start)
+
+        return if (startHandleLineNumber == endHandleLineNumber) {
+            Rect(
+                topLeft = startHandleRect.topLeft,
+                bottomRight = currentTextLayoutResult.getCursorRect(range.end).bottomRight
+            ).toDpRect(view.density)
+        } else {
+            val startLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
+            val startLineRight = currentTextLayoutResult.getLineRight(startLineNumber)
+            Rect(
+                startHandleRect.left,
+                startHandleRect.top,
+                startLineRight,
+                startHandleRect.bottom
+            ).toDpRect(view.density)
+        }
+    }
+
+    override fun closestPositionToPoint(point: DpOffset): Int? {
+        return textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+    }
+
+    override fun closestPositionToPoint(point: DpOffset, withinRange: TextRange): Int? {
+        val pointOffset =
+            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+                ?: return null
+        return pointOffset.coerceIn(withinRange.start, withinRange.end)
+    }
+
+    override fun characterRangeAtPoint(point: DpOffset): TextRange? {
+        val pointOffset =
+            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
+                ?: return null
+        return textLayoutResult?.getWordBoundary(pointOffset)
+    }
+
+    override fun positionWithinRange(
+        range: TextRange,
+        farthestInDirection: PlatformTextLayoutDirection
+    ): Int? {
+        if (isIncorrect(range)) return null
+        return when (farthestInDirection) {
+            PlatformTextLayoutDirection.Up -> range.start
+            PlatformTextLayoutDirection.Down -> range.end
+            else -> {
+                val layout = textLayoutResult ?: return null
+                val startLine = layout.getLineForOffset(range.start)
+                val endLine = layout.getLineForOffset(range.end)
+
+                val candidateOffsets = buildSet {
+                    add(range.start)
+                    add(range.end)
+
+                    for (line in startLine..endLine) {
+                        add(max(range.start, layout.getLineStart(line)))
+                        add(min(range.end, layout.getLineEnd(line)))
+                    }
+                }
+
+                when (farthestInDirection) {
+                    PlatformTextLayoutDirection.Left ->
+                        candidateOffsets.minByOrNull { layout.getHorizontalPosition(it, true) }
+                    PlatformTextLayoutDirection.Right ->
+                        candidateOffsets.maxByOrNull { layout.getHorizontalPosition(it, true) }
+                    else -> null
+                }
+            }
+        }
+    }
+
+    private fun isIncorrect(range: TextRange): Boolean {
+        return range.start < 0 || range.end > endOfDocument() || range.start > range.end
+    }
+
+    companion object {
+        // Due to unexpected delays between the commands to show/hide the keyboard,
+        // it may jump when switching between text fields.
+        // Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
+        protected const val CLEAR_FOCUS_DELAY: Long = 10L
+
+        protected val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
+    }
+}

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -121,11 +121,11 @@ internal abstract class BaseTextInputConnection(
     protected abstract fun detachView()
 
     override fun showKeyboard() {
-        focusedViewsList?.addAndFocus(textUIView)
+        focusedViewsList?.addAndFocus(textInputView)
     }
 
     override fun dismissKeyboard() {
-        focusedViewsList?.remove(textUIView, delayMillis = CLEAR_FOCUS_DELAY)
+        focusedViewsList?.remove(textInputView, delayMillis = CLEAR_FOCUS_DELAY)
     }
 
     override fun updateState(newValue: TextFieldValue) {
@@ -182,7 +182,7 @@ internal abstract class BaseTextInputConnection(
 
     protected var textInputServiceInvalidationsCount = 0
 
-    protected abstract val textUIView: UIView
+    protected abstract val textInputView: UIView
     protected var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
     protected var currentImeOptions: ImeOptions? = null
     protected var currentImeActionHandler: ((ImeAction) -> Unit)? = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -23,25 +23,18 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.DpInsets
-import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.TextInputDelegate
-import androidx.compose.ui.platform.TextSelectionRect
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.BackgroundInputView
 import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.NativeTextInputView
 import androidx.compose.ui.window.OverlayInputView
 import kotlin.math.absoluteValue
-import kotlin.math.max
 import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -163,11 +156,10 @@ internal abstract class BaseTextInputConnection(
     ) {
         textFieldFrameInRoot = textFieldFrame
         this.clippingTextFrame = clippingTextFrame
-        this.unclippedTextPosition = unclippedTextPosition
 
-        updateTextViewPosition()
+        updateTextViewPosition(unclippedTextPosition)
     }
-    protected abstract fun updateTextViewPosition()
+    protected abstract fun updateTextViewPosition(unclippedTextPosition: Offset)
 
     override fun onPreviewKeyEvent(event: KeyEvent): Boolean {
         return when (event.key) {
@@ -200,9 +192,6 @@ internal abstract class BaseTextInputConnection(
 
     protected var textFieldFrameInRoot: Rect? = null
     protected var clippingTextFrame: Rect? = null
-    protected var currentContentBounds: Rect? = null
-    protected var currentContentInsets: DpInsets? = null
-    protected var unclippedTextPosition: Offset? = null
 
     protected var textLayoutResult: TextLayoutResult? = null
 
@@ -583,185 +572,7 @@ internal abstract class BaseTextInputConnection(
         }
     }
 
-    override fun selectionDpRectsForRange(range: TextRange): List<TextSelectionRect> {
-        // Native selection rects are required for correct work of the text editing menu
-        // Without them, it will be impossible to call the text editing menu by tapping on the selected area
-        if (range.collapsed || isIncorrect(range)) {
-            return emptyList()
-        }
-        val currentTextLayoutResult = textLayoutResult ?: return emptyList()
-
-        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
-        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
-        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return emptyList()
-
-        val startSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.start)
-        val endSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.end)
-
-        val firstLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-        val lastLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
-
-        return if (firstLineNumber == lastLineNumber) {
-            listOf(
-                TextSelectionRect(
-                    dpRect = Rect(
-                        topLeft = startSelectionHandleRect.topLeft,
-                        bottomRight = endSelectionHandleRect.bottomRight
-                    ).toDpRect(view.density),
-                    writingDirection = TextDirection.Content,
-                    containsStart = true,
-                    containsEnd = true,
-                    isVertical = false
-                )
-            )
-        } else {
-            // TODO Consider RTL Layout
-            // We require separate rects for start line, end line and everything in between them
-            val contentInsets = currentContentInsets ?: return emptyList()
-            val contentRect = currentContentBounds?.let {
-                with(view.density) {
-                    Rect(
-                        top = it.top + contentInsets.top.toPx(),
-                        left = it.left + contentInsets.left.toPx(),
-                        right = it.right + contentInsets.right.toPx(),
-                        bottom = it.bottom + contentInsets.bottom.toPx()
-                    )
-                }
-            } ?: return emptyList()
-
-            val firstLineSelectionRect = TextSelectionRect(
-                dpRect = Rect(
-                    top = startSelectionHandleRect.top,
-                    left = startSelectionHandleRect.left,
-                    right = contentRect.right,
-                    bottom = startSelectionHandleRect.bottom
-                ).toDpRect(view.density),
-                writingDirection = TextDirection.Content,
-                containsStart = true,
-                containsEnd = false,
-                isVertical = false
-            )
-
-            val middleAreaSelectionRect = TextSelectionRect(
-                dpRect = Rect(
-                    top = startSelectionHandleRect.bottom,
-                    left = contentRect.left,
-                    right = contentRect.right,
-                    bottom = endSelectionHandleRect.top
-                ).toDpRect(view.density),
-                writingDirection = TextDirection.Content,
-                containsStart = false,
-                containsEnd = false,
-                isVertical = false
-            )
-
-            val lastLineStartRect = currentTextLayoutResult.getCursorRect(
-                currentTextLayoutResult.getLineStart(lastLineNumber)
-            )
-            val lastLineRect = TextSelectionRect(
-                dpRect = Rect(
-                    topLeft = lastLineStartRect.topLeft,
-                    bottomRight = endSelectionHandleRect.bottomRight
-                ).toDpRect(view.density),
-                writingDirection = TextDirection.Content,
-                containsStart = false,
-                containsEnd = true,
-                isVertical = false
-            )
-
-            listOf(
-                firstLineSelectionRect,
-                middleAreaSelectionRect,
-                lastLineRect
-            )
-        }
-    }
-
-    override fun firstSelectionRectForRange(range: TextRange): DpRect? {
-        if (range.collapsed || isIncorrect(range)) {
-            return null
-        }
-        val currentTextLayoutResult = textLayoutResult ?: return null
-
-        // Layout in native text input mode may be outdated, so not checking this may cause OOB error
-        // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
-        if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return null
-
-        val startHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-        val endHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
-
-        val startHandleRect = currentTextLayoutResult.getCursorRect(range.start)
-
-        return if (startHandleLineNumber == endHandleLineNumber) {
-            Rect(
-                topLeft = startHandleRect.topLeft,
-                bottomRight = currentTextLayoutResult.getCursorRect(range.end).bottomRight
-            ).toDpRect(view.density)
-        } else {
-            val startLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
-            val startLineRight = currentTextLayoutResult.getLineRight(startLineNumber)
-            Rect(
-                startHandleRect.left,
-                startHandleRect.top,
-                startLineRight,
-                startHandleRect.bottom
-            ).toDpRect(view.density)
-        }
-    }
-
-    override fun closestPositionToPoint(point: DpOffset): Int? {
-        return textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-    }
-
-    override fun closestPositionToPoint(point: DpOffset, withinRange: TextRange): Int? {
-        val pointOffset =
-            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-                ?: return null
-        return pointOffset.coerceIn(withinRange.start, withinRange.end)
-    }
-
-    override fun characterRangeAtPoint(point: DpOffset): TextRange? {
-        val pointOffset =
-            textLayoutResult?.getOffsetForPosition(point.toOffset(view.density))
-                ?: return null
-        return textLayoutResult?.getWordBoundary(pointOffset)
-    }
-
-    override fun positionWithinRange(
-        range: TextRange,
-        farthestInDirection: PlatformTextLayoutDirection
-    ): Int? {
-        if (isIncorrect(range)) return null
-        return when (farthestInDirection) {
-            PlatformTextLayoutDirection.Up -> range.start
-            PlatformTextLayoutDirection.Down -> range.end
-            else -> {
-                val layout = textLayoutResult ?: return null
-                val startLine = layout.getLineForOffset(range.start)
-                val endLine = layout.getLineForOffset(range.end)
-
-                val candidateOffsets = buildSet {
-                    add(range.start)
-                    add(range.end)
-
-                    for (line in startLine..endLine) {
-                        add(max(range.start, layout.getLineStart(line)))
-                        add(min(range.end, layout.getLineEnd(line)))
-                    }
-                }
-
-                when (farthestInDirection) {
-                    PlatformTextLayoutDirection.Left ->
-                        candidateOffsets.minByOrNull { layout.getHorizontalPosition(it, true) }
-                    PlatformTextLayoutDirection.Right ->
-                        candidateOffsets.maxByOrNull { layout.getHorizontalPosition(it, true) }
-                    else -> null
-                }
-            }
-        }
-    }
-
-    private fun isIncorrect(range: TextRange): Boolean {
+    protected fun isIncorrect(range: TextRange): Boolean {
         return range.start < 0 || range.end > endOfDocument() || range.start > range.end
     }
 
@@ -769,8 +580,8 @@ internal abstract class BaseTextInputConnection(
         // Due to unexpected delays between the commands to show/hide the keyboard,
         // it may jump when switching between text fields.
         // Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
-        const val CLEAR_FOCUS_DELAY: Long = 10L
+        internal const val CLEAR_FOCUS_DELAY: Long = 10L
 
-        val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
+        internal val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -43,38 +43,7 @@ import org.jetbrains.skia.BreakIterator
 import platform.UIKit.UIPress
 import platform.UIKit.UIView
 
-internal interface TextInputConnection {
-    fun open(
-        value: TextFieldValue,
-        imeOptions: ImeOptions,
-        onEditCommand: (List<EditCommand>) -> Unit,
-        onImeActionPerformed: (ImeAction) -> Unit
-    )
-
-    /**
-     * Tears down this connection: removes the underlying view from the hierarchy and releases
-     * focus. Safe to call even if [open] was never invoked — not all connection types require
-     * an active text input session (e.g. [SelectionContainerConnection]).
-     */
-    fun close()
-    fun showKeyboard()
-    fun dismissKeyboard()
-
-    fun updateState(newValue: TextFieldValue)
-    fun updateTextLayoutResult(textLayoutResult: TextLayoutResult)
-    fun updateViewGeometry(
-        textFieldFrame: Rect,
-        unclippedTextPosition: Offset
-    )
-
-    fun onPreviewKeyEvent(event: KeyEvent): Boolean
-
-    fun flushEditCommandsIfNeeded(force: Boolean = false)
-
-    val hasInvalidations: Boolean
-}
-
-internal abstract class BaseTextInputConnection(
+internal abstract class TextInputConnection(
     protected val updateView: () -> Unit,
     protected val view: UIView,
     protected val coroutineScope: CoroutineScope,
@@ -86,8 +55,8 @@ internal abstract class BaseTextInputConnection(
     @Suppress("UNUSED")
     protected var onKeyboardPresses: (Set<*>) -> Unit,
     private var focusManager: () -> ComposeSceneFocusManager?,
-): TextInputConnection, TextEditingDelegate {
-    override fun open(
+): TextEditingDelegate {
+    fun start(
         value: TextFieldValue,
         imeOptions: ImeOptions,
         onEditCommand: (List<EditCommand>) -> Unit,
@@ -105,7 +74,7 @@ internal abstract class BaseTextInputConnection(
 
     protected abstract fun attachInputToView(imeOptions: ImeOptions)
 
-    override fun close() {
+    open fun stop() {
         flushEditCommandsIfNeeded(force = true)
         sessionEditProcessor = null
         currentOnEditCommand = null
@@ -120,15 +89,15 @@ internal abstract class BaseTextInputConnection(
 
     protected abstract fun detachView()
 
-    override fun showKeyboard() {
+    fun showKeyboard() {
         focusedViewsList?.addAndFocus(textInputView)
     }
 
-    override fun dismissKeyboard() {
+    fun dismissKeyboard() {
         focusedViewsList?.remove(textInputView, delayMillis = CLEAR_FOCUS_DELAY)
     }
 
-    override fun updateState(newValue: TextFieldValue) {
+    fun updateState(newValue: TextFieldValue) {
         val internalOldValue = sessionEditProcessor?.toTextFieldValue()
         val textChanged = internalOldValue == null || internalOldValue.text != newValue.text
         val selectionChanged = textChanged || internalOldValue.selection != newValue.selection
@@ -146,11 +115,11 @@ internal abstract class BaseTextInputConnection(
     protected abstract fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean)
     protected abstract fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean)
 
-    override fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {
+    fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {
         this.textLayoutResult = textLayoutResult
     }
 
-    override fun updateViewGeometry(
+    open fun updateViewGeometry(
         textFieldFrame: Rect,
         unclippedTextPosition: Offset
     ) {
@@ -159,7 +128,7 @@ internal abstract class BaseTextInputConnection(
     }
     protected abstract fun updateTextViewPosition(unclippedTextPosition: Offset)
 
-    override fun onPreviewKeyEvent(event: KeyEvent): Boolean {
+    fun onPreviewKeyEvent(event: KeyEvent): Boolean {
         return when (event.key) {
             Key.Enter -> handleEnterKey(event)
             Key.Backspace -> handleBackspace(event)
@@ -168,7 +137,7 @@ internal abstract class BaseTextInputConnection(
         }
     }
 
-    override fun flushEditCommandsIfNeeded(force: Boolean) {
+    fun flushEditCommandsIfNeeded(force: Boolean = false) {
         if ((force || editBatchDepth == 0) && editCommandsBatch.isNotEmpty()) {
             val commandList = editCommandsBatch.toList()
             editCommandsBatch.clear()
@@ -177,7 +146,7 @@ internal abstract class BaseTextInputConnection(
         }
     }
 
-    override val hasInvalidations: Boolean
+    val hasInvalidations: Boolean
         get() = textInputServiceInvalidationsCount > 0
 
     protected var textInputServiceInvalidationsCount = 0

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.TextInputDelegate
 import androidx.compose.ui.platform.TextSelectionRect
@@ -37,9 +38,8 @@ import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.BackgroundInputView
 import androidx.compose.ui.window.FocusedViewsList
-import androidx.compose.ui.window.ComposeTextInputView
+import androidx.compose.ui.window.NativeTextInputView
 import androidx.compose.ui.window.OverlayInputView
-import kotlin.apply
 import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.math.min
@@ -102,8 +102,6 @@ internal abstract class BaseTextInputConnection(
         currentOnEditCommand = onEditCommand
         currentImeOptions = imeOptions
         currentImeActionHandler = onImeActionPerformed
-
-        showKeyboard()
     }
 
     override fun close() {
@@ -348,7 +346,7 @@ internal abstract class BaseTextInputConnection(
     private fun hasFocusedNonComposeInputViewInWindowHierarchy(): Boolean {
         fun hasFocusedNonComposeInputView(view: UIView): Boolean {
             if (view.isFirstResponder) {
-                return view !is ComposeTextInputView &&
+                return view !is NativeTextInputView &&
                     view !is OverlayInputView &&
                     view !is BackgroundInputView
             }
@@ -771,8 +769,8 @@ internal abstract class BaseTextInputConnection(
         // Due to unexpected delays between the commands to show/hide the keyboard,
         // it may jump when switching between text fields.
         // Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
-        protected const val CLEAR_FOCUS_DELAY: Long = 10L
+        const val CLEAR_FOCUS_DELAY: Long = 10L
 
-        protected val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
+        val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -94,7 +94,11 @@ internal abstract class BaseTextInputConnection(
         currentOnEditCommand = onEditCommand
         currentImeOptions = imeOptions
         currentImeActionHandler = onImeActionPerformed
+        attachInputToView(imeOptions)
+        showKeyboard()
     }
+
+    protected abstract fun attachInputToView(imeOptions: ImeOptions)
 
     override fun close() {
         flushEditCommandsIfNeeded(force = true)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -23,7 +23,10 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.EmptyInputTraits
+import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.TextEditingDelegate
+import androidx.compose.ui.platform.getUITextInputTraits
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
@@ -40,7 +43,6 @@ import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
-import platform.UIKit.UIPress
 import platform.UIKit.UIView
 
 internal abstract class TextInputConnection(
@@ -48,12 +50,7 @@ internal abstract class TextInputConnection(
     protected val view: UIView,
     protected val coroutineScope: CoroutineScope,
     protected val focusedViewsList: FocusedViewsList?,
-    /**
-     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
-     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
-     */
-    @Suppress("UNUSED")
-    protected var onKeyboardPresses: (Set<*>) -> Unit,
+    override var onKeyboardPresses: (Set<*>) -> Unit,
     private var focusManager: () -> ComposeSceneFocusManager?,
 ): TextEditingDelegate {
     fun start(
@@ -67,18 +64,20 @@ internal abstract class TextInputConnection(
         }
         currentOnEditCommand = onEditCommand
         currentImeOptions = imeOptions
+        inputTraits = getUITextInputTraits(imeOptions)
         currentImeActionHandler = onImeActionPerformed
-        attachInputToView(imeOptions)
+        attachInputToView()
         showKeyboard()
     }
 
-    protected abstract fun attachInputToView(imeOptions: ImeOptions)
+    protected abstract fun attachInputToView()
 
     open fun stop() {
         flushEditCommandsIfNeeded(force = true)
         sessionEditProcessor = null
         currentOnEditCommand = null
         currentImeOptions = null
+        inputTraits = EmptyInputTraits
         currentImeActionHandler = null
         textLayoutResult = null
 
@@ -154,6 +153,7 @@ internal abstract class TextInputConnection(
     protected abstract val textInputView: UIView
     protected var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
     protected var currentImeOptions: ImeOptions? = null
+    override var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
     protected var currentImeActionHandler: ((ImeAction) -> Unit)? = null
 
     protected var textFieldFrameInRoot: Rect? = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -103,6 +103,7 @@ internal abstract class BaseTextInputConnection(
     override fun close() {
         flushEditCommandsIfNeeded(force = true)
         sessionEditProcessor = null
+        currentOnEditCommand = null
         currentImeOptions = null
         currentImeActionHandler = null
         textLayoutResult = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -350,18 +350,8 @@ internal abstract class TextInputConnection(
         editBatchDepth--
     }
 
-    /**
-     * A Boolean value that indicates whether the text-entry object has any text.
-     * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
-     */
     override fun hasText(): Boolean = getState()?.text?.isNotEmpty() ?: false
 
-    /**
-     * Inserts a character into the displayed text.
-     * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
-     * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
-     * @param text A string object representing the character typed on the system keyboard.
-     */
     override fun insertText(text: String) {
         if (text == "\n") {
             if (runImeActionIfRequired()) {
@@ -374,11 +364,6 @@ internal abstract class TextInputConnection(
         sendEditCommand(CommitTextCommand(text, 1))
     }
 
-    /**
-     * Deletes a character from the displayed text.
-     * Remove the character just before the cursor from your class’s backing store and redisplay the text.
-     * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
-     */
     override fun deleteBackward() {
         val deleteCommand = if (getState()?.selection?.collapsed == true) {
             DeleteSurroundingTextCommand(lengthBeforeCursor = 1, lengthAfterCursor = 0)
@@ -388,19 +373,8 @@ internal abstract class TextInputConnection(
         sendEditCommand(deleteCommand)
     }
 
-    /**
-     * The text position for the end of a document.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
-     */
     override fun endOfDocument(): Int = getState()?.text?.length ?: 0
 
-    /**
-     * The range of selected text in a document.
-     * If the text range has a length, it indicates the currently selected text.
-     * If it has zero length, it indicates the caret (insertion point).
-     * If the text-range object is nil, it indicates that there is no current selection.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
-     */
     override fun getSelectedTextRange(): TextRange? = getState()?.selection
 
     override fun setSelectedTextRange(range: TextRange?) {
@@ -421,12 +395,6 @@ internal abstract class TextInputConnection(
         )
     }
 
-    /**
-     * Returns the text in the specified range.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
-     * @param range A range of text in a document.
-     * @return A substring of a document that falls within the specified range.
-     */
     override fun textInRange(range: TextRange): String? {
         if (isIncorrect(range)) {
             return null
@@ -435,12 +403,6 @@ internal abstract class TextInputConnection(
         return text.substring(range.start, range.end)
     }
 
-    /**
-     * Replaces the text in a document that is in the specified range.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
-     * @param range A range of text in a document.
-     * @param text A string to replace the text in range.
-     */
     override fun replaceRange(range: TextRange, text: String) {
         sendEditCommand(
             SetComposingRegionCommand(range.start, range.end),
@@ -449,15 +411,6 @@ internal abstract class TextInputConnection(
         )
     }
 
-    /**
-     * Inserts the provided text and marks it to indicate that it is part of an active input session.
-     * Setting marked text either replaces the existing marked text or,
-     * if none is present, inserts it in place of the current selection.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
-     * @param markedText The text to be marked.
-     * @param selectedRange A range within markedText that indicates the current selection.
-     * This range is always relative to markedText.
-     */
     override fun setMarkedText(markedText: String?, selectedRange: TextRange) {
         if (markedText != null) {
             sendEditCommand(
@@ -466,31 +419,14 @@ internal abstract class TextInputConnection(
         }
     }
 
-    /**
-     * The range of currently marked text in a document.
-     * If there is no marked text, the value of the property is nil.
-     * Marked text is provisionally inserted text that requires user confirmation;
-     * it occurs in multistage text input.
-     * The current selection, which can be a caret or an extended range, always occurs within the marked text.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
-     */
     override fun markedTextRange(): TextRange? {
         return getState()?.composition
     }
 
-    /**
-     * Unmarks the currently marked text.
-     * After this method is called, the value of markedTextRange is nil.
-     * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
-     */
     override fun unmarkText() {
         sendEditCommand(FinishComposingTextCommand())
     }
 
-    /**
-     * Returns the text position at a specified offset from another text position.
-     * Returned value must be in range between 0 and length of text (inclusive).
-     */
     override fun positionFromPosition(position: Int, offset: Int): Int? {
         val text = getState()?.text ?: return null
 
@@ -522,10 +458,6 @@ internal abstract class TextInputConnection(
         return resultPosition
     }
 
-    /**
-     * Returns the text position at a specified offset from another text position.
-     * Returned value must be in range between 0 and length of text (inclusive).
-     */
     override fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int? {
         val text = getState()?.text ?: return null
         val layoutResult = textLayoutResult ?: return null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -51,6 +51,11 @@ internal interface TextInputConnection {
         onImeActionPerformed: (ImeAction) -> Unit
     )
 
+    /**
+     * Tears down this connection: removes the underlying view from the hierarchy and releases
+     * focus. Safe to call even if [open] was never invoked — not all connection types require
+     * an active text input session (e.g. [SelectionContainerConnection]).
+     */
     fun close()
     fun showKeyboard()
     fun dismissKeyboard()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -359,15 +359,10 @@ internal class ComposeTextInputView(
         withinRange: UITextRange
     ): NSInteger = 0L
 
-    override fun positionWithinRangeAtCharacterOffset(
-        range: UITextRange,
-        atCharacterOffset: NSInteger
-    ): UITextPosition = TextInputPosition(0)
-
-    override fun positionWithinRangeFarthestInDirection(
+    override fun positionWithinRange(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection
-    ): UITextPosition = TextInputPosition(0)
+    ): UITextPosition? = TextInputPosition(0)
 
     override fun characterRangeByExtendingPosition(
         position: UITextPosition,
@@ -476,7 +471,6 @@ internal class ComposeTextInputView(
     fun hideTextMenu() = this.hideEditMenu()
 
     fun isTextMenuShown() = isEditMenuShown
-    override fun shouldUseNonComposeMenuActions() = false
 
     private val _tokenizer = TextInputStringTokenizer(textInput = this) {
         input?.let { it.textInRange(TextRange(0, it.endOfDocument())) }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -1,0 +1,495 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.platform.EmptyInputTraits
+import androidx.compose.ui.platform.IntermediateTextPosition
+import androidx.compose.ui.platform.IntermediateTextRange
+import androidx.compose.ui.platform.IntermediateTextTokenizer
+import androidx.compose.ui.platform.SkikoUITextInputTraits
+import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.toTextRange
+import androidx.compose.ui.platform.toUITextRange
+import androidx.compose.ui.platform.withDeferredEditBatch
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.uikit.utils.CMPEditMenuView
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.readValue
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.CoroutineScope
+import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGRect
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGRectNull
+import platform.CoreGraphics.CGRectZero
+import platform.Foundation.NSComparisonResult
+import platform.Foundation.NSDictionary
+import platform.Foundation.NSOrderedAscending
+import platform.Foundation.NSOrderedDescending
+import platform.Foundation.NSOrderedSame
+import platform.Foundation.NSRange
+import platform.Foundation.dictionary
+import platform.UIKit.NSWritingDirection
+import platform.UIKit.NSWritingDirectionNatural
+import platform.UIKit.UIKeyInputProtocol
+import platform.UIKit.UIKeyboardAppearance
+import platform.UIKit.UIKeyboardType
+import platform.UIKit.UIPress
+import platform.UIKit.UIPressesEvent
+import platform.UIKit.UIReturnKeyType
+import platform.UIKit.UITextAutocapitalizationType
+import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UITextContentType
+import platform.UIKit.UITextInputDelegateProtocol
+import platform.UIKit.UITextInputProtocol
+import platform.UIKit.UITextInputTokenizerProtocol
+import platform.UIKit.UITextLayoutDirection
+import platform.UIKit.UITextLayoutDirectionDown
+import platform.UIKit.UITextLayoutDirectionLeft
+import platform.UIKit.UITextLayoutDirectionRight
+import platform.UIKit.UITextLayoutDirectionUp
+import platform.UIKit.UITextPosition
+import platform.UIKit.UITextRange
+import platform.UIKit.UITextSelectionRect
+import platform.UIKit.UITextStorageDirection
+import platform.UIKit.UIView
+import platform.UIKit.UIWritingToolsBehavior
+import platform.darwin.NSInteger
+
+/**
+ * Hidden UIView to interact with iOS Keyboard and TextInput system.
+ */
+internal class ComposeTextInputView(
+    private val doubleTapTimeoutMillis: Long,
+    private val coroutineScope: CoroutineScope
+) : CMPEditMenuView(frame = CGRectZero.readValue()),
+    UIKeyInputProtocol, UITextInputProtocol {
+    private var _inputDelegate: UITextInputDelegateProtocol? = null
+    var input: TextInputDelegate? = null
+        set(value) {
+            field = value
+            if (value == null) {
+                hideTextMenu()
+            }
+        }
+
+    /**
+     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
+     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
+     */
+    var onKeyboardPresses: (Set<*>) -> Unit = {}
+
+    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
+
+    override fun inputView(): UIView? = inputTraits.inputView()
+    override fun inputAccessoryView(): UIView? = inputTraits.inputAccessoryView()
+
+    override fun canBecomeFirstResponder() = true
+
+    override fun resignFirstResponder(): Boolean {
+        input?.onResignFocus()
+        hideTextMenu()
+        return super.resignFirstResponder()
+    }
+
+    override fun beginFloatingCursorAtPoint(point: CValue<CGPoint>) {
+        input?.beginFloatingCursor(point.useContents { DpOffset(x.dp, y.dp) })
+    }
+
+    override fun updateFloatingCursorAtPoint(point: CValue<CGPoint>) {
+        input?.updateFloatingCursor(point.useContents { DpOffset(x.dp, y.dp) })
+    }
+
+    override fun endFloatingCursor() {
+        input?.endFloatingCursor()
+    }
+
+    override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
+        onKeyboardPresses(presses)
+        super.pressesBegan(presses, withEvent)
+    }
+
+    override fun pressesEnded(presses: Set<*>, withEvent: UIPressesEvent?) {
+        onKeyboardPresses(presses)
+        super.pressesEnded(presses, withEvent)
+    }
+
+    /**
+     * A Boolean value that indicates whether the text-entry object has any text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
+     */
+    override fun hasText(): Boolean {
+        return input?.hasText() ?: false
+    }
+
+    /**
+     * Inserts a character into the displayed text.
+     * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
+     * @param text A string object representing the character typed on the system keyboard.
+     */
+    override fun insertText(text: String) {
+        input?.insertText(text)
+    }
+
+    /**
+     * Deletes a character from the displayed text.
+     * Remove the character just before the cursor from your class’s backing store and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
+     */
+    override fun deleteBackward() {
+        input?.deleteBackward()
+    }
+
+    override fun inputDelegate(): UITextInputDelegateProtocol? {
+        return _inputDelegate
+    }
+
+    override fun setInputDelegate(inputDelegate: UITextInputDelegateProtocol?) {
+        _inputDelegate = inputDelegate
+    }
+
+    /**
+     * Returns the text in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
+     * @param range A range of text in a document.
+     * @return A substring of a document that falls within the specified range.
+     */
+    override fun textInRange(range: UITextRange): String? {
+        val textRange = range.toTextRange() ?: return null
+        return input?.textInRange(textRange)
+    }
+
+    /**
+     * Replaces the text in a document that is in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
+     * @param range A range of text in a document.
+     * @param withText A string to replace the text in range.
+     */
+    override fun replaceRange(range: UITextRange, withText: String) {
+        val textRange = range.toTextRange() ?: return
+        input?.withDeferredEditBatch(coroutineScope) {
+            replaceRange(textRange, withText)
+        }
+    }
+
+    override fun setSelectedTextRange(selectedTextRange: UITextRange?) {
+        val range = selectedTextRange?.toTextRange()
+        input?.withDeferredEditBatch(coroutineScope) {
+            setSelectedTextRange(range)
+        }
+    }
+
+    /**
+     * The range of selected text in a document.
+     * If the text range has a length, it indicates the currently selected text.
+     * If it has zero length, it indicates the caret (insertion point).
+     * If the text-range object is nil, it indicates that there is no current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
+     */
+    override fun selectedTextRange(): UITextRange? {
+        return input?.getSelectedTextRange()?.toUITextRange()
+    }
+
+    /**
+     * The range of currently marked text in a document.
+     * If there is no marked text, the value of the property is nil.
+     * Marked text is provisionally inserted text that requires user confirmation;
+     * it occurs in multistage text input.
+     * The current selection, which can be a caret or an extended range, always occurs within the marked text.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
+     */
+    override fun markedTextRange(): UITextRange? {
+        return input?.markedTextRange()?.toUITextRange()
+    }
+
+    override fun setMarkedTextStyle(markedTextStyle: Map<Any?, *>?) {
+        // do nothing
+    }
+
+    override fun markedTextStyle(): Map<Any?, *>? {
+        return null
+    }
+
+    /**
+     * Inserts the provided text and marks it to indicate that it is part of an active input session.
+     * Setting marked text either replaces the existing marked text or,
+     * if none is present, inserts it in place of the current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
+     * @param markedText The text to be marked.
+     * @param selectedRange A range within markedText that indicates the current selection.
+     * This range is always relative to markedText.
+     */
+    override fun setMarkedText(markedText: String?, selectedRange: CValue<NSRange>) {
+        val (locationRelative, lengthRelative) = selectedRange.useContents {
+            location.toInt() to length.toInt()
+        }
+        val relativeTextRange = TextRange(locationRelative, locationRelative + lengthRelative)
+
+        // Due to iOS specifics, [setMarkedText] can be called several times in a row. Batching
+        // helps to avoid text input problems, when Composables use parameters set during
+        // recomposition instead of the current ones. Example:
+        // 1. State "1" -> TextField(text = "1")
+        // 2. setMarkedText "12" -> Not equal to TextField(text = "1") -> State "12"
+        // 3. setMarkedText "1" -> Equal to TextField(text = "1") -> State remains "12"
+        // scene.render() - Recomposes TextField
+        // 4. State "12" -> TextField(text = "12") - Invalid state. Should be TextField(text = "1")
+        input?.withDeferredEditBatch(withScope = coroutineScope) {
+            setMarkedText(markedText, relativeTextRange)
+        }
+    }
+
+    /**
+     * Unmarks the currently marked text.
+     * After this method is called, the value of markedTextRange is nil.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
+     */
+    override fun unmarkText() {
+        input?.unmarkText()
+    }
+
+    override fun beginningOfDocument(): UITextPosition {
+        return IntermediateTextPosition(0)
+    }
+
+    /**
+     * The text position for the end of a document.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
+     */
+    override fun endOfDocument(): UITextPosition {
+        return IntermediateTextPosition(input?.endOfDocument() ?: 0)
+    }
+
+    /**
+     * Attention! fromPosition and toPosition may be null
+     */
+    override fun textRangeFromPosition(
+        fromPosition: UITextPosition,
+        toPosition: UITextPosition
+    ): UITextRange? {
+        val from = (fromPosition as? IntermediateTextPosition)?.position ?: return null
+        val to = (toPosition as? IntermediateTextPosition)?.position ?: return null
+        return IntermediateTextRange(
+            IntermediateTextPosition(minOf(from, to)),
+            IntermediateTextPosition(maxOf(from, to))
+        )
+    }
+
+    /**
+     * Attention! position may be null
+     * @param position a custom UITextPosition object that represents a location in a document.
+     * @param offset a character offset from position. It can be a positive or negative value.
+     * Offset should be considered as a number of Unicode characters. One Unicode character can contain several bytes.
+     */
+    override fun positionFromPosition(
+        position: UITextPosition,
+        offset: NSInteger
+    ): UITextPosition? {
+        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val input = input ?: return null
+        return input.positionFromPosition(position = p, offset = offset.toInt())?.let {
+            IntermediateTextPosition(it)
+        }
+    }
+
+    private fun positionFromPositionVertical(
+        position: UITextPosition,
+        offset: NSInteger
+    ): UITextPosition? {
+        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val input = input ?: return null
+        return input.verticalPositionFromPosition(position = p, verticalOffset = offset.toInt())
+            ?.let { IntermediateTextPosition(it) }
+    }
+
+    override fun positionFromPosition(
+        position: UITextPosition,
+        inDirection: UITextLayoutDirection,
+        offset: NSInteger
+    ): UITextPosition? {
+        return when (inDirection) {
+            UITextLayoutDirectionLeft -> positionFromPosition(position, -offset)
+            UITextLayoutDirectionRight -> positionFromPosition(position, offset)
+            UITextLayoutDirectionDown -> positionFromPositionVertical(position, offset)
+            UITextLayoutDirectionUp -> positionFromPositionVertical(position, -offset)
+            else -> null
+        }
+    }
+
+    /**
+     * Attention! position and toPosition may be null
+     */
+    override fun comparePosition(
+        position: UITextPosition,
+        toPosition: UITextPosition
+    ): NSComparisonResult {
+        val from = (position as? IntermediateTextPosition)?.position ?: return NSOrderedSame
+        val to = (toPosition as? IntermediateTextPosition)?.position ?: return NSOrderedSame
+        val result = if (from < to) {
+            NSOrderedAscending
+        } else if (from > to) {
+            NSOrderedDescending
+        } else {
+            NSOrderedSame
+        }
+        return result
+    }
+
+    override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
+        if (from !is IntermediateTextPosition || toPosition !is IntermediateTextPosition) {
+            return 0
+        }
+        return (toPosition.position - from.position).toLong()
+    }
+
+    override fun characterOffsetOfPosition(
+        position: UITextPosition,
+        withinRange: UITextRange
+    ): NSInteger = 0L
+
+    override fun positionWithinRangeAtCharacterOffset(
+        range: UITextRange,
+        atCharacterOffset: NSInteger
+    ): UITextPosition = IntermediateTextPosition(0)
+
+    override fun positionWithinRangeFarthestInDirection(
+        range: UITextRange,
+        farthestInDirection: UITextLayoutDirection
+    ): UITextPosition = IntermediateTextPosition(0)
+
+    override fun characterRangeByExtendingPosition(
+        position: UITextPosition,
+        inDirection: UITextLayoutDirection
+    ): UITextRange? {
+        val oldPosition = position as? IntermediateTextPosition ?: return null
+        val newPosition = positionFromPosition(oldPosition, inDirection = inDirection, offset = 1)
+            as? IntermediateTextPosition ?: return null
+        return if (newPosition.position < oldPosition.position) {
+            IntermediateTextRange(newPosition, oldPosition)
+        } else {
+            IntermediateTextRange(oldPosition, newPosition)
+        }
+    }
+
+    override fun baseWritingDirectionForPosition(
+        position: UITextPosition,
+        inDirection: UITextStorageDirection
+    ): NSWritingDirection {
+        return NSWritingDirectionNatural
+    }
+
+    override fun setBaseWritingDirection(
+        writingDirection: NSWritingDirection,
+        forRange: UITextRange
+    ) {}
+
+    override fun firstRectForRange(range: UITextRange): CValue<CGRect> =
+        CGRectNull.readValue()
+
+    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> =
+        CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
+
+    override fun selectionRectsForRange(range: UITextRange): List<*> =
+        listOf<UITextSelectionRect>()
+
+    override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? =
+        null
+
+    override fun closestPositionToPoint(
+        point: CValue<CGPoint>,
+        withinRange: UITextRange
+    ): UITextPosition? = null
+
+    override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? =
+        null
+
+    override fun textStylingAtPosition(
+        position: UITextPosition,
+        inDirection: UITextStorageDirection
+    ): Map<Any?, *> {
+        return NSDictionary.dictionary()
+    }
+
+    override fun shouldChangeTextInRange(range: UITextRange, replacementText: String): Boolean {
+        // Here we should decide to replace text in range or not.
+        // By default, this method returns true.
+        return true
+    }
+
+    override fun textInputView(): UIView {
+        return this
+    }
+
+    override fun keyboardType(): UIKeyboardType = inputTraits.keyboardType()
+    override fun keyboardAppearance(): UIKeyboardAppearance = inputTraits.keyboardAppearance()
+    override fun returnKeyType(): UIReturnKeyType = inputTraits.returnKeyType()
+    override fun textContentType(): UITextContentType = inputTraits.textContentType()
+    override fun isSecureTextEntry(): Boolean = inputTraits.isSecureTextEntry()
+    override fun enablesReturnKeyAutomatically(): Boolean = inputTraits.enablesReturnKeyAutomatically()
+    override fun autocapitalizationType(): UITextAutocapitalizationType = inputTraits.autocapitalizationType()
+    override fun autocorrectionType(): UITextAutocorrectionType = inputTraits.autocorrectionType()
+    override fun writingToolsBehavior(): UIWritingToolsBehavior = inputTraits.writingToolsBehavior()
+
+    /**
+     * Call when something changes in text data
+     */
+    fun textWillChange() {
+        _inputDelegate?.textWillChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun textDidChange() {
+        _inputDelegate?.textDidChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun selectionWillChange() {
+        _inputDelegate?.selectionWillChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun selectionDidChange() {
+        _inputDelegate?.selectionDidChange(this)
+    }
+
+    override fun isUserInteractionEnabled(): Boolean = false
+
+    override fun editMenuDelay(): Double =
+        doubleTapTimeoutMillis.milliseconds.toDouble(DurationUnit.SECONDS)
+
+    fun hideTextMenu() = this.hideEditMenu()
+
+    fun isTextMenuShown() = isEditMenuShown
+    override fun shouldUseNonComposeMenuActions() = false
+
+    private val _tokenizer = IntermediateTextTokenizer(textInput = this) {
+        input?.let { it.textInRange(TextRange(0, it.endOfDocument())) }
+    }
+    override fun tokenizer(): UITextInputTokenizerProtocol = _tokenizer
+}
+
+

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -17,9 +17,9 @@
 package androidx.compose.ui.window
 
 import androidx.compose.ui.platform.EmptyInputTraits
-import androidx.compose.ui.platform.IntermediateTextPosition
-import androidx.compose.ui.platform.IntermediateTextRange
-import androidx.compose.ui.platform.IntermediateTextTokenizer
+import androidx.compose.ui.platform.TextInputPosition
+import androidx.compose.ui.platform.TextInputRange
+import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.TextEditingDelegate
 import androidx.compose.ui.platform.toTextRange
@@ -267,7 +267,7 @@ internal class ComposeTextInputView(
     }
 
     override fun beginningOfDocument(): UITextPosition {
-        return IntermediateTextPosition(0)
+        return TextInputPosition(0)
     }
 
     /**
@@ -275,7 +275,7 @@ internal class ComposeTextInputView(
      * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
      */
     override fun endOfDocument(): UITextPosition {
-        return IntermediateTextPosition(input?.endOfDocument() ?: 0)
+        return TextInputPosition(input?.endOfDocument() ?: 0)
     }
 
     /**
@@ -285,11 +285,11 @@ internal class ComposeTextInputView(
         fromPosition: UITextPosition,
         toPosition: UITextPosition
     ): UITextRange? {
-        val from = (fromPosition as? IntermediateTextPosition)?.position ?: return null
-        val to = (toPosition as? IntermediateTextPosition)?.position ?: return null
-        return IntermediateTextRange(
-            IntermediateTextPosition(minOf(from, to)),
-            IntermediateTextPosition(maxOf(from, to))
+        val from = (fromPosition as? TextInputPosition)?.position ?: return null
+        val to = (toPosition as? TextInputPosition)?.position ?: return null
+        return TextInputRange(
+            TextInputPosition(minOf(from, to)),
+            TextInputPosition(maxOf(from, to))
         )
     }
 
@@ -303,10 +303,10 @@ internal class ComposeTextInputView(
         position: UITextPosition,
         offset: NSInteger
     ): UITextPosition? {
-        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val p = (position as? TextInputPosition)?.position ?: return null
         val input = input ?: return null
         return input.positionFromPosition(position = p, offset = offset.toInt())?.let {
-            IntermediateTextPosition(it)
+            TextInputPosition(it)
         }
     }
 
@@ -314,10 +314,10 @@ internal class ComposeTextInputView(
         position: UITextPosition,
         offset: NSInteger
     ): UITextPosition? {
-        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val p = (position as? TextInputPosition)?.position ?: return null
         val input = input ?: return null
         return input.verticalPositionFromPosition(position = p, verticalOffset = offset.toInt())
-            ?.let { IntermediateTextPosition(it) }
+            ?.let { TextInputPosition(it) }
     }
 
     override fun positionFromPosition(
@@ -341,8 +341,8 @@ internal class ComposeTextInputView(
         position: UITextPosition,
         toPosition: UITextPosition
     ): NSComparisonResult {
-        val from = (position as? IntermediateTextPosition)?.position ?: return NSOrderedSame
-        val to = (toPosition as? IntermediateTextPosition)?.position ?: return NSOrderedSame
+        val from = (position as? TextInputPosition)?.position ?: return NSOrderedSame
+        val to = (toPosition as? TextInputPosition)?.position ?: return NSOrderedSame
         val result = if (from < to) {
             NSOrderedAscending
         } else if (from > to) {
@@ -354,7 +354,7 @@ internal class ComposeTextInputView(
     }
 
     override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
-        if (from !is IntermediateTextPosition || toPosition !is IntermediateTextPosition) {
+        if (from !is TextInputPosition || toPosition !is TextInputPosition) {
             return 0
         }
         return (toPosition.position - from.position).toLong()
@@ -368,24 +368,24 @@ internal class ComposeTextInputView(
     override fun positionWithinRangeAtCharacterOffset(
         range: UITextRange,
         atCharacterOffset: NSInteger
-    ): UITextPosition = IntermediateTextPosition(0)
+    ): UITextPosition = TextInputPosition(0)
 
     override fun positionWithinRangeFarthestInDirection(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection
-    ): UITextPosition = IntermediateTextPosition(0)
+    ): UITextPosition = TextInputPosition(0)
 
     override fun characterRangeByExtendingPosition(
         position: UITextPosition,
         inDirection: UITextLayoutDirection
     ): UITextRange? {
-        val oldPosition = position as? IntermediateTextPosition ?: return null
+        val oldPosition = position as? TextInputPosition ?: return null
         val newPosition = positionFromPosition(oldPosition, inDirection = inDirection, offset = 1)
-            as? IntermediateTextPosition ?: return null
+            as? TextInputPosition ?: return null
         return if (newPosition.position < oldPosition.position) {
-            IntermediateTextRange(newPosition, oldPosition)
+            TextInputRange(newPosition, oldPosition)
         } else {
-            IntermediateTextRange(oldPosition, newPosition)
+            TextInputRange(oldPosition, newPosition)
         }
     }
 
@@ -484,7 +484,7 @@ internal class ComposeTextInputView(
     fun isTextMenuShown() = isEditMenuShown
     override fun shouldUseNonComposeMenuActions() = false
 
-    private val _tokenizer = IntermediateTextTokenizer(textInput = this) {
+    private val _tokenizer = TextInputStringTokenizer(textInput = this) {
         input?.let { it.textInRange(TextRange(0, it.endOfDocument())) }
     }
     override fun tokenizer(): UITextInputTokenizerProtocol = _tokenizer

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -52,7 +52,6 @@ import platform.UIKit.NSWritingDirectionNatural
 import platform.UIKit.UIKeyInputProtocol
 import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardType
-import platform.UIKit.UIPress
 import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
@@ -91,13 +90,8 @@ internal class ComposeTextInputView(
             }
         }
 
-    /**
-     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
-     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
-     */
-    var onKeyboardPresses: (Set<*>) -> Unit = {}
-
-    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
+    private val inputTraits: SkikoUITextInputTraits
+        get() = input?.inputTraits ?: EmptyInputTraits
 
     override fun inputView(): UIView? = inputTraits.inputView()
     override fun inputAccessoryView(): UIView? = inputTraits.inputAccessoryView()
@@ -123,12 +117,12 @@ internal class ComposeTextInputView(
     }
 
     override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
+        input?.onKeyboardPresses(presses)
         super.pressesBegan(presses, withEvent)
     }
 
     override fun pressesEnded(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
+        input?.onKeyboardPresses(presses)
         super.pressesEnded(presses, withEvent)
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.platform.IntermediateTextPosition
 import androidx.compose.ui.platform.IntermediateTextRange
 import androidx.compose.ui.platform.IntermediateTextTokenizer
 import androidx.compose.ui.platform.SkikoUITextInputTraits
-import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.TextEditingDelegate
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch
@@ -83,7 +83,7 @@ internal class ComposeTextInputView(
 ) : CMPEditMenuView(frame = CGRectZero.readValue()),
     UIKeyInputProtocol, UITextInputProtocol {
     private var _inputDelegate: UITextInputDelegateProtocol? = null
-    var input: TextInputDelegate? = null
+    var input: TextEditingDelegate? = null
         set(value) {
             field = value
             if (value == null) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -410,16 +410,14 @@ internal class ComposeTextInputView(
     override fun selectionRectsForRange(range: UITextRange): List<*> =
         listOf<UITextSelectionRect>()
 
-    override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? =
-        null
+    override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? = null
 
     override fun closestPositionToPoint(
         point: CValue<CGPoint>,
         withinRange: UITextRange
     ): UITextPosition? = null
 
-    override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? =
-        null
+    override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? = null
 
     override fun textStylingAtPosition(
         position: UITextPosition,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -489,5 +489,3 @@ internal class ComposeTextInputView(
     }
     override fun tokenizer(): UITextInputTokenizerProtocol = _tokenizer
 }
-
-

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
@@ -56,7 +56,6 @@ import platform.UIKit.UIGestureRecognizerStateChanged
 import platform.UIKit.UIGestureRecognizerStateEnded
 import platform.UIKit.UIGestureRecognizerStateFailed
 import platform.UIKit.UIGestureRecognizerStatePossible
-import platform.UIKit.UIHoverGestureRecognizer
 import platform.UIKit.UIPanGestureRecognizer
 import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIScreenEdgePanGestureRecognizer
@@ -661,7 +660,7 @@ internal class OverlayInputView(
             return null
         }
         val nativeTextInputViewHitTest = subviews.firstNotNullOfOrNull { it ->
-            (it as? IntermediateTextScrollView)?.let {
+            (it as? NativeTextInputScrollView)?.let {
                 val inputPoint = convertPoint(point, toView = it)
                 it.hitTest(inputPoint, withEvent)
             }
@@ -819,7 +818,7 @@ private fun UIView.findAncestorInteractionMode(touch: UITouch): UIKitInteropInte
         if (view is InteropWrappingView) {
             return view.interactionMode
         }
-        if (view is IntermediateTextScrollView) {
+        if (view is NativeTextInputScrollView) {
             return view.interactionModeAt(touch.locationInView(view))
         }
         view = view.superview

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,33 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
-import androidx.compose.ui.platform.IOSSkikoInput
+import androidx.compose.ui.platform.IntermediateTextPosition
+import androidx.compose.ui.platform.IntermediateTextRange
+import androidx.compose.ui.platform.IntermediateTextSelectionRect
+import androidx.compose.ui.platform.IntermediateTextTokenizer
+import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.SkikoUITextInputTraits
-import androidx.compose.ui.platform.TextSelectionRect
+import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.toTextRange
+import androidx.compose.ui.platform.toUITextRange
+import androidx.compose.ui.platform.withDeferredEditBatch
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.DpInsets
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
 import androidx.compose.ui.uikit.utils.CMPEditMenuView
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
-import androidx.compose.ui.uikit.utils.CMPTextInputStringTokenizer
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.asCGRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.DurationUnit
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import org.jetbrains.skia.BreakIterator
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
@@ -53,7 +55,6 @@ import platform.CoreGraphics.CGRectGetHeight
 import platform.CoreGraphics.CGRectGetWidth
 import platform.CoreGraphics.CGRectInset
 import platform.CoreGraphics.CGRectMake
-import platform.CoreGraphics.CGRectNull
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSizeEqualToSize
 import platform.Foundation.NSComparisonResult
@@ -79,14 +80,11 @@ import platform.UIKit.UIMenu
 import platform.UIKit.UIMenuElement
 import platform.UIKit.UIPress
 import platform.UIKit.UIPressesEvent
-import platform.UIKit.UIResponder
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UIScrollView
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
-import platform.UIKit.UITextDirection
-import platform.UIKit.UITextGranularity
 import platform.UIKit.UITextInputDelegateProtocol
 import platform.UIKit.UITextInputProtocol
 import platform.UIKit.UITextInputTokenizerProtocol
@@ -101,8 +99,6 @@ import platform.UIKit.UITextPosition
 import platform.UIKit.UITextRange
 import platform.UIKit.UITextSelectionRect
 import platform.UIKit.UITextStorageDirection
-import platform.UIKit.UITextStorageDirectionForward
-import platform.UIKit.UITextWritingDirection
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehavior
@@ -110,38 +106,25 @@ import platform.UIKit.addInteraction
 import platform.UIKit.systemBlueColor
 import platform.darwin.NSInteger
 
-private val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
-/**
- * Hidden UIView to interact with iOS Keyboard and TextInput system.
- */
-internal class IntermediateTextInputUIView(
-    private val doubleTapTimeoutMillis: Long,
-    private val usingNativeTextInput: Boolean,
-    private val coroutineScope: CoroutineScope
-) : CMPEditMenuView(frame = CGRectZero.readValue()),
-    UIKeyInputProtocol, UITextInputProtocol {
-    private var _inputDelegate: UITextInputDelegateProtocol? = null
-    var input: IOSSkikoInput? = null
-        set(value) {
-            field = value
-            if (value == null) {
-                hideTextMenu()
-            }
-        }
+internal class NativeTextInputView(
+    private val coroutineScope: CoroutineScope,
+): CMPEditMenuView(frame = CGRectZero.readValue()), UIKeyInputProtocol, UITextInputProtocol {
 
-    private val touchesTrackerGestureRecognizer = TouchTrackingGestureRecognizer().also {
-        if (usingNativeTextInput) {
-            addGestureRecognizer(it)
-        }
-    }
+    var input: TextInputDelegate? = null // TODO: Rename?
+
+    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
+
+    private var _inputDelegate: UITextInputDelegateProtocol? = null
 
     /**
      * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
      * Erasure happens due to K/N not supporting Obj-C lightweight generics.
      */
-    var onKeyboardPresses: (Set<*>) -> Unit = NoOpOnKeyboardPresses
+    var onKeyboardPresses: (Set<*>) -> Unit = {}
 
-    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
+    private val touchesTrackerGestureRecognizer = TouchTrackingGestureRecognizer().also {
+        addGestureRecognizer(it)
+    }
 
     override fun inputView(): UIView? = inputTraits.inputView()
     override fun inputAccessoryView(): UIView? = inputTraits.inputAccessoryView()
@@ -153,18 +136,15 @@ internal class IntermediateTextInputUIView(
             .also {
                 it.setTextInput(this)
             }
-
     private var selectionInteractionAttached: Boolean = false
 
     override fun didMoveToWindow() {
         super.didMoveToWindow()
-        if (usingNativeTextInput) {
-            if (window != null && !selectionInteractionAttached) {
-                // Ensure UIKit text interaction is attached early so that cursor and selection
-                // handles can be created and shown when needed.
-                this.addInteraction(selectionInteraction)
-                selectionInteractionAttached = true
-            }
+        if (window != null && !selectionInteractionAttached) {
+            // Ensure UIKit text interaction is attached early so that cursor and selection
+            // handles can be created and shown when needed.
+            this.addInteraction(selectionInteraction)
+            selectionInteractionAttached = true
         }
     }
 
@@ -172,11 +152,9 @@ internal class IntermediateTextInputUIView(
         val isFirstResponder = this.isFirstResponder()
         val result = super.becomeFirstResponder()
 
-        if (usingNativeTextInput) {
-            if (!isFirstResponder && this.isFirstResponder()) {
-                this.addInteraction(selectionInteraction)
-                this.activateTextInputInteractionIfNeeded()
-            }
+        if (!isFirstResponder && this.isFirstResponder()) {
+            this.addInteraction(selectionInteraction)
+            this.activateTextInputInteractionIfNeeded()
         }
 
         return result
@@ -191,12 +169,6 @@ internal class IntermediateTextInputUIView(
             }
             super.setTintColor(colorToSet)
         }
-    }
-
-    override fun resignFirstResponder(): Boolean {
-        input?.onResignFocus()
-        hideTextMenu()
-        return super.resignFirstResponder()
     }
 
     override fun beginFloatingCursorAtPoint(point: CValue<CGPoint>) {
@@ -222,14 +194,10 @@ internal class IntermediateTextInputUIView(
     }
 
     override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
-        if (usingNativeTextInput) {
-            return if (input == null) {
-                null
-            } else {
-                super.hitTest(point, withEvent)
-            }
+        return if (input == null) {
+            null
         } else {
-            return super.hitTest(point, withEvent)
+            super.hitTest(point, withEvent)
         }
     }
 
@@ -287,33 +255,27 @@ internal class IntermediateTextInputUIView(
      */
     override fun replaceRange(range: UITextRange, withText: String) {
         val textRange = range.toTextRange() ?: return
-        input?.withBatch {
-            input?.replaceRange(textRange, withText)
+        input?.withDeferredEditBatch(coroutineScope) {
+            replaceRange(textRange, withText)
         }
     }
 
     override fun setSelectedTextRange(selectedTextRange: UITextRange?) {
         val range = selectedTextRange?.toTextRange()
-        if (usingNativeTextInput) {
-            if (input?.getSelectedTextRange() != range) {
-                // iOS <= 16 does not update selection handles when selection changes from the keyboard
-                // Posting an extra notification solves this issue
-                val notifySelectionChanges = !available(OS.Ios to OSVersion(major = 17)) &&
-                    !touchesTrackerGestureRecognizer.isTrackingTouches
-                if (notifySelectionChanges) {
-                    selectionWillChange()
-                }
-                input?.withBatch {
-                    input?.setSelectedTextRange(range)
-                }
-                if (notifySelectionChanges) {
-                    selectionDidChange()
-                }
-            }
-        } else {
-            input?.withBatch {
-                input?.setSelectedTextRange(range)
-            }
+        if (input?.getSelectedTextRange() == range) { return }
+
+        // iOS <= 16 does not update selection handles when selection changes from the keyboard
+        // Posting an extra notification solves this issue
+        val notifySelectionChanges = !available(OS.Ios to OSVersion(major = 17)) &&
+            !touchesTrackerGestureRecognizer.isTrackingTouches
+        if (notifySelectionChanges) {
+            selectionWillChange()
+        }
+        input?.withDeferredEditBatch(coroutineScope) {
+            setSelectedTextRange(range)
+        }
+        if (notifySelectionChanges) {
+            selectionDidChange()
         }
     }
 
@@ -371,8 +333,8 @@ internal class IntermediateTextInputUIView(
         // 3. setMarkedText "1" -> Equal to TextField(text = "1") -> State remains "12"
         // scene.render() - Recomposes TextField
         // 4. State "12" -> TextField(text = "12") - Invalid state. Should be TextField(text = "1")
-        input?.withBatch {
-            input?.setMarkedText(markedText, relativeTextRange)
+        input?.withDeferredEditBatch(coroutineScope) {
+            setMarkedText(markedText, relativeTextRange)
         }
     }
 
@@ -483,38 +445,32 @@ internal class IntermediateTextInputUIView(
         position: UITextPosition,
         withinRange: UITextRange
     ): NSInteger {
-        return if (usingNativeTextInput) {
-            val withinTextRange = withinRange.toTextRange() ?: return 0L
-            val intermediatePosition = (position as? IntermediateTextPosition)?.position ?: 0
-            (intermediatePosition - withinTextRange.start).toLong()
-        } else 0L
+        val withinTextRange = withinRange.toTextRange() ?: return 0L
+        val intermediatePosition = (position as? IntermediateTextPosition)?.position ?: 0
+        return (intermediatePosition - withinTextRange.start).toLong()
     }
 
     override fun positionWithinRangeAtCharacterOffset(
         range: UITextRange,
         atCharacterOffset: NSInteger
-    ): UITextPosition = if (usingNativeTextInput) {
+    ): UITextPosition {
         val fallback = IntermediateTextPosition(0)
         val textRange = range.toTextRange() ?: return fallback
-        (textRange.start + atCharacterOffset.toInt()).takeIf { range.isValid() && it in textRange }
+        return (textRange.start + atCharacterOffset.toInt()).takeIf { range.isValid() && it in textRange }
             ?.let { IntermediateTextPosition(it) } ?: fallback
-    } else {
-        IntermediateTextPosition(0)
     }
 
     override fun positionWithinRangeFarthestInDirection(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection
-    ): UITextPosition = if (usingNativeTextInput) {
+    ): UITextPosition {
         val fallback = IntermediateTextPosition(0)
         val textRange = range.toTextRange() ?: return fallback
-        PlatformTextLayoutDirection(farthestInDirection)?.let { direction ->
+        return PlatformTextLayoutDirection(farthestInDirection)?.let { direction ->
             input?.positionWithinRange(textRange, direction)?.let {
                 IntermediateTextPosition(it)
             }
         } ?: fallback
-    } else {
-        IntermediateTextPosition(0)
     }
 
     override fun characterRangeByExtendingPosition(
@@ -544,77 +500,51 @@ internal class IntermediateTextInputUIView(
     ) {}
 
     override fun firstRectForRange(range: UITextRange): CValue<CGRect> {
-        if (usingNativeTextInput) {
-            val fallback = CGRectZero.readValue()
-            val textRange = range.toTextRange() ?: return fallback
-            return input?.firstSelectionRectForRange(textRange)?.asCGRect()
-                ?: fallback
-        } else {
-            return CGRectNull.readValue()
-        }
-
+        val fallback = CGRectZero.readValue()
+        val textRange = range.toTextRange() ?: return fallback
+        return input?.firstSelectionRectForRange(textRange)?.asCGRect()
+            ?: fallback
     }
 
     override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> {
         val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
-        if (usingNativeTextInput) {
-            val position = (position as? IntermediateTextPosition)?.position ?: return fallbackRect
-            val caretDpRect = input?.caretDpRectForPosition(position)
-            return caretDpRect?.asCGRect() ?: fallbackRect
-        } else {
-            return fallbackRect
-        }
+        val position = (position as? IntermediateTextPosition)?.position ?: return fallbackRect
+        val caretDpRect = input?.caretDpRectForPosition(position)
+        return caretDpRect?.asCGRect() ?: fallbackRect
     }
 
     override fun selectionRectsForRange(range: UITextRange): List<*> {
-        if (usingNativeTextInput) {
-            val fallbackList = listOf<UITextSelectionRect>()
-            val textRange = TextRange(
-                start = (range.start as? IntermediateTextPosition)?.position ?: return fallbackList,
-                end = (range.end as? IntermediateTextPosition)?.position ?: return fallbackList
-            )
-            val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
-
-            return rects.fastMap { IntermediateTextSelectionRect(it) }
-        } else {
-            return listOf<UITextSelectionRect>()
-        }
+        val fallbackList = listOf<UITextSelectionRect>()
+        val textRange = TextRange(
+            start = (range.start as? IntermediateTextPosition)?.position ?: return fallbackList,
+            end = (range.end as? IntermediateTextPosition)?.position ?: return fallbackList
+        )
+        val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
+        return rects.fastMap { IntermediateTextSelectionRect(it) }
     }
 
     override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? {
-        if (usingNativeTextInput) {
-            val closestPosition =
-                input?.closestPositionToPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
-            return IntermediateTextPosition(closestPosition)
-        } else {
-            return null
-        }
+        val closestPosition =
+            input?.closestPositionToPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
+        return IntermediateTextPosition(closestPosition)
     }
 
     override fun closestPositionToPoint(
         point: CValue<CGPoint>,
         withinRange: UITextRange
     ): UITextPosition? {
-        if (usingNativeTextInput) {
-            val textRange = (withinRange as? IntermediateTextRange)?.toTextRange() ?: return null
-            val closestPosition = input?.closestPositionToPoint(
-                point.useContents { DpOffset(x.dp, y.dp) },
-                textRange
-            ) ?: return null
-            return IntermediateTextPosition(closestPosition)
-        } else {
-            return null
-        }
+        val textRange = (withinRange as? IntermediateTextRange)?.toTextRange() ?: return null
+        val closestPosition = input?.closestPositionToPoint(
+            point.useContents { DpOffset(x.dp, y.dp) },
+            textRange
+        ) ?: return null
+        return IntermediateTextPosition(closestPosition)
     }
 
     override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? {
-        if (usingNativeTextInput) {
-            val characterRange =
-                input?.characterRangeAtPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
-            return IntermediateTextRange(characterRange.start, characterRange.end)
-        } else {
-            return null
-        }
+        val characterRange =
+            input?.characterRangeAtPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
+        return IntermediateTextRange(characterRange.start, characterRange.end)
     }
 
     override fun textStylingAtPosition(
@@ -673,16 +603,7 @@ internal class IntermediateTextInputUIView(
         _inputDelegate?.selectionDidChange(this)
     }
 
-    override fun isUserInteractionEnabled(): Boolean = usingNativeTextInput
-
-    override fun editMenuDelay(): Double =
-        doubleTapTimeoutMillis.milliseconds.toDouble(DurationUnit.SECONDS)
-
-    fun hideTextMenu() = this.hideEditMenu()
-
-    fun isTextMenuShown() = isEditMenuShown
-    override fun shouldUseNonComposeMenuActions() = usingNativeTextInput
-
+    override fun shouldUseNonComposeMenuActions() = true
     private var onCopy: (() -> Unit)? = null
     private var onPaste: (() -> Unit)? = null
     private var onCut: (() -> Unit)? = null
@@ -690,52 +611,29 @@ internal class IntermediateTextInputUIView(
     private var customActions: List<CMPEditMenuCustomAction> = emptyList()
 
     override fun copy(sender: Any?) {
-        if (usingNativeTextInput) {
-            onCopy?.invoke()
-        } else {
-            super.copy(sender)
-        }
+        onCopy?.invoke()
     }
 
     override fun paste(sender: Any?) {
-        if (usingNativeTextInput) {
-            onPaste?.invoke()
-        } else {
-            super.paste(sender)
-        }
+        onPaste?.invoke()
     }
 
     override fun cut(sender: Any?) {
-        if (usingNativeTextInput) {
-            onCut?.invoke()
-        } else {
-            super.cut(sender)
-        }
+        onCut?.invoke()
     }
 
     override fun selectAll(sender: Any?) {
-        if (usingNativeTextInput) {
-            onSelectAll?.invoke()
-        } else {
-            super.selectAll(sender)
-        }
+        onSelectAll?.invoke()
     }
 
-    override fun canPerformAction(action: COpaquePointer?, withSender: Any?): Boolean {
-        if (usingNativeTextInput) {
-            val selectorName = NSStringFromSelector(action)
-
-            return when (selectorName) {
-                "copy:" -> onCopy != null
-                "paste:" -> onPaste != null
-                "cut:" -> onCut != null
-                "selectAll:" -> onSelectAll != null
-                else -> super.canPerformAction(action, withSender)
-            }
-        } else {
-            return super.canPerformAction(action, withSender)
+    override fun canPerformAction(action: COpaquePointer?, withSender: Any?): Boolean =
+        when (NSStringFromSelector(action)) {
+            "copy:" -> onCopy != null
+            "paste:" -> onPaste != null
+            "cut:" -> onCut != null
+            "selectAll:" -> onSelectAll != null
+            else -> super.canPerformAction(action, withSender)
         }
-    }
 
     fun updateMenuActions(
         copy: (() -> Unit)?,
@@ -751,19 +649,14 @@ internal class IntermediateTextInputUIView(
         this.customActions = customActions
     }
 
-
     override fun editMenuForTextRange(textRange: UITextRange, suggestedActions: List<*>): UIMenu? {
-        if (usingNativeTextInput) {
-            val customMenuElements = makeCustomMenuElements()
-            if (customMenuElements.isEmpty()) return null // The default menu would be returned
+        val customMenuElements = makeCustomMenuElements()
+        if (customMenuElements.isEmpty()) return null // The default menu would be returned
 
-            @Suppress("UNCHECKED_CAST")
-            val suggestedActionsElements = suggestedActions as List<UIMenuElement>
+        @Suppress("UNCHECKED_CAST")
+        val suggestedActionsElements = suggestedActions as List<UIMenuElement>
 
-            return UIMenu.menuWithTitle("", children = customMenuElements + suggestedActionsElements)
-        } else {
-            return null
-        }
+        return UIMenu.menuWithTitle("", children = customMenuElements + suggestedActionsElements)
     }
 
     private fun makeCustomMenuElements(): List<UIMenuElement> {
@@ -785,18 +678,6 @@ internal class IntermediateTextInputUIView(
     }
     override fun tokenizer(): UITextInputTokenizerProtocol = _tokenizer
 
-    fun resetOnKeyboardPressesCallback() {
-        onKeyboardPresses = NoOpOnKeyboardPresses
-    }
-
-    private fun IOSSkikoInput.withBatch(update: () -> Unit) {
-        beginEditBatch()
-        update()
-        coroutineScope.launch {
-            endEditBatch()
-        }
-    }
-
     private fun UITextRange.isValid(): Boolean {
         val range = this.toTextRange() ?: return false
         val textEndPos = input?.endOfDocument() ?: 0
@@ -804,170 +685,8 @@ internal class IntermediateTextInputUIView(
     }
 }
 
-private class IntermediateTextPosition(val position: Int = 0) : UITextPosition() {
-    override fun description(): String {
-        return "IntermediateTextPosition($position)"
-    }
-
-    init {
-        assert(position >= 0) { "position should be >= 0" }
-    }
-}
-
-private class IntermediateTextSelectionRect(
-    private var _rect: CValue<CGRect>,
-    private val _writingDirection: UITextWritingDirection,
-    private val _containsStart: Boolean,
-    private val _containsEnd: Boolean,
-    private val _isVertical: Boolean
-
-) : UITextSelectionRect() {
-    constructor(textSelectionRect: TextSelectionRect) : this(
-        textSelectionRect.dpRect.asCGRect(),
-        NSWritingDirectionNatural,
-        textSelectionRect.containsStart,
-        textSelectionRect.containsEnd,
-        textSelectionRect.isVertical
-    )
-
-    override fun rect(): CValue<CGRect> = _rect
-    override fun writingDirection(): NSWritingDirection = _writingDirection
-    override fun containsStart(): Boolean = _containsStart
-    override fun containsEnd(): Boolean = _containsEnd
-    override fun isVertical(): Boolean = _isVertical
-}
-
-private fun IntermediateTextRange(start: Int, end: Int) =
-    IntermediateTextRange(
-        _start = IntermediateTextPosition(start),
-        _end = IntermediateTextPosition(end)
-    )
-
-private class IntermediateTextRange(
-    val _start: IntermediateTextPosition,
-    val _end: IntermediateTextPosition
-) : UITextRange() {
-    override fun isEmpty() = (_end.position - _start.position) <= 0
-    override fun start(): UITextPosition = _start
-    override fun end(): UITextPosition = _end
-
-    override fun description(): String {
-        return "IntermediateTextRange(start=$_start, end=$_end)"
-    }
-}
-
-// Despite UITextRange being declared as non-null, iOS can still pass null to methods that take a UITextRange parameter.
-private fun UITextRange.toTextRange(): TextRange? {
-    val start = (start() as? IntermediateTextPosition)?.position ?: return null
-    val end = (end() as? IntermediateTextPosition)?.position ?: return null
-    return TextRange(start, end)
-}
-
-private fun TextRange.toUITextRange(): UITextRange =
-    IntermediateTextRange(start = start, end = end)
-
-internal class IntermediateTextTokenizer(
-    textInput: UIResponder,
-    val getString: () -> String?
-): CMPTextInputStringTokenizer(textInput) {
-    private val newLineCharacters = setOf('\n', '\r', '\u2029')
-
-    override fun positionFromPosition(
-        position: UITextPosition,
-        toBoundary: UITextGranularity,
-        inDirection: UITextDirection
-    ): UITextPosition? {
-        val textPosition = position as? IntermediateTextPosition ?: return null
-        val isForward = inDirection == UITextStorageDirectionForward ||
-            inDirection == UITextLayoutDirectionRight ||
-            inDirection == UITextLayoutDirectionDown
-
-        val iterator = when (toBoundary) {
-            UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
-            UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
-            UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
-            UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
-            UITextGranularity.UITextGranularityParagraph ->
-                return positionFromPositionToParagraphBoundary(position, isForward)
-
-            else -> return super.positionFromPosition(position, toBoundary, inDirection)
-        }
-
-        val string = getString() ?: ""
-        iterator.setText(string)
-
-        val iteratorResult = if (isForward) {
-            if (textPosition.position >= string.length - 1) {
-                string.length
-            } else {
-                iterator.following(textPosition.position)
-            }
-        } else {
-            if (textPosition.position <= 0) {
-                0
-            } else {
-                iterator.preceding(textPosition.position)
-            }
-        }
-
-        return IntermediateTextPosition(iteratorResult)
-    }
-
-    override fun isPositionAtBoundary(
-        position: UITextPosition,
-        atBoundary: UITextGranularity,
-        inDirection: UITextDirection
-    ): Boolean {
-        val textPosition = position as? IntermediateTextPosition ?: return false
-
-        val iterator = when (atBoundary) {
-            UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
-            UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
-            UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
-            UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
-            UITextGranularity.UITextGranularityParagraph -> {
-                return isAtParagraphBoundary(getString() ?: "", textPosition.position)
-            }
-            else -> return super.isPositionAtBoundary(position, atBoundary, inDirection)
-        }
-
-        iterator.setText(getString() ?: "")
-        return iterator.isBoundary(textPosition.position)
-    }
-
-    private fun positionFromPositionToParagraphBoundary(
-        position: UITextPosition,
-        isForward: Boolean
-    ): UITextPosition? {
-        val textPosition = position as? IntermediateTextPosition ?: return null
-
-        val string = getString() ?: ""
-        var location = textPosition.position
-        while (isForward && location < string.length || !isForward && location > 0) {
-            if (isForward) {
-                if (string[location] in newLineCharacters) {
-                    break
-                }
-                location++
-            } else {
-                if (string[location] in newLineCharacters) {
-                    location++
-                    break
-                }
-                location--
-            }
-        }
-        return IntermediateTextPosition(location)
-    }
-
-    private fun isAtParagraphBoundary(text: String, position: Int): Boolean {
-        if (position == 0 || position == text.length) return true
-        return text[position] in newLineCharacters || text[position - 1] in newLineCharacters
-    }
-}
-
 /**
- * A [UIScrollView] that hosts the [IntermediateTextInputUIView] when native input handling (Native Text Input)
+ * A [UIScrollView] that hosts the [ComposeTextInputView] when native input handling (Native Text Input)
  * is enabled.
  *
  * This container is necessary because:
@@ -976,7 +695,7 @@ internal class IntermediateTextTokenizer(
  *    to align correctly with the Compose-rendered text.
  * 2. It synchronizes its [contentOffset] and [contentInset] with the Compose text field's
  *    internal scroll state, ensuring that the UITextInput-conforming overlay view
- *    ([IntermediateTextInputUIView]) stays in sync with the visual rendering.
+ *    ([ComposeTextInputView]) stays in sync with the visual rendering.
  * 3. It provides a larger hit-testing area for native interactive elements (like selection handles)
  *    that may overflow the immediate visual bounds of the text field.
  *
@@ -993,7 +712,7 @@ internal class IntermediateTextScrollView(): UIScrollView(frame = CGRectZero.rea
         setClipsToBounds(true)
     }
 
-    var textView: IntermediateTextInputUIView? = null
+    var textView: NativeTextInputView? = null
         set(value) {
             if (field != value) {
                 field?.removeFromSuperview()
@@ -1171,19 +890,5 @@ private class TouchTrackingGestureRecognizer : CMPGestureRecognizer(target = nul
     ): Boolean {
         // Prevent other gesture recognizers so this one handles touches exclusively
         return true
-    }
-}
-
-// Kotlin wrapper for UITextLayoutDirection
-internal enum class PlatformTextLayoutDirection(val platform: UITextLayoutDirection) {
-    Left(UITextLayoutDirectionLeft),
-    Right(UITextLayoutDirectionRight),
-    Up(UITextLayoutDirectionUp),
-    Down(UITextLayoutDirectionDown);
-
-    companion object {
-        operator fun invoke(platform: UITextLayoutDirection): PlatformTextLayoutDirection? {
-            return entries.find { it.platform == platform }
-        }
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.platform.IntermediateTextRange
 import androidx.compose.ui.platform.IntermediateTextSelectionRect
 import androidx.compose.ui.platform.IntermediateTextTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
-import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.NativeTextEditingDelegate
+import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
-import androidx.compose.ui.uikit.utils.CMPEditMenuView
+import androidx.compose.ui.uikit.utils.CMPTextInputView
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
@@ -107,7 +107,7 @@ import platform.darwin.NSInteger
 
 internal class NativeTextInputView(
     private val coroutineScope: CoroutineScope,
-): CMPEditMenuView(frame = CGRectZero.readValue()), UIKeyInputProtocol, UITextInputProtocol {
+): CMPTextInputView(frame = CGRectZero.readValue()), UIKeyInputProtocol, UITextInputProtocol {
 
     var input: NativeTextEditingDelegate? = null
 
@@ -119,9 +119,6 @@ internal class NativeTextInputView(
     private val touchesTrackerGestureRecognizer = TouchTrackingGestureRecognizer().also {
         addGestureRecognizer(it)
     }
-
-    override fun inputView(): UIView? = inputTraits.inputView()
-    override fun inputAccessoryView(): UIView? = inputTraits.inputAccessoryView()
 
     override fun canBecomeFirstResponder() = true
 
@@ -597,7 +594,6 @@ internal class NativeTextInputView(
         _inputDelegate?.selectionDidChange(this)
     }
 
-    override fun shouldUseNonComposeMenuActions() = true
     private var onCopy: (() -> Unit)? = null
     private var onPaste: (() -> Unit)? = null
     private var onCut: (() -> Unit)? = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.platform.IntermediateTextSelectionRect
 import androidx.compose.ui.platform.IntermediateTextTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.SkikoUITextInputTraits
-import androidx.compose.ui.platform.NativeTextInputDelegate
+import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch
@@ -110,7 +110,7 @@ internal class NativeTextInputView(
     private val coroutineScope: CoroutineScope,
 ): CMPEditMenuView(frame = CGRectZero.readValue()), UIKeyInputProtocol, UITextInputProtocol {
 
-    var input: NativeTextInputDelegate? = null // TODO: Rename?
+    var input: NativeTextEditingDelegate? = null
 
     var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -78,7 +78,6 @@ import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardType
 import platform.UIKit.UIMenu
 import platform.UIKit.UIMenuElement
-import platform.UIKit.UIPress
 import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UIScrollView
@@ -112,15 +111,10 @@ internal class NativeTextInputView(
 
     var input: NativeTextEditingDelegate? = null
 
-    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
+    private val inputTraits: SkikoUITextInputTraits
+        get() = input?.inputTraits ?: EmptyInputTraits
 
     private var _inputDelegate: UITextInputDelegateProtocol? = null
-
-    /**
-     * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
-     * Erasure happens due to K/N not supporting Obj-C lightweight generics.
-     */
-    var onKeyboardPresses: (Set<*>) -> Unit = {}
 
     private val touchesTrackerGestureRecognizer = TouchTrackingGestureRecognizer().also {
         addGestureRecognizer(it)
@@ -184,12 +178,12 @@ internal class NativeTextInputView(
     }
 
     override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
+        input?.onKeyboardPresses(presses)
         super.pressesBegan(presses, withEvent)
     }
 
     override fun pressesEnded(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
+        input?.onKeyboardPresses(presses)
         super.pressesEnded(presses, withEvent)
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -18,10 +18,10 @@ package androidx.compose.ui.window
 
 import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
-import androidx.compose.ui.platform.IntermediateTextPosition
-import androidx.compose.ui.platform.IntermediateTextRange
+import androidx.compose.ui.platform.TextInputPosition
+import androidx.compose.ui.platform.TextInputRange
 import androidx.compose.ui.platform.IntermediateTextSelectionRect
-import androidx.compose.ui.platform.IntermediateTextTokenizer
+import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.SkikoUITextInputTraits
@@ -348,7 +348,7 @@ internal class NativeTextInputView(
     }
 
     override fun beginningOfDocument(): UITextPosition {
-        return IntermediateTextPosition(0)
+        return TextInputPosition(0)
     }
 
     /**
@@ -356,7 +356,7 @@ internal class NativeTextInputView(
      * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
      */
     override fun endOfDocument(): UITextPosition {
-        return IntermediateTextPosition(input?.endOfDocument() ?: 0)
+        return TextInputPosition(input?.endOfDocument() ?: 0)
     }
 
     /**
@@ -366,11 +366,11 @@ internal class NativeTextInputView(
         fromPosition: UITextPosition,
         toPosition: UITextPosition
     ): UITextRange? {
-        val from = (fromPosition as? IntermediateTextPosition)?.position ?: return null
-        val to = (toPosition as? IntermediateTextPosition)?.position ?: return null
-        return IntermediateTextRange(
-            IntermediateTextPosition(minOf(from, to)),
-            IntermediateTextPosition(maxOf(from, to))
+        val from = (fromPosition as? TextInputPosition)?.position ?: return null
+        val to = (toPosition as? TextInputPosition)?.position ?: return null
+        return TextInputRange(
+            TextInputPosition(minOf(from, to)),
+            TextInputPosition(maxOf(from, to))
         )
     }
 
@@ -384,10 +384,10 @@ internal class NativeTextInputView(
         position: UITextPosition,
         offset: NSInteger
     ): UITextPosition? {
-        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val p = (position as? TextInputPosition)?.position ?: return null
         val input = input ?: return null
         return input.positionFromPosition(position = p, offset = offset.toInt())?.let {
-            IntermediateTextPosition(it)
+            TextInputPosition(it)
         }
     }
 
@@ -395,10 +395,10 @@ internal class NativeTextInputView(
         position: UITextPosition,
         offset: NSInteger
     ): UITextPosition? {
-        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val p = (position as? TextInputPosition)?.position ?: return null
         val input = input ?: return null
         return input.verticalPositionFromPosition(position = p, verticalOffset = offset.toInt())
-            ?.let { IntermediateTextPosition(it) }
+            ?.let { TextInputPosition(it) }
     }
 
     override fun positionFromPosition(
@@ -422,8 +422,8 @@ internal class NativeTextInputView(
         position: UITextPosition,
         toPosition: UITextPosition
     ): NSComparisonResult {
-        val from = (position as? IntermediateTextPosition)?.position ?: return NSOrderedSame
-        val to = (toPosition as? IntermediateTextPosition)?.position ?: return NSOrderedSame
+        val from = (position as? TextInputPosition)?.position ?: return NSOrderedSame
+        val to = (toPosition as? TextInputPosition)?.position ?: return NSOrderedSame
         val result = if (from < to) {
             NSOrderedAscending
         } else if (from > to) {
@@ -435,7 +435,7 @@ internal class NativeTextInputView(
     }
 
     override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
-        if (from !is IntermediateTextPosition || toPosition !is IntermediateTextPosition) {
+        if (from !is TextInputPosition || toPosition !is TextInputPosition) {
             return 0
         }
         return (toPosition.position - from.position).toLong()
@@ -446,7 +446,7 @@ internal class NativeTextInputView(
         withinRange: UITextRange
     ): NSInteger {
         val withinTextRange = withinRange.toTextRange() ?: return 0L
-        val intermediatePosition = (position as? IntermediateTextPosition)?.position ?: 0
+        val intermediatePosition = (position as? TextInputPosition)?.position ?: 0
         return (intermediatePosition - withinTextRange.start).toLong()
     }
 
@@ -454,21 +454,21 @@ internal class NativeTextInputView(
         range: UITextRange,
         atCharacterOffset: NSInteger
     ): UITextPosition {
-        val fallback = IntermediateTextPosition(0)
+        val fallback = TextInputPosition(0)
         val textRange = range.toTextRange() ?: return fallback
         return (textRange.start + atCharacterOffset.toInt()).takeIf { range.isValid() && it in textRange }
-            ?.let { IntermediateTextPosition(it) } ?: fallback
+            ?.let { TextInputPosition(it) } ?: fallback
     }
 
     override fun positionWithinRangeFarthestInDirection(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection
     ): UITextPosition {
-        val fallback = IntermediateTextPosition(0)
+        val fallback = TextInputPosition(0)
         val textRange = range.toTextRange() ?: return fallback
         return PlatformTextLayoutDirection(farthestInDirection)?.let { direction ->
             input?.positionWithinRange(textRange, direction)?.let {
-                IntermediateTextPosition(it)
+                TextInputPosition(it)
             }
         } ?: fallback
     }
@@ -477,13 +477,13 @@ internal class NativeTextInputView(
         position: UITextPosition,
         inDirection: UITextLayoutDirection
     ): UITextRange? {
-        val oldPosition = position as? IntermediateTextPosition ?: return null
+        val oldPosition = position as? TextInputPosition ?: return null
         val newPosition = positionFromPosition(oldPosition, inDirection = inDirection, offset = 1)
-            as? IntermediateTextPosition ?: return null
+            as? TextInputPosition ?: return null
         return if (newPosition.position < oldPosition.position) {
-            IntermediateTextRange(newPosition, oldPosition)
+            TextInputRange(newPosition, oldPosition)
         } else {
-            IntermediateTextRange(oldPosition, newPosition)
+            TextInputRange(oldPosition, newPosition)
         }
     }
 
@@ -508,7 +508,7 @@ internal class NativeTextInputView(
 
     override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> {
         val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
-        val position = (position as? IntermediateTextPosition)?.position ?: return fallbackRect
+        val position = (position as? TextInputPosition)?.position ?: return fallbackRect
         val caretDpRect = input?.caretDpRectForPosition(position)
         return caretDpRect?.asCGRect() ?: fallbackRect
     }
@@ -516,8 +516,8 @@ internal class NativeTextInputView(
     override fun selectionRectsForRange(range: UITextRange): List<*> {
         val fallbackList = listOf<UITextSelectionRect>()
         val textRange = TextRange(
-            start = (range.start as? IntermediateTextPosition)?.position ?: return fallbackList,
-            end = (range.end as? IntermediateTextPosition)?.position ?: return fallbackList
+            start = (range.start as? TextInputPosition)?.position ?: return fallbackList,
+            end = (range.end as? TextInputPosition)?.position ?: return fallbackList
         )
         val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
         return rects.fastMap { IntermediateTextSelectionRect(it) }
@@ -526,25 +526,25 @@ internal class NativeTextInputView(
     override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? {
         val closestPosition =
             input?.closestPositionToPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
-        return IntermediateTextPosition(closestPosition)
+        return TextInputPosition(closestPosition)
     }
 
     override fun closestPositionToPoint(
         point: CValue<CGPoint>,
         withinRange: UITextRange
     ): UITextPosition? {
-        val textRange = (withinRange as? IntermediateTextRange)?.toTextRange() ?: return null
+        val textRange = (withinRange as? TextInputRange)?.toTextRange() ?: return null
         val closestPosition = input?.closestPositionToPoint(
             point.useContents { DpOffset(x.dp, y.dp) },
             textRange
         ) ?: return null
-        return IntermediateTextPosition(closestPosition)
+        return TextInputPosition(closestPosition)
     }
 
     override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? {
         val characterRange =
             input?.characterRangeAtPoint(point.useContents { DpOffset(x.dp, y.dp) }) ?: return null
-        return IntermediateTextRange(characterRange.start, characterRange.end)
+        return TextInputRange(characterRange.start, characterRange.end)
     }
 
     override fun textStylingAtPosition(
@@ -673,7 +673,7 @@ internal class NativeTextInputView(
         }
     }
 
-    private val _tokenizer = IntermediateTextTokenizer(textInput = this) {
+    private val _tokenizer = TextInputStringTokenizer(textInput = this) {
         input?.let { it.textInRange(TextRange(0, it.endOfDocument())) }
     }
     override fun tokenizer(): UITextInputTokenizerProtocol = _tokenizer
@@ -702,7 +702,7 @@ internal class NativeTextInputView(
  * This view does not handle user-driven scrolling; scrolling is still managed by Compose,
  * which then updates this scroll view's state.
  */
-internal class IntermediateTextScrollView(): UIScrollView(frame = CGRectZero.readValue()) {
+internal class NativeTextInputScrollView(): UIScrollView(frame = CGRectZero.readValue()) {
     init {
         setScrollEnabled(false)
         setShowsVerticalScrollIndicator(false)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.TextInputPosition
 import androidx.compose.ui.platform.TextInputRange
-import androidx.compose.ui.platform.TextInputSelectionRect
 import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.NativeTextEditingDelegate
@@ -36,7 +35,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.asCGRect
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CValue
@@ -510,8 +508,7 @@ internal class NativeTextInputView(
             start = (range.start as? TextInputPosition)?.position ?: return fallbackList,
             end = (range.end as? TextInputPosition)?.position ?: return fallbackList
         )
-        val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
-        return rects.fastMap { TextInputSelectionRect(it) }
+        return input?.selectionDpRectsForRange(textRange) ?: fallbackList
     }
 
     override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.TextInputPosition
 import androidx.compose.ui.platform.TextInputRange
-import androidx.compose.ui.platform.IntermediateTextSelectionRect
+import androidx.compose.ui.platform.TextInputSelectionRect
 import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.NativeTextEditingDelegate
@@ -514,7 +514,7 @@ internal class NativeTextInputView(
             end = (range.end as? TextInputPosition)?.position ?: return fallbackList
         )
         val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
-        return rects.fastMap { IntermediateTextSelectionRect(it) }
+        return rects.fastMap { TextInputSelectionRect(it) }
     }
 
     override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.platform.IntermediateTextSelectionRect
 import androidx.compose.ui.platform.IntermediateTextTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.SkikoUITextInputTraits
-import androidx.compose.ui.platform.TextInputDelegate
+import androidx.compose.ui.platform.NativeTextInputDelegate
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch
@@ -110,7 +110,7 @@ internal class NativeTextInputView(
     private val coroutineScope: CoroutineScope,
 ): CMPEditMenuView(frame = CGRectZero.readValue()), UIKeyInputProtocol, UITextInputProtocol {
 
-    var input: TextInputDelegate? = null // TODO: Rename?
+    var input: NativeTextInputDelegate? = null // TODO: Rename?
 
     var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.platform.DpInsets
 import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.IntermediateTextPosition
 import androidx.compose.ui.platform.IntermediateTextRange
@@ -28,7 +29,6 @@ import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.platform.withDeferredEditBatch
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.DpInsets
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
 import androidx.compose.ui.uikit.utils.CMPEditMenuView
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -686,7 +686,7 @@ internal class NativeTextInputView(
 }
 
 /**
- * A [UIScrollView] that hosts the [ComposeTextInputView] when native input handling (Native Text Input)
+ * A [UIScrollView] that hosts the [NativeTextInputView] when native input handling (Native Text Input)
  * is enabled.
  *
  * This container is necessary because:
@@ -695,7 +695,7 @@ internal class NativeTextInputView(
  *    to align correctly with the Compose-rendered text.
  * 2. It synchronizes its [contentOffset] and [contentInset] with the Compose text field's
  *    internal scroll state, ensuring that the UITextInput-conforming overlay view
- *    ([ComposeTextInputView]) stays in sync with the visual rendering.
+ *    ([NativeTextInputView]) stays in sync with the visual rendering.
  * 3. It provides a larger hit-testing area for native interactive elements (like selection handles)
  *    that may overflow the immediate visual bounds of the text field.
  *

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.test.waitForIdle
 import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.IntermediateTextInputUIView
+import androidx.compose.ui.window.ComposeTextInputView
 import kotlin.native.runtime.GC
 import kotlin.native.runtime.NativeRuntimeApi
 import kotlin.test.AfterTest
@@ -552,7 +552,7 @@ class MemoryLeaksTest {
 
     @OptIn(ExperimentalForeignApi::class)
     private fun startFakeTextInputSession(useNativeInput: Boolean = false) {
-        val input = IntermediateTextInputUIView(0, useNativeInput, coroutineScope = mainScope)
+        val input = ComposeTextInputView(0, coroutineScope = mainScope)
         UIApplication.sharedApplication.keyWindow?.rootViewController?.view?.addSubview(input)
         input.setFrame(CGRectMake(0.0, 0.0, 100.0, 100.0))
         input.becomeFirstResponder()


### PR DESCRIPTION
iOS text input had a single monolithic `UIKitTextInputService` that handled both the Compose path (Compose draws caret/selection) and the NITI path (UIKit owns caret, handles and context menu) with `if (usingNativeTextInput)` branches throughout, and a single shared view reused across sessions.

Each text input session now gets its own dedicated connection object that owns its view for the duration of the session. The two paths are split into separate classes with no branching in shared code.

Class Hierarchy changes

**Before:**
```
UIKitTextInputService
└── IntermediateTextInputUIView (IOSSkikoInput protocol)
```

**After:**
```
UIKitTextInputService
├── ComposeTextInputConnection (TextInputConnection) → ComposeTextInputView (TextEditingDelegate)
└── NativeTextInputConnection  (TextInputConnection) → NativeTextInputView  (NativeTextEditingDelegate)
```

`SelectionContainerConnection` extends `ComposeTextInputConnection` and makes the SelectionContainer menu scenario explicit — instead of scattered conditions inside `showMenu`, there is now a dedicated connection type that clearly represents opening a context menu without an active text input session.

### Fixes:
[CMP-9972](https://youtrack.jetbrains.com/issue/CMP-9972) [iOS] Refactor iOS Text Input

## Testing
This should be tested by QA

## Release Notes
N/A
