### PR TITLE
Minimal fix for missed pointerup after drug in Safari

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.web.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.web.kt
@@ -67,7 +67,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 actual fun DragAndDropExample() {
     val exportedText = "Hello, DnD!"
 
-    var isTargetEnabled by remember { mutableStateOf(false) }
+    var isTargetEnabled by remember { mutableStateOf(true) }
 
 
     Box(

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -376,6 +376,7 @@ internal class ComposeWindow(
     }
 
     private fun initEvents(canvas: HTMLCanvasElement) {
+
         listOf(
             "pointerenter",
             "pointerdown",
@@ -385,6 +386,12 @@ internal class ComposeWindow(
             "pointercancel"
         ).forEach { name ->
             addTypedEvent<PointerEvent>(name, passive = false) { onPointerEvent(it) }
+        }
+
+        state.globalEvents.addDisposableEvent("dragend") {
+            // in Safari pointerup event is not firing when we drop or cancel drop
+            // see https://youtrack.jetbrains.com/issue/CMP-10102
+            actualActivePointerButtons = null
         }
 
         addTypedEvent<TouchEvent>("touchstart") { evt ->


### PR DESCRIPTION
This is the most possible non-invasive way to fix the bug that exists in safari with processing pointer events after drag cancellation

## Testing
manual 

## Release Notes
### Fixes - Web
- [Safari] Fix an issue where buttons required a second click to respond after performing drag-and-drop operations

