### PR TITLE
Clean up the nodes collection in ComposeWebSemanticsListener

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.w3c.dom.HTMLElement
 
 internal class ComposeWebSemanticsListener(
@@ -216,7 +218,11 @@ internal class ComposeWebSemanticsListener(
             }
         }
 
-        removedIds.forEach { webNodes.remove(it) }
+        removedIds.forEach {
+            webNodes.remove(it)
+            nodes.remove(it)
+            nodeToParent.remove(it)
+        }
     }
 
     private fun syncNode(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -61,7 +61,6 @@ import org.w3c.dom.get
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
-//@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
 class CfWA11YTest : OnCanvasTests {
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -61,6 +62,7 @@ import org.w3c.dom.get
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
+@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
 class CfWA11YTest : OnCanvasTests {
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -20,18 +20,20 @@
 
 package androidx.compose.ui.platform.a11y
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.currentTimeMillis
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,7 +61,7 @@ import org.w3c.dom.get
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
-@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
+//@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
 class CfWA11YTest : OnCanvasTests {
 
     @Test
@@ -480,5 +482,73 @@ class CfWA11YTest : OnCanvasTests {
 
         assertEquals("textbox", textField.getAttribute("role"))
         assertEquals("Hello, World!", textField.innerText)
+    }
+
+    @Test // A reproducer for https://youtrack.jetbrains.com/issue/CMP-10226
+    fun nodeReappearsAfterSemanticsModifierToggle() = runApplicationTest {
+        // A LayoutNode that gains/loses a semantic modifier alternates between
+        // being a semantic node (in the a11y tree with its own semanticsId)
+        // and being "transparent" (fillOneLayerOfSemanticsWrappers recurses
+        // through it). The same semanticsId reappears when the modifier is re-added.
+        var addSemantics by mutableStateOf(true)
+
+        createComposeWindow {
+            Column(
+                modifier = if (addSemantics) Modifier.testTag("myColumn") else Modifier
+            ) {
+                Text("ChildText")
+            }
+        }
+
+        awaitA11YChanges()
+        val a11yContainer = getA11YContainer()!!
+        assertTrue(a11yContainer.innerHTML.contains("ChildText"))
+        assertNotNull(getShadowRoot().getElementById("myColumn"))
+
+        // Remove semantic modifier: Column becomes transparent in the semantic tree
+        addSemantics = false
+        awaitA11YChanges()
+        assertNull(getShadowRoot().getElementById("myColumn"))
+
+        // Re-add semantic modifier: same LayoutNode, same semanticsId reappears.
+        // Without proper cleanup of tracking maps, this would crash with "Node $id not found".
+        addSemantics = true
+        awaitA11YChanges()
+        assertNotNull(getShadowRoot().getElementById("myColumn"))
+        assertTrue(a11yContainer.innerHTML.contains("ChildText"))
+    }
+
+    @Test // Reproduces the user-reported scenario from CMP-10226
+    fun spacerReappearsAfterGraphicsLayerClipToggle() = runApplicationTest {
+        // graphicsLayer sets Shape semantics ONLY when clip=true
+        // When the clip modifier is conditionally applied, the Spacer's only semantic property
+        // (Shape) appears and disappears, causing the Spacer to enter/leave the semantic tree
+        // while keeping the same LayoutNode and semanticsId.
+        var enableClip by mutableStateOf(true)
+
+        createComposeWindow {
+            // Conditionally add/remove the entire graphicsLayer modifier so
+            // the modifier chain rebuild triggers semantics invalidation.
+            Spacer(
+                modifier = if (enableClip)
+                    Modifier.graphicsLayer(clip = true, shape = RectangleShape)
+                else Modifier
+            )
+            Text("Sibling")
+        }
+
+        awaitA11YChanges()
+        val a11yContainer = getA11YContainer()!!
+        assertTrue(a11yContainer.innerHTML.contains("Sibling"))
+
+        // Remove clip modifier: Spacer loses Shape semantic → leaves the semantic tree
+        enableClip = false
+        awaitA11YChanges()
+
+        // Re-add clip modifier: same LayoutNode, same semanticsId reappears with Shape semantic.
+        // Without proper cleanup of tracking maps, this would crash with "Node $id not found".
+        enableClip = true
+        awaitA11YChanges()
+        assertTrue(a11yContainer.innerHTML.contains("Sibling"))
     }
 }


### PR DESCRIPTION
This fixes an unexpected situation - error("Node $currentId not found")

Fixes https://youtrack.jetbrains.com/issue/CMP-10226

Solution:
- clean up the nodes collection too

## Testing
- Added the tests
- This should be tested by QA

## Release Notes
### Fixes - Web
- Fix an unexected crash in A11Y:  `Node $id not found` 
