### PR TITLE
Fix `SwingPanel` size not scaling according to `LocalDensity`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.window.density
 import java.awt.Component
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
@@ -89,13 +90,13 @@ internal class SwingInteropViewHolder<T : Component>(
     override fun layoutAccordingTo(layoutCoordinates: LayoutCoordinates) {
         val rootCoordinates = layoutCoordinates.findRootCoordinates()
 
+        val awtToComposeScale = container.root.density
         val clippedBounds = rootCoordinates
             .localBoundingBoxOf(layoutCoordinates, clipBounds = true)
-            .round(density)
-
+            .round(awtToComposeScale)
         val bounds = rootCoordinates
             .localBoundingBoxOf(layoutCoordinates, clipBounds = false)
-            .round(density)
+            .round(awtToComposeScale)
 
         clipBounds = clippedBounds // Clipping area for skia canvas
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
@@ -24,6 +24,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LayoutBoundsHolder
 import androidx.compose.ui.layout.layoutBounds
@@ -37,13 +42,16 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.roundToDimension
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.BorderLayout
 import java.awt.Dimension
+import java.awt.Graphics
 import java.awt.Point
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
+import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
@@ -207,5 +215,47 @@ class SwingPanelTest {
         window.sendMouseWheelEvent(x = 200, y = 200, wheelRotation = 50.0)
         awaitIdle()
         assertTrue(scrollState.value > 0, "Compose did not scroll; SwingPanel blocked the event")
+    }
+
+    @Test
+    fun swingPanelRespondsToDensityChange() = runApplicationTest {
+        val swingComponent = object: JComponent() {
+            override fun paint(g: Graphics) {
+                g.color = java.awt.Color.RED
+                g.fillRect(0, 0, width, height)
+            }
+        }
+        val swingElementSize = DpSize(200.dp, 200.dp)
+
+        var densityScale by mutableFloatStateOf(1f)
+        launchTestWindowApplication(
+            state = WindowState(size = DpSize(500.dp, 500.dp))
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                val density = LocalDensity.current.density
+                CompositionLocalProvider(LocalDensity provides Density(densityScale * density)) {
+                    SwingPanel(
+                        modifier = Modifier.size(swingElementSize),
+                        factory = { swingComponent }
+                    )
+                }
+            }
+        }
+
+        awaitIdle()
+        assertEquals(
+            expected = swingElementSize.roundToDimension(),
+            actual = swingComponent.size
+        )
+
+        densityScale = 2f
+        awaitIdle()
+        assertEquals(
+            expected = (swingElementSize * densityScale).roundToDimension(),
+            actual = swingComponent.size
+        )
     }
 }


### PR DESCRIPTION
Fix `SwingPanel` size not scaling according to `LocalDensity`

`SwingInteropViewHolder.layoutAccordingTo` was using the local density to convert between Compose and AWT coordinates. But the local density can be changed, whereas the AWT:compose factor is fixed (the density of the window).

Fixes https://youtrack.jetbrains.com/issue/CMP-9449

## Testing
Tested manually with 
```
fun main() = singleWindowApplication {
    var zoom by remember { mutableStateOf(1.1f) }
    val defaultDensity = LocalDensity.current.density
    CompositionLocalProvider(LocalDensity provides Density(defaultDensity * zoom, 1f)) {
        Column(Modifier.fillMaxSize()) {
            SwingPanel(
                factory = {
                    object: JComponent() {
                        override fun paint(g: Graphics) {
                            g.color = java.awt.Color.RED
                            g.fillRect(0, 0, width, height)
                        }
                    }
                },
                modifier = Modifier.border(1.dp, Color.Black).padding(1.dp).size(200.dp, 200.dp)
            )

            Spacer(Modifier.height(16.dp))

            Row(verticalAlignment = Alignment.CenterVertically) {
                Button(onClick = { zoom *= 1.1f }) { Text("Zoom In") }
                Button(onClick = { zoom /= 1.1f }) { Text("Zoom out") }
            }
        }
    }
}
```
and added a unit test.

## Release Notes
### Fixes - Desktop
- Fix `SwingPanel` size not scaling according to `LocalDensity`. Note that this doesn't scale the Swing content of the `SwingPanel`.
