### PR TITLE
Poll the system theme in desktop

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
@@ -20,32 +20,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
-import androidx.compose.ui.SystemTheme
+import org.jetbrains.skiko.SystemTheme
 
-/**
- * This function should be used to help build responsive UIs that follow the system setting, to
- * avoid harsh contrast changes when switching between applications.
- *
- * This function returns `true` if the [Configuration.UI_MODE_NIGHT_YES] bit is set. It is
- * also possible for this bit to be [Configuration.UI_MODE_NIGHT_UNDEFINED], in which case
- * light theme is treated as the default, and this function returns `false`.
- *
- * It is also recommended to provide user accessible overrides in your application, so users can
- * choose to force an always-light or always-dark theme. To do this, you should provide the current
- * theme value in a CompositionLocal or similar to components further down your hierarchy, only
- * calling this effect once at the top level if no user override has been set. This also helps
- * avoid multiple calls to this effect, which can be expensive as it queries system configuration.
- *
- * For example, to draw a white rectangle when in dark theme, and a black rectangle when in light
- * theme:
- *
- * @sample androidx.compose.foundation.samples.DarkThemeSample
- *
- * @return `true` if the system is considered to be in 'dark theme'.
- */
 @OptIn(InternalComposeUiApi::class)
 @Composable
 @ReadOnlyComposable
 internal actual fun _isSystemInDarkTheme(): Boolean {
-    return LocalSystemTheme.current == SystemTheme.Dark
+    return LocalSystemTheme.current == SystemTheme.DARK
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/DesktopComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/DesktopComposeUiFlags.skiko.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.ui.platform.DesktopPlatform
+import kotlin.jvm.JvmField
+
+internal object DesktopComposeUiFlags {
+    @Suppress("MutableBareField")
+    @JvmField
+    var pollSystemTheme: Boolean = DesktopPlatform.Current != DesktopPlatform.Linux
+}
+
+/**
+ * Whether the system theme should be polled to allow `isSystemInDarkTheme` to reflect the system
+ * theme as it changes.
+ *
+ * This should be set before any Compose UI is created. Setting it afterward will have no effect
+ * on existing UIs.
+ *
+ * Note that it's a temporary flag, it will be removed in the future.
+ */
+@ExperimentalComposeUiApi
+var ComposeUiFlags.pollSystemTheme by DesktopComposeUiFlags::pollSystemTheme

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jetbrains.skiko.SystemTheme
+
+private var subscriberCount = 0
+private var pollingJob: Job? = null
+private val subscribeLock = Any()
+private var currentSystemTheme = mutableStateOf(SystemTheme.UNKNOWN)
+
+@OptIn(DelicateCoroutinesApi::class)
+private fun onSubscriberAdded() {
+    synchronized(subscribeLock) {
+        if (subscriberCount == 0) {
+            pollingJob = GlobalScope.launch {
+                withContext(Dispatchers.IO) {
+                    pollCurrentSystemTheme()
+                }
+            }
+        }
+        subscriberCount += 1
+    }
+}
+
+private fun onSubscriberRemoved() {
+    synchronized(subscribeLock) {
+        subscriberCount -= 1
+        if (subscriberCount == 0) {
+            pollingJob?.cancel()
+            pollingJob = null
+        }
+    }
+}
+
+private suspend fun pollCurrentSystemTheme() {
+    while (true) {
+        currentSystemTheme.value = org.jetbrains.skiko.currentSystemTheme
+        delay(1.seconds)
+    }
+}
+
+@Composable
+internal fun ProvideSystemTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        LocalSystemTheme provides currentSystemTheme.value,
+        content = content
+    )
+
+    DisposableEffect(Unit) {
+        onSubscriberAdded()
+        onDispose {
+            onSubscriberRemoved()
+        }
+    }
+}
+
+@VisibleForTesting
+internal fun systemThemeSubscriberCount() = subscriberCount
+
+@VisibleForTesting
+internal fun systemThemePollingJob() = pollingJob

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
@@ -37,12 +37,6 @@ private var pollingJob: Job? = null
 private val subscribeLock = Any()
 private var currentSystemTheme = mutableStateOf(org.jetbrains.skiko.currentSystemTheme)
 
-private val pollSystemTheme by lazy {
-    System.getProperty("compose.systemtheme.poll")?.toBoolean() ?: defaultPollSystemTheme()
-}
-
-private fun defaultPollSystemTheme() = !hostOs.isLinux
-
 @OptIn(DelicateCoroutinesApi::class)
 private fun onSubscriberAdded() {
     synchronized(subscribeLock) {
@@ -81,7 +75,7 @@ internal fun ProvideSystemTheme(content: @Composable () -> Unit) {
         content = content
     )
 
-    if (pollSystemTheme) {
+    if (DesktopComposeUiFlags.pollSystemTheme) {
         DisposableEffect(Unit) {
             onSubscriberAdded()
             onDispose {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
@@ -30,12 +30,18 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jetbrains.skiko.SystemTheme
+import org.jetbrains.skiko.hostOs
 
 private var subscriberCount = 0
 private var pollingJob: Job? = null
 private val subscribeLock = Any()
-private var currentSystemTheme = mutableStateOf(SystemTheme.UNKNOWN)
+private var currentSystemTheme = mutableStateOf(org.jetbrains.skiko.currentSystemTheme)
+
+private val pollSystemTheme by lazy {
+    System.getProperty("compose.systemtheme.poll")?.toBoolean() ?: defaultPollSystemTheme()
+}
+
+private fun defaultPollSystemTheme() = !hostOs.isLinux
 
 @OptIn(DelicateCoroutinesApi::class)
 private fun onSubscriberAdded() {
@@ -63,6 +69,7 @@ private fun onSubscriberRemoved() {
 
 private suspend fun pollCurrentSystemTheme() {
     while (true) {
+        println("Polling system theme")
         currentSystemTheme.value = org.jetbrains.skiko.currentSystemTheme
         delay(1.seconds)
     }
@@ -75,10 +82,12 @@ internal fun ProvideSystemTheme(content: @Composable () -> Unit) {
         content = content
     )
 
-    DisposableEffect(Unit) {
-        onSubscriberAdded()
-        onDispose {
-            onSubscriberRemoved()
+    if (pollSystemTheme) {
+        DisposableEffect(Unit) {
+            onSubscriberAdded()
+            onDispose {
+                onSubscriberRemoved()
+            }
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
@@ -69,7 +69,6 @@ private fun onSubscriberRemoved() {
 
 private suspend fun pollCurrentSystemTheme() {
     while (true) {
-        println("Polling system theme")
         currentSystemTheme.value = org.jetbrains.skiko.currentSystemTheme
         delay(1.seconds)
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatform.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatform.desktop.kt
@@ -40,7 +40,7 @@ internal enum class DesktopPlatform {
 
     companion object {
         /**
-         * Identify OS on which the application is currently running.
+         * Identify the operating system on which the application is currently running.
          */
         val Current: DesktopPlatform by lazy {
             val name = System.getProperty("os.name")

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ComposeUiFlags
+import androidx.compose.ui.ProvideSystemTheme
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.DebouncingEdtExecutor
@@ -668,8 +669,10 @@ internal class ComposeSceneMediator(
         runOnceComponentAttached {
             catchExceptions {
                 scene.setContent {
-                    interopContainer {
-                        content()
+                    ProvideSystemTheme {
+                        interopContainer {
+                            content()
+                        }
                     }
                 }
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.platform
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ProvideSystemTheme
+import androidx.compose.ui.systemThemePollingJob
+import androidx.compose.ui.systemThemeSubscriberCount
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SystemThemeTest {
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testSystemThemePollingState() = runComposeUiTest {
+        var provideSystemTheme1 by mutableStateOf(false)
+        var provideSystemTheme2 by mutableStateOf(false)
+        setContent {
+            if (provideSystemTheme1) {
+                ProvideSystemTheme { }
+            }
+            if (provideSystemTheme2) {
+                ProvideSystemTheme { }
+            }
+        }
+
+        assertEquals(0, systemThemeSubscriberCount())
+        assertNull(systemThemePollingJob())
+
+        provideSystemTheme1 = true
+        waitForIdle()
+        assertEquals(1, systemThemeSubscriberCount())
+        assertNotNull(systemThemePollingJob())
+
+        provideSystemTheme2 = true
+        waitForIdle()
+        assertEquals(2, systemThemeSubscriberCount())
+        assertNotNull(systemThemePollingJob())
+
+        provideSystemTheme1 = false
+        provideSystemTheme2 = false
+        waitForIdle()
+        assertEquals(0, systemThemeSubscriberCount())
+        assertNull(systemThemePollingJob())
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
@@ -32,35 +32,47 @@ import kotlin.test.assertNull
 class SystemThemeTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun testSystemThemePollingState() = runComposeUiTest {
-        var provideSystemTheme1 by mutableStateOf(false)
-        var provideSystemTheme2 by mutableStateOf(false)
-        setContent {
-            if (provideSystemTheme1) {
-                ProvideSystemTheme { }
+    fun testSystemThemePollingState() {
+        val prevValue = System.getProperty("compose.systemtheme.poll")
+        System.setProperty("compose.systemtheme.poll", "true")
+        try {
+            runComposeUiTest {
+                var provideSystemTheme1 by mutableStateOf(false)
+                var provideSystemTheme2 by mutableStateOf(false)
+                setContent {
+                    if (provideSystemTheme1) {
+                        ProvideSystemTheme { }
+                    }
+                    if (provideSystemTheme2) {
+                        ProvideSystemTheme { }
+                    }
+                }
+
+                assertEquals(0, systemThemeSubscriberCount())
+                assertNull(systemThemePollingJob())
+
+                provideSystemTheme1 = true
+                waitForIdle()
+                assertEquals(1, systemThemeSubscriberCount())
+                assertNotNull(systemThemePollingJob())
+
+                provideSystemTheme2 = true
+                waitForIdle()
+                assertEquals(2, systemThemeSubscriberCount())
+                assertNotNull(systemThemePollingJob())
+
+                provideSystemTheme1 = false
+                provideSystemTheme2 = false
+                waitForIdle()
+                assertEquals(0, systemThemeSubscriberCount())
+                assertNull(systemThemePollingJob())
             }
-            if (provideSystemTheme2) {
-                ProvideSystemTheme { }
+        } finally {
+            if (prevValue != null) {
+                System.setProperty("compose.systemtheme.poll", prevValue)
+            } else {
+                System.clearProperty("compose.systemtheme.poll")
             }
         }
-
-        assertEquals(0, systemThemeSubscriberCount())
-        assertNull(systemThemePollingJob())
-
-        provideSystemTheme1 = true
-        waitForIdle()
-        assertEquals(1, systemThemeSubscriberCount())
-        assertNotNull(systemThemePollingJob())
-
-        provideSystemTheme2 = true
-        waitForIdle()
-        assertEquals(2, systemThemeSubscriberCount())
-        assertNotNull(systemThemePollingJob())
-
-        provideSystemTheme1 = false
-        provideSystemTheme2 = false
-        waitForIdle()
-        assertEquals(0, systemThemeSubscriberCount())
-        assertNull(systemThemePollingJob())
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/SystemThemeTest.kt
@@ -19,7 +19,9 @@ package androidx.compose.platform
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ProvideSystemTheme
+import androidx.compose.ui.pollSystemTheme
 import androidx.compose.ui.systemThemePollingJob
 import androidx.compose.ui.systemThemeSubscriberCount
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -33,8 +35,8 @@ class SystemThemeTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testSystemThemePollingState() {
-        val prevValue = System.getProperty("compose.systemtheme.poll")
-        System.setProperty("compose.systemtheme.poll", "true")
+        val prevValue = ComposeUiFlags.pollSystemTheme
+        ComposeUiFlags.pollSystemTheme = true
         try {
             runComposeUiTest {
                 var provideSystemTheme1 by mutableStateOf(false)
@@ -68,11 +70,7 @@ class SystemThemeTest {
                 assertNull(systemThemePollingJob())
             }
         } finally {
-            if (prevValue != null) {
-                System.setProperty("compose.systemtheme.poll", prevValue)
-            } else {
-                System.clearProperty("compose.systemtheme.poll")
-            }
+            ComposeUiFlags.pollSystemTheme = prevValue
         }
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.LocalSystemTheme
-import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.navigationevent.UIKitNavigationEventInput
 import androidx.compose.ui.platform.DefaultArchitectureComponentsOwner
@@ -56,6 +55,7 @@ import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import org.jetbrains.skiko.SystemTheme
 import platform.Foundation.NSKeyValueObservingOptionNew
 import platform.Foundation.addObserver
 import platform.Foundation.removeObserver
@@ -117,7 +117,7 @@ internal class ComposeContainer(
     private val interfaceOrientationState: MutableState<InterfaceOrientation> = mutableStateOf(
         InterfaceOrientation.Portrait
     )
-    private val systemThemeState: MutableState<SystemTheme> = mutableStateOf(SystemTheme.Unknown)
+    private val systemThemeState: MutableState<SystemTheme> = mutableStateOf(SystemTheme.UNKNOWN)
 
     private val focusedViewsList = FocusedViewsList()
 
@@ -398,9 +398,9 @@ internal class ComposeContainer(
 
 private fun UIUserInterfaceStyle.asComposeSystemTheme(): SystemTheme {
     return when (this) {
-        UIUserInterfaceStyle.UIUserInterfaceStyleLight -> SystemTheme.Light
-        UIUserInterfaceStyle.UIUserInterfaceStyleDark -> SystemTheme.Dark
-        else -> SystemTheme.Unknown
+        UIUserInterfaceStyle.UIUserInterfaceStyleLight -> SystemTheme.LIGHT
+        UIUserInterfaceStyle.UIUserInterfaceStyleDark -> SystemTheme.DARK
+        else -> SystemTheme.UNKNOWN
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,12 @@
 package androidx.compose.ui
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
 import org.jetbrains.skiko.currentSystemTheme
 
+@Deprecated("This class was made public by mistake and will be removed in a future release")
 enum class SystemTheme {
     Dark, Light, Unknown
 }
 
 @InternalComposeUiApi
-val LocalSystemTheme = staticCompositionLocalOf {
-    currentSystemTheme.asComposeSystemTheme()
-}
-
-private fun SkikoSystemTheme.asComposeSystemTheme() : SystemTheme {
-    return when (this) {
-        SkikoSystemTheme.DARK -> SystemTheme.Dark
-        SkikoSystemTheme.LIGHT -> SystemTheme.Light
-        SkikoSystemTheme.UNKNOWN -> SystemTheme.Unknown
-    }
-}
-
-
+val LocalSystemTheme = staticCompositionLocalOf { currentSystemTheme }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
@@ -17,11 +17,11 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.LocalSystemTheme
-import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.jetbrains.skiko.SystemTheme
 import platform.UIKit.UIUserInterfaceStyle
 
 class SystemThemeTest {
@@ -34,7 +34,7 @@ class SystemThemeTest {
             systemTheme = LocalSystemTheme.current
         }
 
-        assertEquals(SystemTheme.Light, systemTheme)
+        assertEquals(SystemTheme.LIGHT, systemTheme)
     }
 
     @Test
@@ -45,7 +45,7 @@ class SystemThemeTest {
             systemTheme = LocalSystemTheme.current
         }
 
-        assertEquals(SystemTheme.Dark, systemTheme)
+        assertEquals(SystemTheme.DARK, systemTheme)
     }
 
     @Test
@@ -59,14 +59,14 @@ class SystemThemeTest {
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleLight
-        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.LIGHT }
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleDark
-        waitUntil("System theme should eventually be Dark") { systemTheme == SystemTheme.Dark }
+        waitUntil("System theme should eventually be Dark") { systemTheme == SystemTheme.DARK }
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleLight
-        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.LIGHT }
     }
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/SystemThemeObserver.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/SystemThemeObserver.web.kt
@@ -18,9 +18,9 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.SystemTheme
 import kotlin.js.js
 import kotlinx.browser.window
+import org.jetbrains.skiko.SystemTheme
 import org.w3c.dom.MediaQueryList
 import org.w3c.dom.MediaQueryListEvent
 import org.w3c.dom.Window
@@ -43,22 +43,22 @@ internal class SystemThemeObserverImpl(window : Window) : SystemThemeObserver {
 
     private val _currentSystemTheme = mutableStateOf(
         when {
-            !isMatchMediaSupported() -> SystemTheme.Unknown
-            media.matches -> SystemTheme.Dark
-            else -> SystemTheme.Light
+            !isMatchMediaSupported() -> SystemTheme.UNKNOWN
+            media.matches -> SystemTheme.DARK
+            else -> SystemTheme.LIGHT
         }
     )
 
     private val listener: (Event) -> Unit = { event ->
         _currentSystemTheme.value = if ((event as MediaQueryListEvent).matches)
-            SystemTheme.Dark else SystemTheme.Light
+            SystemTheme.DARK else SystemTheme.LIGHT
     }
 
     override fun dispose() {
-        if (isMatchMediaSupported()){
+        if (isMatchMediaSupported()) {
             try {
                 media.removeEventListener("change", listener)
-            } catch (t : Throwable){
+            } catch (t : Throwable) {
                 media.removeListener(listener)
             }
         }


### PR DESCRIPTION
Poll the system theme in desktopMain once per second.
Also, removed the unnecessary Compose `SystemTheme` type.

This should have negligible performance, and should not affect any wake locks (or at least not more than text field cursor blinking, which also uses a coroutine + delay).

Note that the polling is disabled by default on Linux.

Fixes https://youtrack.jetbrains.com/issue/CMP-1986/isSystemInDarkTheme-should-dynamically-update-when-system-theme-is-changed

## Testing
Added a unit test and tested manually with
```
fun main() = singleWindowApplication {
    MaterialTheme(colors = if (isSystemInDarkTheme()) darkColors() else lightColors()) {
        Surface(modifier = Modifier.fillMaxSize()) { }
    }
}
```
and changing the macOS theme from settings.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- On Windows and macOS, `isSystemInDarkTheme` will now return dynamic values as the OS theme changes, causing any callers to recompose. This is done by polling the system in the background once a second. This behavior can be controlled by setting `ComposeUiFlags.pollSystemTheme`.