### PR TITLE
Minimal fix for missed pointerup after drug in Safari (#3011)

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -371,6 +371,7 @@ internal class ComposeWindow(
     }
 
     private fun initEvents(canvas: HTMLCanvasElement) {
+
         listOf(
             "pointerenter",
             "pointerdown",
@@ -380,6 +381,12 @@ internal class ComposeWindow(
             "pointercancel"
         ).forEach { name ->
             addTypedEvent<PointerEvent>(name, passive = false) { onPointerEvent(it) }
+        }
+
+        state.globalEvents.addDisposableEvent("dragend") {
+            // in Safari pointerup event is not firing when we drop or cancel drop
+            // see https://youtrack.jetbrains.com/issue/CMP-10102
+            actualActivePointerButtons = null
         }
 
         addTypedEvent<TouchEvent>("touchstart") { evt ->


### PR DESCRIPTION
🍒 Cherry-pick of a51049b208b

This is the most possible non-invasive way to fix the bug that exists in safari with processing pointer events after drag cancellation

manual

Fixes [CMP-10102](https://youtrack.jetbrains.com/issue/CMP-10102) [Web] Safari. DragAndDrop. After performing drag and drop operations buttons are unclickable on the first attempt

## Testing
manual

## Release Notes
### Fixes - Web
- [Safari] Fix an issue where buttons required a second click to respond after performing drag-and-drop operations
