### PR TITLE
Fix `GraphicsLayerOwnerLayer.getInverseMatrix`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
@@ -362,18 +362,22 @@ internal class GraphicsLayerOwnerLayer(
     }
 
     private fun getInverseMatrix(): Matrix? {
+        val matrix = getMatrix()
+        if (isIdentity) {
+            return matrix
+        }
+
         val inverseMatrix = inverseMatrixCache ?: Matrix().also { inverseMatrixCache = it }
         if (!isInverseMatrixDirty) {
-            if (inverseMatrix[0, 0].isNaN()) {
-                return null
+            return if (inverseMatrix[0, 0].isNaN()) {
+                null
+            } else {
+                inverseMatrix
             }
-            return inverseMatrix
         }
+
         isInverseMatrixDirty = false
-        val matrix = getMatrix()
-        return if (isIdentity) {
-            matrix
-        } else if (matrix.invertTo(inverseMatrix)) {
+        return if (matrix.invertTo(inverseMatrix)) {
             inverseMatrix
         } else {
             inverseMatrix[0, 0] = Float.NaN

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
@@ -22,8 +22,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
+import androidx.compose.ui.assertThat
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isFinite
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.node.OwnedLayer
@@ -570,6 +572,19 @@ class OwnerLayerTest {
         assertTrue(graphicsContext!!.layers.contains(layer.graphicsLayer))
         layer.destroy()
         assertFalse(graphicsContext!!.layers.contains(layer.graphicsLayer))
+    }
+
+    @Test
+    fun inverseMatrixCalculationOnChangeFromNonInvertibleToIdentityMatrix() {
+        val layer = TestRenderNodeLayer()
+        layer.updateProperties(scaleX = 0f)
+        assertFalse(layer.mapOffset(Offset.Zero, inverse = true).isFinite)
+        layer.updateProperties(scaleX = 1f)
+        layer.underlyingMatrix
+
+        // This is not an accidental duplicate line! the bug was on the 2nd call to getInverseMatrix
+        assertTrue(layer.mapOffset(Offset.Zero, inverse = true).isFinite)
+        assertTrue(layer.mapOffset(Offset.Zero, inverse = true).isFinite)
     }
 
     private var graphicsContext: TestGraphicsContext? = null


### PR DESCRIPTION
The current code is:

```
private fun getInverseMatrix(): Matrix? {
    val inverseMatrix = inverseMatrixCache ?: Matrix().also { inverseMatrixCache = it }
    if (!isInverseMatrixDirty) {
        if (inverseMatrix[0, 0].isNaN()) {
            return null
        }
        return inverseMatrix
    }
    isInverseMatrixDirty = false
    val matrix = getMatrix()
    return if (isIdentity) {
        matrix
    } else if (matrix.invertTo(inverseMatrix)) {
        inverseMatrix
    } else {
        inverseMatrix[0, 0] = Float.NaN
        null
    }
}
```

The scenario:
1. matrix is set to a non-invertible one
2. `getInverseMatrix` is called and `inverseMatrix[0, 0]` is set to `NaN`
3. `updateLayerProperties` is called and both `isMatrixDirty` and `isInverseMatrixDirtyare` set to `true`.
4. `getMatrix()` is called, calling `updateMatrix()`, which recomputes `matrixCache` and sets its value to the identity matrix, and `isIdentity` to `true`.
5. `getInverseMatrix` is called, and since `isInverseMatrixDirty` is true, it goes to the 2nd part, but there `isIdentity` is true, so it just returns `matrix`, **without updating `inverseMatrixCache`**, and sets isInverseMatrixDirty = false.
6. `getInverseMatrix` is called again, but this time `isInverseMatrixDirty` is `false`, so it looks at `inverseMatrix[0, 0]`, which is `NaN`, and it returns `null`.

Fixes https://youtrack.jetbrains.com/issue/CMP-9341

I've also reported it to Google, so they can fix their version of `GraphicsLayerOwnerLayer`.

## Testing
Added a unit test.

## Release Notes
### Fixes - Multiple Platforms
- Fixed a deep bug in matrix computation which caused pointer hit-paths to not be computed correctly sometimes, leading to elements that could not be interacted with via the mouse or touch.
