### PR TITLE
Fix RTL cursor crash in SkiaParagraph#getBoxBackwardByOffset

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -380,7 +380,7 @@ internal class SkiaParagraph(
                     return if (!isRtl) {
                         val bottom = box.rect.bottom + box.rect.bottom - box.rect.top
                         val rect = SkRect(0f, box.rect.bottom, 0f, bottom)
-                        return TextBox(rect, box.direction)
+                        TextBox(rect, box.direction)
                     } else {
                         // For RTL:
                         // When cursor changes its position across lines, we apply the following rules:
@@ -399,10 +399,10 @@ internal class SkiaParagraph(
                             TextBox(rect, box.direction)
                         } else {
                             // TODO: Use unicode code points (CodePoint.charCount() instead of +1)
-                            val nextBox =  paragraph.getRectsForRange(
+                            val nextBox = paragraph.getRectsForRange(
                                 offset, offset + 1,
                                 RectHeightMode.STRUT, RectWidthMode.TIGHT
-                            ).first()
+                            ).firstOrNull() ?: return null
                             val rect = SkRect(
                                 nextBox.rect.left, nextBox.rect.top,
                                 nextBox.rect.left, nextBox.rect.bottom

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -402,6 +402,7 @@ internal class SkiaParagraph(
                             val nextBox = paragraph.getRectsForRange(
                                 offset, offset + 1,
                                 RectHeightMode.STRUT, RectWidthMode.TIGHT
+//                            ).first()
                             ).firstOrNull() ?: return null
                             val rect = SkRect(
                                 nextBox.rect.left, nextBox.rect.top,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -402,7 +402,6 @@ internal class SkiaParagraph(
                             val nextBox = paragraph.getRectsForRange(
                                 offset, offset + 1,
                                 RectHeightMode.STRUT, RectWidthMode.TIGHT
-//                            ).first()
                             ).firstOrNull() ?: return null
                             val rect = SkRect(
                                 nextBox.rect.left, nextBox.rect.top,

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -446,6 +447,33 @@ class SkikoParagraphTest {
 
         // Verify paragraph was created successfully without crashing
         assertEquals(1, paragraph.lineCount)
+    }
+
+    // Regression test for https://youtrack.jetbrains.com/issue/CMP-10034
+    @Test
+    fun getCursorRect_doesNotCrash_inRtlParagraphsWithNewlinesAndSpecialCharacters() {
+        val problemTexts = listOf(
+            // Arabic with diacritics across a newline: "اّ\nبَ"
+            "\u0627\u0651\n\u0628\u064E",
+            // Hebrew followed by newline and emoji: "אב\n😀"
+            "\u05D0\u05D1\n\uD83D\uDE00",
+            // RTL with multiple newlines and combining marks: "א\nבְ\nג"
+            "\u05D0\n\u05D1\u05B0\n\u05D2",
+            // Newline at start: "\nאב"
+            "\n\u05D0\u05D1",
+            // Newline followed by combining mark: "א\nְב"
+            "\u05D0\n\u05B0\u05D1",
+        )
+
+        for (text in problemTexts) {
+            val paragraph = simpleParagraph(
+                text = text,
+                textStyle = TextStyle(textDirection = TextDirection.Rtl, fontSize = 20.sp)
+            )
+            for (offset in 0..text.length) {
+                paragraph.getCursorRect(offset)
+            }
+        }
     }
 
     private fun simpleParagraph(text: String, textStyle: TextStyle = TextStyle()) = Paragraph(


### PR DESCRIPTION
Fixed crash in getBoxBackwardByOffset with RTL text containing newlines followed by combining marks

Fixes:
[CMP-10034 SkiaParagraph.getBoxBackwardByOffset crashes: .first() on empty array in RTL branch](https://youtrack.jetbrains.com/issue/CMP-10034)

## Testing
Added autotest in Skiko
`getCursorRect_doesNotCrash_inRtlParagraphsWithNewlinesAndSpecialCharacters()`

## Release Notes
### Fixes - Multiple Platforms
Fixed a crash in RTL text cursor positioning when paragraphs contain newlines followed by emojis or combining marks
