### PR TITLE
Web: handle pointercancel as cancellation instead of release

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -565,6 +565,20 @@ internal class ComposeWindow(
     }
 
     private fun onPointerEvent(event: PointerEvent) {
+        if (event.type == "pointercancel") {
+            if (isTouchEvent(event)) {
+                activeTouchPointers.clear()
+                activeTouchOffset = null
+            } else {
+                actualActivePointerButtons = null
+            }
+
+            event.target?.let { releasePointerCapture(it, event.pointerId) }
+
+            scene.cancelPointerInput()
+            return
+        }
+
         val eventType = event.getPointerEventType()
         var result: PointerEventResult? = null
 
@@ -761,6 +775,10 @@ internal fun onDomReady(block: () -> Unit) {
     }
 }
 
+private fun releasePointerCapture(target: EventTarget, pointerId: Int) {
+    js("try { target.releasePointerCapture(pointerId) } catch (e) {}")
+}
+
 private fun setPointerCapture(target: EventTarget, pointerId: Int) {
     js("try { target.setPointerCapture(pointerId) } catch (e) {}")
 }
@@ -822,6 +840,10 @@ private fun clipTargetElement(canvas: HTMLCanvasElement): HTMLTextAreaElement {
 
 // strings checks are faster on a JS side
 // language=js
+private fun isTouchEvent(event: PointerEvent): Boolean = js("event.pointerType === 'touch'")
+
+// strings checks are faster on a JS side
+// language=js
 private fun isMouseEvent(event: PointerEvent): Boolean = js("event.pointerType === 'mouse'")
 
 // strings checks are faster on a JS side
@@ -832,7 +854,6 @@ private fun getPointerEventCode(event: PointerEvent): Int = js(
           case 'pointerdown':
             return 1; // PointerEventType.Press
           case 'pointerup':
-          case 'pointercancel':
             return 2; // PointerEventType.Release
           case 'pointermove':
             return 3; // PointerEventType.Move


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-10249


On web targets, `pointercancel` events were mapped to `PointerEventType.Release` in `getPointerEventCode`, which is semantically wrong. `pointercancel` is fired when the browser takes over the gesture (native scrolling, system back-swipe, palm rejection, pointer-lock break, device disconnect, etc.) — not when the user releases the pointer normally.

Treating it as `Release` leaves Compose with stale pointer state: `activeTouchPointers` and `actualActivePointerButtons` are not cleared in a way that matches the platform semantics, and the DOM-level pointer capture stays attached to the target.

This change makes web behaviour consistent with how `ACTION_CANCEL` is handled on Android and `UITouchPhase.cancelled` on iOS:

- Detect `pointercancel` early in `onPointerEvent` and short-circuit the regular Press/Move/Release path.
- Clear the appropriate active-pointer trackers (`activeTouchPointers` + `activeTouchOffset` for touch, `actualActivePointerButtons` otherwise).
- Release the DOM pointer capture on the event target via a new `releasePointerCapture` helper (mirroring the existing `setPointerCapture`).
- Forward the cancellation to the scene via `scene.cancelPointerInput()` instead of dispatching a synthetic Release event.

The `case 'pointercancel'` branch in `getPointerEventCode` is removed because the event is now handled before that function is reached.

A small `isTouchEvent` JS helper is added alongside the existing `isMouseEvent` to keep the pointer-type check on the JS side.

## Testing
Manual + `./gradlew webTest`.

Repro: start a touch drag/press in a web build and trigger a browser-level gesture that cancels the pointer (e.g. iOS Safari back-swipe, palm rejection on Android Chrome, dragging out of the window with `pointercancel` fired by the browser). Without the fix, Compose keeps the pointer in a pressed state after the cancellation; with the fix, the gesture is properly cancelled.

## Release Notes
### Fixes - Web
- Fixed pointer state remaining active when the browser cancels a pointer via `pointercancel` (system gestures, palm rejection, device disconnect, etc.)
