### PR TITLE
Implement HapticFeedback for web targets

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DefaultHapticFeedback.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DefaultHapticFeedback.web.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsArray
+import kotlin.js.JsNumber
+import kotlin.js.js
+import kotlin.js.toJsArray
+import kotlin.js.toJsNumber
+
+internal class WebHapticFeedback : HapticFeedback {
+    @OptIn(ExperimentalWasmJsInterop::class)
+    override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+        vibrate(vibrationPatternFor(hapticFeedbackType))
+    }
+}
+
+// TODO: to eventually avoid the hardcoded values, follow the new browser API proposal https://github.com/WICG/web-haptics
+// and rely on it once it's implemented
+@OptIn(ExperimentalWasmJsInterop::class)
+internal fun vibrationPatternFor(hapticFeedbackType: HapticFeedbackType): JsArray<JsNumber> =
+    when (hapticFeedbackType) {
+        HapticFeedbackType.Confirm -> vibrationPatternOf(18, 32, 36)
+        HapticFeedbackType.Reject -> vibrationPatternOf(18, 28, 18, 28, 18)
+        HapticFeedbackType.ContextClick,
+        HapticFeedbackType.GestureEnd,
+        HapticFeedbackType.GestureThresholdActivate,
+        HapticFeedbackType.LongPress,
+        HapticFeedbackType.ToggleOff,
+        HapticFeedbackType.ToggleOn,
+        HapticFeedbackType.VirtualKey -> vibrationPatternOf(12)
+        HapticFeedbackType.KeyboardTap,
+        HapticFeedbackType.SegmentFrequentTick,
+        HapticFeedbackType.SegmentTick,
+        HapticFeedbackType.TextHandleMove -> vibrationPatternOf(6)
+        else -> vibrationPatternOf(12)
+    }
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun vibrationPatternOf(vararg durations: Int): JsArray<JsNumber> =
+    durations.map { it.toDouble().toJsNumber() }.toJsArray()
+
+//language=javascript
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun vibrate(pattern: JsArray<JsNumber>) {
+    js(
+        """
+        if (typeof window !== 'undefined' &&
+            window.navigator != null &&
+            typeof window.navigator.vibrate === 'function') {
+            window.navigator.vibrate(pattern)
+        }
+        """
+    )
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DefaultHapticFeedback.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DefaultHapticFeedback.web.kt
@@ -25,48 +25,64 @@ import kotlin.js.js
 import kotlin.js.toJsArray
 import kotlin.js.toJsNumber
 
+@OptIn(ExperimentalWasmJsInterop::class)
 internal class WebHapticFeedback : HapticFeedback {
-    @OptIn(ExperimentalWasmJsInterop::class)
+    // Check if API is supported before doing anything
+    private val isVibrationSupported = isVibrationSupported()
+
+    // Declare these hardcoded patterns to avoid js-interop on every call
+    private val ConfirmVibrationPattern: JsArray<JsNumber> = vibrationPatternOf(18, 32, 36)
+    private val RejectVibrationPattern: JsArray<JsNumber> = vibrationPatternOf(18, 28, 18, 28, 18)
+    private val SinglePulseVibrationPattern: JsArray<JsNumber> = vibrationPatternOf(12)
+    private val SoftTickVibrationPattern: JsArray<JsNumber> = vibrationPatternOf(6)
+
     override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
-        vibrate(vibrationPatternFor(hapticFeedbackType))
+        if (!isVibrationSupported) return
+        val pattern = vibrationPatternFor(hapticFeedbackType) ?: return
+        vibrate(pattern)
+    }
+
+    // We don't have a high-level browser API right now. So we hardcode the patterns here.
+    // TODO: to eventually avoid the hardcoded values, follow the new browser API proposal https://github.com/WICG/web-haptics
+    // and rely on it once it's implemented
+    @OptIn(ExperimentalWasmJsInterop::class)
+    internal fun vibrationPatternFor(hapticFeedbackType: HapticFeedbackType): JsArray<JsNumber>? {
+        return when (hapticFeedbackType) {
+            HapticFeedbackType.Confirm -> ConfirmVibrationPattern
+            HapticFeedbackType.Reject -> RejectVibrationPattern
+            HapticFeedbackType.ContextClick,
+            HapticFeedbackType.GestureEnd,
+            HapticFeedbackType.GestureThresholdActivate,
+            HapticFeedbackType.LongPress,
+            HapticFeedbackType.ToggleOff,
+            HapticFeedbackType.ToggleOn,
+            HapticFeedbackType.VirtualKey -> SinglePulseVibrationPattern
+            HapticFeedbackType.KeyboardTap,
+            HapticFeedbackType.SegmentFrequentTick,
+            HapticFeedbackType.SegmentTick -> SoftTickVibrationPattern
+            HapticFeedbackType.TextHandleMove -> null
+            else -> null
+        }
     }
 }
-
-// TODO: to eventually avoid the hardcoded values, follow the new browser API proposal https://github.com/WICG/web-haptics
-// and rely on it once it's implemented
-@OptIn(ExperimentalWasmJsInterop::class)
-internal fun vibrationPatternFor(hapticFeedbackType: HapticFeedbackType): JsArray<JsNumber> =
-    when (hapticFeedbackType) {
-        HapticFeedbackType.Confirm -> vibrationPatternOf(18, 32, 36)
-        HapticFeedbackType.Reject -> vibrationPatternOf(18, 28, 18, 28, 18)
-        HapticFeedbackType.ContextClick,
-        HapticFeedbackType.GestureEnd,
-        HapticFeedbackType.GestureThresholdActivate,
-        HapticFeedbackType.LongPress,
-        HapticFeedbackType.ToggleOff,
-        HapticFeedbackType.ToggleOn,
-        HapticFeedbackType.VirtualKey -> vibrationPatternOf(12)
-        HapticFeedbackType.KeyboardTap,
-        HapticFeedbackType.SegmentFrequentTick,
-        HapticFeedbackType.SegmentTick,
-        HapticFeedbackType.TextHandleMove -> vibrationPatternOf(6)
-        else -> vibrationPatternOf(12)
-    }
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun vibrationPatternOf(vararg durations: Int): JsArray<JsNumber> =
     durations.map { it.toDouble().toJsNumber() }.toJsArray()
 
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun isVibrationSupported(): Boolean = js(
+    //language=javascript
+    """
+        typeof window !== 'undefined' &&
+        window.navigator != null &&
+        typeof window.navigator.vibrate === 'function'
+    """
+)
+
 //language=javascript
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun vibrate(pattern: JsArray<JsNumber>) {
-    js(
-        """
-        if (typeof window !== 'undefined' &&
-            window.navigator != null &&
-            typeof window.navigator.vibrate === 'function') {
-            window.navigator.vibrate(pattern)
-        }
-        """
-    )
+    // Assuming the API support has been checked in advance, we can safely call it
+    js("window.navigator.vibrate(pattern)")
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -53,11 +53,13 @@ import androidx.compose.ui.internal.focusExt
 import androidx.compose.ui.navigationevent.BackNavigationEventInput
 import androidx.compose.ui.platform.DefaultArchitectureComponentsOwner
 import androidx.compose.ui.platform.DefaultInputModeManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.platform.WebHapticFeedback
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.WebTextToolbar
 import androidx.compose.ui.platform.WebWakeLockManager
@@ -203,6 +205,8 @@ internal class ComposeWindow(
 
     @VisibleForTesting
     internal val archComponentsOwner = DefaultArchitectureComponentsOwner()
+
+    private val hapticFeedback = WebHapticFeedback()
 
     private val navigationEventInput = BackNavigationEventInput()
 
@@ -464,6 +468,7 @@ internal class ComposeWindow(
         scene.setContent {
             CompositionLocalProvider(
                 LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value,
+                LocalHapticFeedback provides hapticFeedback,
                 LocalInteropContainer provides interopContainer,
                 LocalActiveClipEventsTarget provides clipEventsTargetProvider,
                 content = {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebHapticFeedbackTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebHapticFeedbackTest.kt
@@ -19,57 +19,32 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class WebHapticFeedbackTest : OnCanvasTests {
 
     @Test
     fun composeWindowProvidesWebHapticFeedback() = runApplicationTest {
-        var hapticFeedback: Any? = null
+        var hapticFeedback: WebHapticFeedback? = null
 
         createComposeWindow {
-            hapticFeedback = LocalHapticFeedback.current
+            hapticFeedback = LocalHapticFeedback.current as? WebHapticFeedback
         }
 
-        assertIs<WebHapticFeedback>(hapticFeedback)
-    }
+        assertNotNull(hapticFeedback, "LocalHapticFeedback should provide WebHapticFeedback")
+        val pattern = hapticFeedback!!.vibrationPatternFor(HapticFeedbackType.Confirm)
 
-    @Test
-    fun mapsConfirmToMultiPulsePattern() {
-        assertPatternEquals(
-            expected = listOf(18, 32, 36),
-            actual = vibrationPatternFor(HapticFeedbackType.Confirm)
-        )
-    }
+        assertNotNull(pattern, "pattern should not be null")
 
-    @Test
-    fun mapsRejectToErrorPattern() {
-        assertPatternEquals(
-            expected = listOf(18, 28, 18, 28, 18),
-            actual = vibrationPatternFor(HapticFeedbackType.Reject)
-        )
-    }
-
-    @Test
-    fun mapsSelectionAndTextHandleTypesToShortPulse() {
-        assertPatternEquals(
-            expected = listOf(6),
-            actual = vibrationPatternFor(HapticFeedbackType.SegmentTick)
-        )
-        assertPatternEquals(
-            expected = listOf(6),
-            actual = vibrationPatternFor(HapticFeedbackType.TextHandleMove)
-        )
-    }
-
-    private fun assertPatternEquals(expected: List<Int>, actual: dynamic) {
-        val actualValues = js("Array.from(actual)").unsafeCast<Array<Double>>()
-        assertContentEquals(
-            expected.toTypedArray(),
-            actualValues.map(Double::toInt).toTypedArray()
-        )
+        // We can't verify the vibration has been performed,
+        // so just call performHapticFeedback to check that it doesn't fail
+        hapticFeedback!!.performHapticFeedback(HapticFeedbackType.Confirm)
     }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebHapticFeedbackTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebHapticFeedbackTest.kt
@@ -1,0 +1,75 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertIs
+
+class WebHapticFeedbackTest : OnCanvasTests {
+
+    @Test
+    fun composeWindowProvidesWebHapticFeedback() = runApplicationTest {
+        var hapticFeedback: Any? = null
+
+        createComposeWindow {
+            hapticFeedback = LocalHapticFeedback.current
+        }
+
+        assertIs<WebHapticFeedback>(hapticFeedback)
+    }
+
+    @Test
+    fun mapsConfirmToMultiPulsePattern() {
+        assertPatternEquals(
+            expected = listOf(18, 32, 36),
+            actual = vibrationPatternFor(HapticFeedbackType.Confirm)
+        )
+    }
+
+    @Test
+    fun mapsRejectToErrorPattern() {
+        assertPatternEquals(
+            expected = listOf(18, 28, 18, 28, 18),
+            actual = vibrationPatternFor(HapticFeedbackType.Reject)
+        )
+    }
+
+    @Test
+    fun mapsSelectionAndTextHandleTypesToShortPulse() {
+        assertPatternEquals(
+            expected = listOf(6),
+            actual = vibrationPatternFor(HapticFeedbackType.SegmentTick)
+        )
+        assertPatternEquals(
+            expected = listOf(6),
+            actual = vibrationPatternFor(HapticFeedbackType.TextHandleMove)
+        )
+    }
+
+    private fun assertPatternEquals(expected: List<Int>, actual: dynamic) {
+        val actualValues = js("Array.from(actual)").unsafeCast<Array<Double>>()
+        assertContentEquals(
+            expected.toTypedArray(),
+            actualValues.map(Double::toInt).toTypedArray()
+        )
+    }
+}


### PR DESCRIPTION
 Fixes https://youtrack.jetbrains.com/issue/CMP-7656/Web.-Support-Haptic-Feedback
 
 Solution:
 - Since there is no high-level haptic browser API right now, the solution relies on the Vibraion API with hardcoded patterns.
 - In the future, we'll consider migrating to the high-level API once it's implemented - https://github.com/WICG/web-haptics
 
 Supported browsers:
 - only Chromium-based. see the doc - https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API

## Testing
- added a simple smoke test 
- This should be tested by QA

## Release Notes
### Features - Web
- Support haptic feedback on web targets
