### PR TITLE
Copy Jetpack Compose 1.11.1

### DIFF
--- a/compose/foundation/foundation-layout/src/androidDeviceTest/kotlin/androidx/compose/foundation/layout/FlexBoxTest.kt
+++ b/compose/foundation/foundation-layout/src/androidDeviceTest/kotlin/androidx/compose/foundation/layout/FlexBoxTest.kt
@@ -984,9 +984,10 @@ class FlexBoxTest {
                         )
                         // Item with shrink=1 (default, will shrink)
                         Box(
-                            Modifier.widthIn(min = 40.dp, max = 60.dp).height(20.dp).onSizeChanged {
-                                widths.add(1, it.width)
-                            }
+                            Modifier.widthIn(min = 20.dp)
+                                .height(20.dp)
+                                .flex { basis(60.dp) }
+                                .onSizeChanged { widths.add(1, it.width) }
                         )
                     }
                 }

--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/FlexBox.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/FlexBox.kt
@@ -550,9 +550,7 @@ private class FlexBoxMeasurePolicy(private val flexBoxConfigState: State<FlexBox
         items.fastForEachUntil(startIndex, endIndex) { item ->
             val flexFactor = if (isGrowing) item.grow else item.shrink
 
-            if (
-                flexFactor == 0f || (!isGrowing && item.flexBaseSize <= item.hypotheticalMainSize)
-            ) {
+            if (flexFactor == 0f || (!isGrowing && item.flexBaseSize < item.hypotheticalMainSize)) {
                 item.targetMainSize = item.hypotheticalMainSize
                 item.isFrozen = true
                 sumFrozenTargetSize += item.targetMainSize

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SnapshotFlow.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SnapshotFlow.kt
@@ -206,10 +206,7 @@ internal abstract class SnapshotFlowManagerImpl internal constructor() {
      * This must be called by a [snapshotFlow] when it is in the process of exiting to dispose of
      * all subscriptions associated with it.
      */
-    internal fun reportSnapshotFlowCancellation(channel: SendChannel<Unit>) {
-        clearWatchSet(channel)
-        commitSubscriptionChanges()
-    }
+    internal abstract fun reportSnapshotFlowCancellation(channel: SendChannel<Unit>)
 
     /**
      * Disposes of this manager. Disposing of a manager disconnects it from the [Snapshot] system,
@@ -335,6 +332,12 @@ private class SingleSubscriptionSnapshotFlowManager : SnapshotFlowManagerImpl() 
         }
     }
 
+    override fun reportSnapshotFlowCancellation(channel: SendChannel<Unit>) {
+        subscribedChannel = null
+        clearWatchSet(channel)
+        commitSubscriptionChanges()
+    }
+
     override fun dispose() {
         unregisterApplyObserver.dispose()
         clearWatchSetImpl()
@@ -445,6 +448,12 @@ private class MultiSubscriptionSnapshotFlowManager : SnapshotFlowManagerImpl() {
             }
         }
         pendingChanges.clear()
+    }
+
+    override fun reportSnapshotFlowCancellation(channel: SendChannel<Unit>) {
+        readObserverCache.remove(channel)
+        clearWatchSet(channel)
+        commitSubscriptionChanges()
     }
 
     override fun dispose() {

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/SnapshotFlowTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/SnapshotFlowTests.kt
@@ -211,6 +211,44 @@ class SnapshotFlowTests {
         collector2.cancel()
     }
 
+    @OptIn(ExperimentalComposeRuntimeApi::class)
+    @Test
+    fun cancelSoleManagedSnapshotFlowThenReuseManager() = runTest {
+        val state = mutableStateOf(false)
+
+        val manager = SnapshotFlowManager()
+
+        val results = mutableListOf<Boolean>()
+
+        val collector1 =
+            snapshotFlow(manager) { state.value }.onEach { results.add(it) }.launchIn(this)
+
+        // This test uses the `runTest` single-threaded dispatcher, which means that changes aren't
+        // flushed to observers until we `yield()` intentionally.
+        yield()
+
+        state.value = true
+        Snapshot.sendApplyNotifications()
+        yield()
+
+        collector1.cancel()
+        val collector2 =
+            snapshotFlow(manager) { state.value }.onEach { results.add(it) }.launchIn(this)
+        val collector3 =
+            snapshotFlow(manager) { state.value }.onEach { results.add(it) }.launchIn(this)
+
+        yield()
+
+        state.value = false
+        Snapshot.sendApplyNotifications()
+        yield()
+
+        assertEquals(listOf(false, true, true, true, false, false), results)
+
+        collector2.cancel()
+        collector3.cancel()
+    }
+
     @Test
     fun twoSnapshotFlowsWithDistinctManagers() = runTest {
         val state = mutableStateOf(false)

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,7 +134,7 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 #   artifactRedirection.version.<redirectionGroup>.<redirectionModule>
 #   covers all sub-module projects
 #   (artifactRedirection.version.androidx.compose covers androidx.compose.*:*)
-artifactRedirection.version.androidx.compose=1.11.0
+artifactRedirection.version.androidx.compose=1.11.1
 artifactRedirection.version.androidx.compose.material3=1.5.0-alpha17
 artifactRedirection.version.androidx.compose.material3.adaptive=1.3.0-alpha10
 artifactRedirection.version.androidx.compose.material3.common=1.0.0-alpha01


### PR DESCRIPTION

Group ID | Release Version | Release SHA | Release Build ID | Release Date
-- | -- | -- | -- | --
androidx.compose.animation | 1.11.1 | 5d39d0c458dbf0b3791cfaba65f42a27e442c15f | 15315148 | 5/6/2026
androidx.compose.foundation | 1.11.1 | 5d39d0c458dbf0b3791cfaba65f42a27e442c15f | 15315148 | 5/6/2026
androidx.compose.material | 1.11.1 | 5d39d0c458dbf0b3791cfaba65f42a27e442c15f | 15315148 | 5/6/2026
androidx.compose.runtime | 1.11.1 | 5d39d0c458dbf0b3791cfaba65f42a27e442c15f | 15315148 | 5/6/2026
androidx.compose.ui | 1.11.1 | 5d39d0c458dbf0b3791cfaba65f42a27e442c15f | 15315148 | 5/6/2026



## Release Notes
N/A
