### PR TITLE
Fix flaky CfWA11YTest

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.sync.withLock
 import org.w3c.dom.HTMLElement
 
 internal class ComposeWebSemanticsListener(
-    val coroutineScope: CoroutineScope,
     val webSemanticsRoot: HTMLElement,
 ) : PlatformContext.SemanticsOwnerListener {
 
@@ -57,7 +56,7 @@ internal class ComposeWebSemanticsListener(
         const val DEBOUNCE_MS = 100L
     }
 
-    init {
+    internal fun start(coroutineScope: CoroutineScope) {
         // Here we do the following:
         // - Every invalidation doesn't trigger an a11y tree sync immediately, but only after the changes have settled (debounce 100ms).
         // - We track the time spent in "debounce", so eventually it must sync the a11y tree despite no pause in invalidation events (the changes couldn't settle).

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.util.fastJoinToString
 import kotlin.js.js
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
-import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
@@ -39,9 +38,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.w3c.dom.HTMLElement
 
 internal class ComposeWebSemanticsListener(

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.util.fastJoinToString
 import kotlin.js.js
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
+import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.w3c.dom.HTMLElement
 
 internal class ComposeWebSemanticsListener(
@@ -75,6 +77,15 @@ internal class ComposeWebSemanticsListener(
                                              | No forced sync here, because the debouncing has just started
          */
         coroutineScope.launch {
+            suspendCancellableCoroutine { continuation ->
+                // tmp. just looking at CI behaviour
+                window.requestAnimationFrame {
+                    window.requestAnimationFrame {
+                        continuation.resumeWith(Result.success(Unit))
+                    }
+                }
+            }
+
             var timeSpentDebouncing = 0L
             var lastDebouncedTime = 0L
             var lastSyncTime = currentTimeMillis()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -54,6 +54,11 @@ internal class ComposeWebSemanticsListener(
         const val DEBOUNCE_MS = 100L
     }
 
+
+    /**
+     * @param coroutineScope The [CoroutineScope] used to run this listener,
+     * typically the composition scope so the listener follows the composition lifecycle.
+     */
     internal fun start(coroutineScope: CoroutineScope) {
         // Here we do the following:
         // - Every invalidation doesn't trigger an a11y tree sync immediately, but only after the changes have settled (debounce 100ms).

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -77,15 +77,6 @@ internal class ComposeWebSemanticsListener(
                                              | No forced sync here, because the debouncing has just started
          */
         coroutineScope.launch {
-            suspendCancellableCoroutine { continuation ->
-                // tmp. just looking at CI behaviour
-                window.requestAnimationFrame {
-                    window.requestAnimationFrame {
-                        continuation.resumeWith(Result.success(Unit))
-                    }
-                }
-            }
-
             var timeSpentDebouncing = 0L
             var lastDebouncedTime = 0L
             var lastSyncTime = currentTimeMillis()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -173,6 +173,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     override fun sizeFlow() = channel.receiveAsFlow()
 }
 
+@VisibleForTesting
 // This value is for internal usage, for example, to call ComposeWindow.dispose() in the tests
 internal val LocalComposeWindow: ProvidableCompositionLocal<ComposeWindow?> = staticCompositionLocalOf {
     error("ComposeWindow is not available in this composition")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -491,6 +491,9 @@ internal class ComposeWindow(
                     if (webSemanticsListener != null) {
                         LaunchedEffect(Unit) {
                             coroutineScope {
+                                // The initial composition would create a lot of noisy invalidations,
+                                // so it makes sense to start the listener here - after the initial composition.
+                                // The composition's coroutine scope ties the listener's lifetime to the composition.
                                 webSemanticsListener.start(this)
                             }
                         }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
 import androidx.compose.ui.events.EventTargetListener
@@ -169,6 +171,10 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     }
 
     override fun sizeFlow() = channel.receiveAsFlow()
+}
+
+internal val LocalComposeWindow: ProvidableCompositionLocal<ComposeWindow?> = staticCompositionLocalOf {
+    error("ComposeWindow is not available in this composition")
 }
 
 @OptIn(InternalComposeApi::class)
@@ -466,6 +472,7 @@ internal class ComposeWindow(
                 LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value,
                 LocalInteropContainer provides interopContainer,
                 LocalActiveClipEventsTarget provides clipEventsTargetProvider,
+                LocalComposeWindow provides this,
                 content = {
                     interopContainer.TrackInteropPlacementContainer {
                         content()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -250,7 +250,6 @@ internal class ComposeWindow(
             override val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? =
                 if (configuration.isA11YEnabled) {
                     ComposeWebSemanticsListener(
-                        coroutineScope = MainScope(),
                         webSemanticsRoot = a11yContainerElement?.apply {
                             setAttribute("aria-label", "")
                             setAttribute("role", "presentation")
@@ -477,6 +476,15 @@ internal class ComposeWindow(
                             // Convert to proper type: IntSize was exposed to public API with meaning of DPs.
                             val boxSize = DpSize(size.width.dp, size.height.dp)
                             this@ComposeWindow.resize(boxSize)
+                        }
+                    }
+
+                    val webSemanticsListener = platformContext.semanticsOwnerListener as? ComposeWebSemanticsListener
+                    if (webSemanticsListener != null) {
+                        LaunchedEffect(Unit) {
+                            coroutineScope {
+                                webSemanticsListener.start(this)
+                            }
                         }
                     }
                 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -173,6 +173,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     override fun sizeFlow() = channel.receiveAsFlow()
 }
 
+// This value is for internal usage, for example, to call ComposeWindow.dispose() in the tests
 internal val LocalComposeWindow: ProvidableCompositionLocal<ComposeWindow?> = staticCompositionLocalOf {
     error("ComposeWindow is not available in this composition")
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -23,7 +23,15 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.window.ComposeViewport
 import androidx.compose.ui.window.ComposeViewportConfiguration
+import androidx.compose.ui.window.ComposeWindow
+import androidx.compose.ui.window.LocalComposeWindow
 import kotlin.coroutines.suspendCoroutine
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsReference
+import kotlin.js.get
+import kotlin.js.js
+import kotlin.js.toJsReference
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -67,19 +75,26 @@ private external interface CanReplaceChildren {
     fun replaceChildren()
 }
 
+@OptIn(ExperimentalWasmJsInterop::class)
 internal interface OnCanvasTests {
 
-    @BeforeTest
-    fun beforeTest() {
-        /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
-        see https://youtrack.jetbrains.com/issue/KT-61888
-         */
+    @AfterTest
+    fun afterTest() {
+        composeWindow?.dispose()
+        composeWindow = null
         resetCanvas()
     }
 
     private fun resetCanvas() {
         (getContainer() as CanReplaceChildren).replaceChildren()
     }
+
+    var composeWindow: ComposeWindow?
+        get() = getStoredComposeWindow(getContainer())?.get()
+        set(value) {
+            val jsReference = value?.toJsReference()
+            storeComposeWindow(getContainer(), jsReference)
+        }
 
     /*
     <container>
@@ -106,7 +121,10 @@ internal interface OnCanvasTests {
         configure: ComposeViewportConfiguration.() -> Unit = {},
         content: @Composable () -> Unit
     ) {
-        ComposeViewport(viewportContainerId = containerId, configure = configure, content = content)
+        ComposeViewport(viewportContainerId = containerId, configure = configure, content = {
+            composeWindow = LocalComposeWindow.current
+            content()
+        })
 
         withContext(Dispatchers.Default) {
             val timeoutDuration = 1.seconds
@@ -252,3 +270,10 @@ internal external class ExtendedShadowRoot : ShadowRoot {
 
     fun elementFromPoint(x: Double, y: Double): Element
 }
+
+private fun storeComposeWindow(container: Element, ref: JsReference<ComposeWindow>?) {
+    js("container.composeWindow = ref")
+}
+
+private fun getStoredComposeWindow(container: Element): JsReference<ComposeWindow>? =
+    js("container.composeWindow")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -89,7 +89,7 @@ internal interface OnCanvasTests {
         (getContainer() as CanReplaceChildren).replaceChildren()
     }
 
-    var composeWindow: ComposeWindow?
+    private var composeWindow: ComposeWindow?
         get() = getStoredComposeWindow(getContainer())?.get()
         set(value) {
             val jsReference = value?.toJsReference()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -282,6 +282,8 @@ internal external class ExtendedShadowRoot : ShadowRoot {
     fun elementFromPoint(x: Double, y: Double): Element
 }
 
+// OnCanvasTests is an interface, so it can't have a backing field for composeWindow.
+// We store the reference as a JS property on the DOM container element instead.
 private fun storeComposeWindow(container: Element, ref: JsReference<ComposeWindow>?) {
     js("container._composeWindowRef = ref")
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -131,7 +132,7 @@ internal interface OnCanvasTests {
             try {
                 // Using withTimeout here for diagnostic. Some flaky tests fail due to timeout. But there is nothing else except this suspend call.
                 withTimeout(timeoutDuration) {
-                    suspendCoroutine<Unit> { continuation ->
+                    suspendCancellableCoroutine<Unit> { continuation ->
                         // This helps reduce the flakiness.
                         // A potential cause of flakiness: the default Coroutine Dispatcher regularly postpones
                         // the resumption of the tasks in its queue to the next frame.

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.window.ComposeViewport
 import androidx.compose.ui.window.ComposeViewportConfiguration
 import androidx.compose.ui.window.ComposeWindow
 import androidx.compose.ui.window.LocalComposeWindow
-import kotlin.coroutines.suspendCoroutine
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.JsReference
 import kotlin.js.get
@@ -79,8 +78,19 @@ private external interface CanReplaceChildren {
 @OptIn(ExperimentalWasmJsInterop::class)
 internal interface OnCanvasTests {
 
+    @BeforeTest
+    fun beforeTest() {
+        // We call ensureCleanState in both beforeTest and afterTest to ensure the clean initial state,
+        // since afterTest might fail due to timeout, etc.
+        ensureCleanState()
+    }
+
     @AfterTest
     fun afterTest() {
+        ensureCleanState()
+    }
+
+    private fun ensureCleanState() {
         composeWindow?.dispose()
         composeWindow = null
         resetCanvas()
@@ -163,7 +173,7 @@ internal interface OnCanvasTests {
             }
         }
 
-        suspendCoroutine { continuation ->
+        suspendCancellableCoroutine { continuation ->
             val initialContent = a11yContainer.innerHTML
             skipFramesUntil(
                 condition = { a11yContainer.innerHTML != initialContent },
@@ -231,7 +241,7 @@ internal class WebApplicationScope(
      * due to DomInputStrategy implementation relying on animation frame events.
      */
     internal suspend fun awaitAnimationFrame() {
-        suspendCoroutine { continuation ->
+        suspendCancellableCoroutine { continuation ->
             window.requestAnimationFrame { continuation.resumeWith(Result.success(Unit)) }
         }
     }
@@ -273,8 +283,8 @@ internal external class ExtendedShadowRoot : ShadowRoot {
 }
 
 private fun storeComposeWindow(container: Element, ref: JsReference<ComposeWindow>?) {
-    js("container.composeWindow = ref")
+    js("container._composeWindowRef = ref")
 }
 
 private fun getStoredComposeWindow(container: Element): JsReference<ComposeWindow>? =
-    js("container.composeWindow")
+    js("container._composeWindowRef")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -95,7 +95,7 @@ internal interface OnCanvasTests {
       <positioning_container/>
     </container>
     */
-    private fun getContainer() = document.getElementById(containerId) ?: error("failed to get canvas with id ${containerId}")
+    fun getContainer() = document.getElementById(containerId) ?: error("failed to get canvas with id ${containerId}")
     private fun getPositioningContainer() = getContainer().children[0] ?: error("failed to get positioning container")
     fun getShadowRoot() = (getPositioningContainer().children[0]?.shadowRoot as? ExtendedShadowRoot) ?: error("failed to get shadowRoot")
     private fun getAppRoot() = getShadowRoot().children[1] as? HTMLElement ?: error("failed to get app root")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -128,14 +128,13 @@ internal interface OnCanvasTests {
         }
     }
 
-    suspend fun awaitA11YChanges(timeout: Duration = 2.seconds) {
+    suspend fun awaitA11YChanges(timeout: Duration = 5.seconds) {
         val a11yContainer = getA11YContainer() ?: return
-        var prevTime = currentTimeMillis()
+        val startTime = currentTimeMillis()
 
         fun skipFramesUntil(condition: () -> Boolean, onTrue: () -> Unit) {
             val currentTime = currentTimeMillis()
-            assertTrue(currentTime - prevTime < timeout.inWholeMilliseconds, "awaitA11YChanges timed out after $timeout")
-            prevTime = currentTime
+            assertTrue(currentTime - startTime < timeout.inWholeMilliseconds, "awaitA11YChanges timed out after $timeout")
             window.requestAnimationFrame {
                 if (!condition()) {
                     skipFramesUntil(condition, onTrue)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -62,7 +62,6 @@ import org.w3c.dom.get
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
-//@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
 class CfWA11YTest : OnCanvasTests {
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -62,11 +62,12 @@ import org.w3c.dom.get
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
-@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
+//@Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest.a11yButtonClick-is-too-flaky
 class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun a11yButtonClick() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var clickCounter = 0
 
         createComposeWindow {
@@ -97,6 +98,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun changesAreApplied() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var clickCounter1 = 0
         var clickCounter2 = 0
 
@@ -158,6 +160,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun orderOfElements() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var show1 by mutableStateOf(true)
         var show2 by mutableStateOf(false)
         var show3 by mutableStateOf(false)
@@ -226,6 +229,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun changesMustBeBatched() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var value by mutableStateOf(0)
 
         var recompositions = 0
@@ -273,6 +277,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun changesMustBeAppliedDespiteConstantDebounceAfter1Second() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var value by mutableStateOf(0)
 
         createComposeWindow {
@@ -328,6 +333,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun noChangesFor1SecondTheDebounceShouldWork() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var show by mutableStateOf(true)
 
         var recompositions = 0
@@ -364,6 +370,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun clickListenerMustBeUpdated() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var clickCounter1 = 0
         var clickCounter2 = 0
 
@@ -412,6 +419,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun noA11YRootAndElementsWithDisabledA11Y() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         createComposeWindow(
             configure = { isA11YEnabled = false }
         ) {
@@ -435,6 +443,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun modifierTestTagIsSetToId() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var showButton by mutableStateOf(true)
         var clickCounter = 0
 
@@ -466,6 +475,7 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun textFieldHasTextBoxRole() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
         var text by mutableStateOf("Hello, World!")
 
         createComposeWindow {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10001/Fix-CfWA11YTest-is-too-flaky

**Changes:**
- Dispose ComposeWindow between tests (this stops the coroutines in obsolete Compositions from finished tests, freeing the resources for the running tests)
- Defer ComposeWebSemanticsListener.start() to after initial composition + use the composition's coroutine scope
- Fix awaitA11YChanges timeout calculation (previously it didn't accumulate the time, so the timeout would almost never happen)
- Use suspendCancellableCoroutine instead of suspendCoroutine 
- Add ensureCleanState in both `@BeforeTest` and `@AfterTest` (added `composeWindow.dispose()` call)
- Add defensive assertions in each CfWA11YTest verifying empty container before composition
- Remove `@Ignore` from CfWA11YTest

## Release Notes
N/A
