### PR TITLE
[iOS] Destroy architecture-components owner on dispose

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -273,7 +273,6 @@ internal class ComposeContainer(
         // provide the saved state to the next Compose scene when the container re-enters
         // the window hierarchy.
         savedState = architectureComponentsOwner.saveState()
-        lifecycleDelegate.onLifecycleStateUpdated = null
 
         view.updateMetalView(metalView = null)
         navigationEventInput.onDidMoveToWindow(null, view)
@@ -287,6 +286,10 @@ internal class ComposeContainer(
         layersHolder = null
 
         interfaceOrientationObserver.isObservingEnabled = false
+
+        // Propagate DESTROYED through the still-attached delegate callback, then detach.
+        lifecycleDelegate.markDisposed()
+        lifecycleDelegate.onLifecycleStateUpdated = null
     }
 
     private fun createComposeSceneContext(

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleDelegate.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleDelegate.ios.kt
@@ -79,6 +79,17 @@ internal class ComposeContainerLifecycleDelegate(
             this.isSceneActive = activeStateListener.isSceneActive
         }
 
+    /**
+     * Marks the lifecycle as disposed, propagating [Lifecycle.State.DESTROYED] to the
+     * currently-attached [onLifecycleStateUpdated] callback (if any). Idempotent.
+     *
+     * Call this from the scene-dispose path before nulling the callback, so the owning
+     * [androidx.lifecycle.ViewModelStoreOwner] is destroyed while the wiring is still live.
+     */
+    fun markDisposed() {
+        this.isDisposed = true
+    }
+
     override fun composeContainerWillDealloc() {
         this.isDisposed = true
         activeStateListener.dispose()

--- a/compose/ui/ui/src/iosTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/iosTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
@@ -86,6 +86,61 @@ class ViewControllerBasedLifecycleOwnerTest {
     }
 
     @Test
+    fun markDisposedPropagatesDestroyedThroughActiveCallback() {
+        val notificationCenter = NSNotificationCenter()
+        val lifecycleOwner = DefaultArchitectureComponentsOwner()
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
+        lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
+        val scene = UIWindowScene()
+        lifecycleDelegate.windowScene = scene
+        lifecycleDelegate.composeContainerWillAppear()
+        notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
+        notificationCenter.postNotificationName(UISceneDidActivateNotification, scene)
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+
+        lifecycleDelegate.markDisposed()
+        assertEquals(Lifecycle.State.DESTROYED, lifecycleOwner.lifecycle.currentState)
+    }
+
+    @Test
+    fun disposeSceneOrdering_destroyedReachesOwnerEvenAfterCallbackDetached() {
+        val notificationCenter = NSNotificationCenter()
+        val lifecycleOwner = DefaultArchitectureComponentsOwner()
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
+        lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
+        val scene = UIWindowScene()
+        lifecycleDelegate.windowScene = scene
+        lifecycleDelegate.composeContainerWillAppear()
+        notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
+        notificationCenter.postNotificationName(UISceneDidActivateNotification, scene)
+        lifecycleDelegate.composeContainerDidDisappear()
+
+        // Simulates ComposeContainer.disposeComposeScene() ordering: mark disposed
+        // first (so DESTROYED propagates through the live callback), then detach.
+        lifecycleDelegate.markDisposed()
+        lifecycleDelegate.onLifecycleStateUpdated = null
+        assertEquals(Lifecycle.State.DESTROYED, lifecycleOwner.lifecycle.currentState)
+
+        // Subsequent dealloc must not crash and must not regress the state.
+        lifecycleDelegate.composeContainerWillDealloc()
+        assertEquals(Lifecycle.State.DESTROYED, lifecycleOwner.lifecycle.currentState)
+    }
+
+    @Test
+    fun markDisposedIsIdempotent() {
+        val notificationCenter = NSNotificationCenter()
+        val lifecycleOwner = DefaultArchitectureComponentsOwner()
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
+        lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
+        val scene = UIWindowScene()
+        lifecycleDelegate.windowScene = scene
+
+        lifecycleDelegate.markDisposed()
+        lifecycleDelegate.markDisposed()
+        assertEquals(Lifecycle.State.DESTROYED, lifecycleOwner.lifecycle.currentState)
+    }
+
+    @Test
     fun viewDidDisappearThenBackground() {
         val notificationCenter = NSNotificationCenter()
         val lifecycleOwner = DefaultArchitectureComponentsOwner()


### PR DESCRIPTION
 On iOS, popping a `ComposeUIViewController` from a `UINavigationController` left                                                                                                                                                                                 
  the attached `DefaultArchitectureComponentsOwner` stuck at `Lifecycle.State.CREATED`,                                                                                                                                                                            
  so `ViewModelStore.clear()` was never called and `ViewModel.onCleared()` never                                                                                                                                                                                   
  fired. `ComposeContainer.disposeComposeScene()` nulled the lifecycle delegate's                                                                                                                                                                                  
  callback before anything could signal `DESTROYED`; the `delegate.isDisposed = true`                                                                                                                                                                              
  flip from a later `composeContainerWillDealloc` correctly computed `DESTROYED`,                                                                                                                                                                                  
  but the callback was already detached, so the transition was silently dropped and                                                                                                                                                                                
  `viewModelScope` coroutines leaked until garbage collection.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                   
  This patch exposes `markDisposed()` on `ComposeContainerLifecycleDelegate` and                                                                                                                                                                                   
  calls it from `disposeComposeScene()` *before* detaching the callback. The
  existing `updateLifecycleState()` state machine then propagates `DESTROYED`                                                                                                                                                                                      
  through the live wiring, runs `viewModelStore.clear()` synchronously, and fires
  every `ViewModel.onCleared()` immediately on pop. No new public API; no                                                                                                                                                                                          
  behaviour change in any other path.
                                                                                                                                                                                                                                                                   
  Fixes [CMP-10175](https://youtrack.jetbrains.com/issue/CMP-10175).
                                                                                                                                                                                                                                                                   
  ## Testing                                                

  Three regression tests added to `ViewControllerBasedLifecycleOwnerTest`:                                                                                                                                                                                         
   
  - `markDisposedPropagatesDestroyedThroughActiveCallback` — `markDisposed()` flips the owner to `DESTROYED` while the callback is live.                                                                                                                           
  - `disposeSceneOrdering_destroyedReachesOwnerEvenAfterCallbackDetached` — full simulated `disposeComposeScene` ordering (mark disposed → detach callback), followed by `composeContainerWillDealloc`, neither crashes nor regresses state.
  - `markDisposedIsIdempotent` — second `markDisposed()` is a no-op.                                                                                                                                                                                               
                                                                                                                                                                                                                                                                   
  Run with:                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                   
  ./gradlew :compose:ui:ui:iosSimulatorArm64Test --tests "androidx.compose.ui.window.ViewControllerBasedLifecycleOwnerTest"                                                                                                                                        
   
  Also manually reproduced and verified on an iOS Simulator with a real KMP app (Compose UI screen with a ViewModel doing periodic network requests). Before the patch, `onCleared()` was never called and the network calls continued indefinitely after pop.     
  After the patch, `onCleared()` fires synchronously inside `disposeComposeScene()` on every pop, across multiple consecutive push/pop cycles.                                                                                                                     
   
  ## Release Notes                                                                                                                                                                                                                                                 
                                                            
  ### Fixes - iOS                                                                                                                                                                                                                                                  
  - Fixed `ViewModel.onCleared()` not being called when a `ComposeUIViewController` is popped from a `UINavigationController`, which previously caused `viewModelScope` coroutines to leak.
                                                                                                                                                                                                                                                                   
                                                                                                                   