### PR TITLE
Workaround iOS 26.0 safe area layout region bug

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPLayoutRegion.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPLayoutRegion.m
@@ -55,53 +55,75 @@ typedef NS_ENUM(NSInteger, CMPLayoutRegionKind) {
 }
 
 - (UIEdgeInsets)edgeInsetsInView:(UIView *)view {
+    // Starting iOS 26, UIKit exposes `UIViewLayoutRegion`s (e.g. safe area / margins with corner
+    // adaptation) which are needed to properly adopt iOS 26 macOS-like system controls.
+    //
+    // However, iOS 26.0 has a bug that can add spurious horizontal insets when using layout
+    // regions. This affects both iPhone and iPad.
+    //
+    // - iOS 26.1+: use layout regions everywhere (bug fixed).
+    // - iOS 26.0 iPhone: fall back to pre-iOS-26 insets to avoid unexpected horizontal shifts.
+    // - iOS 26.0 iPad: keep layout regions despite the horizontal insets in favor of correct insets
+    // for the new navigation elements.
+    if (@available(iOS 26.1, *)) {
+        return [self edgeInsetsForLayoutRegionInView: view];
+    }
     
-    if (@available(iOS 26, *)) {
-        UIViewLayoutRegionAdaptivityAxis axis;
-        switch (_axis) {
-            case CMPLayoutRegionAdaptivityAxisNone:
-                axis = UIViewLayoutRegionAdaptivityAxisNone;
-                break;
-            case CMPLayoutRegionAdaptivityAxisHorizontal:
-                axis = UIViewLayoutRegionAdaptivityAxisHorizontal;
-                break;
-            case CMPLayoutRegionAdaptivityAxisVertical:
-                axis = UIViewLayoutRegionAdaptivityAxisVertical;
-                break;
+    if (@available(iOS 26.0, *)) {
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            return [self edgeInsetsForLayoutRegionInView: view];
         }
-        
-        UIViewLayoutRegion *layoutRegion;
-        switch (_kind) {
-            case CMPLayoutRegionKindMargins:
-                layoutRegion = [UIViewLayoutRegion marginsLayoutRegionWithCornerAdaptation:axis];
-                break;
-            case CMPLayoutRegionKindReadableContent:
-                layoutRegion = [UIViewLayoutRegion readableContentLayoutRegionWithCornerAdaptation:axis];
-                break;
-            case CMPLayoutRegionKindSafeArea:
-                layoutRegion = [UIViewLayoutRegion safeAreaLayoutRegionWithCornerAdaptation:axis];
-                break;
+    }
+    
+    return [self edgeInsetsFallbackInView: view];
+}
+
+- (UIEdgeInsets)edgeInsetsForLayoutRegionInView:(UIView *)view API_AVAILABLE(ios(26.0)) {
+    UIViewLayoutRegionAdaptivityAxis axis;
+    switch (_axis) {
+        case CMPLayoutRegionAdaptivityAxisNone:
+            axis = UIViewLayoutRegionAdaptivityAxisNone;
+            break;
+        case CMPLayoutRegionAdaptivityAxisHorizontal:
+            axis = UIViewLayoutRegionAdaptivityAxisHorizontal;
+            break;
+        case CMPLayoutRegionAdaptivityAxisVertical:
+            axis = UIViewLayoutRegionAdaptivityAxisVertical;
+            break;
+    }
+
+    UIViewLayoutRegion *layoutRegion;
+    switch (_kind) {
+        case CMPLayoutRegionKindMargins:
+            layoutRegion = [UIViewLayoutRegion marginsLayoutRegionWithCornerAdaptation:axis];
+            break;
+        case CMPLayoutRegionKindReadableContent:
+            layoutRegion = [UIViewLayoutRegion readableContentLayoutRegionWithCornerAdaptation:axis];
+            break;
+        case CMPLayoutRegionKindSafeArea:
+            layoutRegion = [UIViewLayoutRegion safeAreaLayoutRegionWithCornerAdaptation:axis];
+            break;
+    }
+
+    return [view edgeInsetsForLayoutRegion:layoutRegion];
+}
+
+- (UIEdgeInsets)edgeInsetsFallbackInView:(UIView *)view {
+    switch (_kind) {
+        case CMPLayoutRegionKindMargins:
+            return view.layoutMargins;
+        case CMPLayoutRegionKindReadableContent: {
+            CGRect layoutFrame = view.readableContentGuide.layoutFrame;
+            CGFloat top = layoutFrame.origin.y;
+            CGFloat left = layoutFrame.origin.x;
+            CGFloat right = view.frame.size.width - (left + layoutFrame.size.width);
+            CGFloat bottom = view.frame.size.height - (top + layoutFrame.size.height);
+            return UIEdgeInsetsMake(top, left, right, bottom);
         }
-        
-        return [view edgeInsetsForLayoutRegion:layoutRegion];
-    } else {
-        switch (_kind) {
-            case CMPLayoutRegionKindMargins:
-                return view.layoutMargins;
-            case CMPLayoutRegionKindReadableContent: {
-                CGRect layoutFrame = view.readableContentGuide.layoutFrame;
-                CGFloat top = layoutFrame.origin.y;
-                CGFloat left = layoutFrame.origin.x;
-                CGFloat right = view.frame.size.width - (left + layoutFrame.size.width);
-                CGFloat bottom = view.frame.size.height - (top + layoutFrame.size.height);
-                return UIEdgeInsetsMake(top, left, right, bottom);
-            }
-            case CMPLayoutRegionKindSafeArea:
-            default:
-                return view.safeAreaInsets;
-        }
+        case CMPLayoutRegionKindSafeArea:
+        default:
+            return view.safeAreaInsets;
     }
 }
 
 @end
-


### PR DESCRIPTION
`UIView.LayoutRegion.safeArea(cornerAdaptation:)` was introduced in iOS 26 to provide correct insets for the new macOS-like system controls (iPad). On iOS 26.0 this API reports different values than on iOS 26.1+ and adds unexpected horizontal safe-area insets.

To avoid content being shifted horizontally **on iPhone**, we fall back to the pre–iOS 26 behavior (using `view.safeAreaInsets`) on **non-pad idioms** when running on iOS 26.0. The same issue can also affect iPad on iOS 26.0, but there we intentionally keep using layout regions: adopting the new iPad controls is prioritized even if it means accepting the extra horizontal inset on iOS 26.0.

Fixes [CMP-10046](https://youtrack.jetbrains.com/issue/CMP-10046) WindowInsets.systemBars add some arbitrary horizontal space on iOS but not on Android

## Testing

This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix `WindowInsets.systemBars` add extra horizontal insets on iOS 26.0