### PR TITLE
Use `screenDensity` to layout interop views

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.ios.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.findRootCoordinates
+import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.toCGRect
 import androidx.compose.ui.unit.roundToIntRect
@@ -69,11 +70,9 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
      * The UIView to be embedded in the wrapping view.
      */
     protected abstract val userComponentView: UIView
-
     private var currentUnclippedRect: IntRect? = null
     private var currentClippedRect: IntRect? = null
     private var currentUserComponentRect: IntRect? = null
-
     private val layout = UIKitInteropElementLayout(group = group, userComponent = userComponentView)
     override val measurePolicy: MeasurePolicy get() = layout.measurePolicy
 
@@ -94,6 +93,7 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
 
     override fun layoutAccordingTo(layoutCoordinates: LayoutCoordinates) {
         val rootCoordinates = layoutCoordinates.findRootCoordinates()
+        val screenDensity = container.root.density
 
         val unclippedRect = rootCoordinates
             .localBoundingBoxOf(
@@ -116,11 +116,11 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
         if (clippedRect != currentClippedRect) {
             val groupFrame = clippedRect
                 .toRect()
-                .toDpRect(density)
+                .toDpRect(screenDensity)
                 .toCGRect()
             val groupAccessibilityFrame = unclippedRect
                 .toRect()
-                .toDpRect(density)
+                .toDpRect(screenDensity)
                 .toCGRect()
 
             container.scheduleUpdate {
@@ -147,7 +147,7 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
             if (userComponentRect != currentUserComponentRect) {
                 val userComponentCGRect = userComponentRect
                     .toRect()
-                    .toDpRect(density)
+                    .toDpRect(screenDensity)
                     .toCGRect()
 
                 container.scheduleUpdate {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -41,9 +41,9 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.asDpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toDpSize
 import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.Popup
@@ -278,7 +278,7 @@ class LocalDensityTest {
 
         assertEquals(
             expected = interopSize,
-            actual = interopView.frame.useContents { size.asDpSize() }
+            actual = interopView.frame.useContents { size.toDpSize() }
         )
 
         densityScale = 2f
@@ -286,7 +286,7 @@ class LocalDensityTest {
 
         assertEquals(
             expected = (interopSize * densityScale),
-            actual = interopView.frame.useContents { size.asDpSize() }
+            actual = interopView.frame.useContents { size.toDpSize() }
         )
     }
 
@@ -327,7 +327,7 @@ class LocalDensityTest {
                 width = screenSize.width - padding * 2 * densityScale,
                 height = interopHeight * densityScale
             ),
-            actual = interopView.frame.useContents { size.asDpSize() },
+            actual = interopView.frame.useContents { size.toDpSize() },
         )
 
         assertEquals(
@@ -349,7 +349,7 @@ class LocalDensityTest {
                 width = screenSize.width - padding * 2 * densityScale,
                 height = interopHeight * densityScale
             ),
-            actual = interopView.frame.useContents { size.asDpSize() },
+            actual = interopView.frame.useContents { size.toDpSize() },
         )
 
         assertEquals(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -16,21 +16,46 @@
 
 package androidx.compose.ui.layers
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.DpRectZero
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.asDpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.Popup
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import platform.UIKit.UIButton
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlStateNormal
+import platform.UIKit.UIView
 
 class LocalDensityTest {
     @Test
@@ -227,5 +252,115 @@ class LocalDensityTest {
         waitForIdle()
 
         assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testInteropViewSizeScaledCustomDensity() = runUIKitInstrumentedTest {
+        val interopSize = DpSize(20.dp, 20.dp)
+        var densityScale by mutableFloatStateOf(1f)
+        val interopView = UIView()
+
+        setContent {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                val density = LocalDensity.current.density
+                CompositionLocalProvider(LocalDensity provides Density(densityScale * density)) {
+                    UIKitView(
+                        factory = { interopView },
+                        modifier = Modifier.size(interopSize)
+                    )
+                }
+            }
+        }
+
+        assertEquals(
+            expected = interopSize,
+            actual = interopView.frame.useContents { size.asDpSize() }
+        )
+
+        densityScale = 2f
+        waitForIdle()
+
+        assertEquals(
+            expected = (interopSize * densityScale),
+            actual = interopView.frame.useContents { size.asDpSize() }
+        )
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testInteropViewPositionForCustomDensity() = runUIKitInstrumentedTest {
+        val interopHeight = 100.dp
+        val padding = 10.dp
+        var densityScale by mutableFloatStateOf(1f)
+        var interopViewRect = DpRectZero()
+        val interopView = UIButton().also {
+            it.setTitle("TAP", forState = UIControlStateNormal)
+            it.backgroundColor = UIColor.redColor
+        }
+
+        setContent {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopStart
+            ) {
+                val density = LocalDensity.current
+                CompositionLocalProvider(LocalDensity provides Density(densityScale * density.density)) {
+                    val currentDensity = LocalDensity.current
+                    UIKitView(
+                        factory = { interopView },
+                        modifier = Modifier
+                            .padding(padding)
+                            .fillMaxWidth()
+                            .height(interopHeight)
+                            .onGloballyPositioned { interopViewRect = it.boundsInWindow().toDpRect(currentDensity) }
+                    )
+                }
+            }
+        }
+
+        assertEquals(
+            expected = DpSize(
+                width = screenSize.width - padding * 2 * densityScale,
+                height = interopHeight * densityScale
+            ),
+            actual = interopView.frame.useContents { size.asDpSize() },
+        )
+
+        assertEquals(
+            expected = DpRect(
+                origin = DpOffset(padding, padding),
+                size = DpSize(
+                    width = (screenSize.width - padding.times(2f)).times(1f / densityScale),
+                    height = interopHeight
+                )
+            ),
+            actual = interopViewRect,
+        )
+
+        densityScale = 2f
+        waitForIdle()
+
+        assertEquals(
+            expected = DpSize(
+                width = screenSize.width - padding * 2 * densityScale,
+                height = interopHeight * densityScale
+            ),
+            actual = interopView.frame.useContents { size.asDpSize() },
+        )
+
+        assertEquals(
+            expected = DpRect(
+                origin = DpOffset(padding, padding),
+                size = DpSize(
+                    width = (screenSize.width - padding * 2 * densityScale).times(1f / densityScale),
+                    height = interopHeight
+                )
+            ),
+            actual = interopViewRect
+        )
     }
 }


### PR DESCRIPTION
Fixes incorrect scaling and positioning of interop `UIKitView` / `UIKitViewController` when `LocalDensity` is modified

Fixes [CMP-9154](https://youtrack.jetbrains.com/issue/CMP-9154) [iOS] UIKitView interop incorrect position with modified density

## Testing

Tests added to `LocalDensityTest.kt`

## Release Notes
### Fixes - iOS
- Fix incorrect scaling and positioning of interop `UIKitView` / `UIKitViewController` element when `LocalDensity` is modified. This change does not affect scaling of `factory` content: `UIView` / `UIViewController`.


