### PR TITLE
Fix `Paragraph.getOffsetForPosition` behavour in corner cases

### DIFF
--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntegrationTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntegrationTest.kt
@@ -314,7 +314,6 @@ class DesktopParagraphIntegrationTest {
     }
 
     @Test
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8594
     fun getOffsetForPosition_rtl_multiline() {
         with(defaultDensity) {
             val firstLine = "\u05D0\u05D1\u05D2"
@@ -369,7 +368,6 @@ class DesktopParagraphIntegrationTest {
     }
 
     @Test
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8594
     fun getOffsetForPosition_ltr_height_outOfBounds() {
         with(defaultDensity) {
             val text = "abc"
@@ -2516,7 +2514,6 @@ class DesktopParagraphIntegrationTest {
     }
 
     @Test
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8594
     fun textDirection_whenDefault_withFirstStrongCharLTR_directionIsLTR() {
         with(defaultDensity) {
             val text = "a\u05D0."

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -518,14 +518,6 @@ internal class SkiaParagraph(
             correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(leftX + 1f, position.y).position
         } else if (position.x >= rightX) { // when clicked to the right of a text line
             correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(rightX - 1f, position.y).position
-            val isNeutralChar = if (correctedGlyphPosition in text.indices) {
-                text.codePointAt(correctedGlyphPosition).isNeutralDirection()
-            } else false
-
-            // For RTL blocks, the position is still not correct, so we have to subtract 1 from the returned result
-            if (!isNeutralChar && getBoxBackwardByOffset(correctedGlyphPosition)?.direction == Direction.RTL) {
-                correctedGlyphPosition -= 1 // TODO Check if it should be CodePoint.charCount()
-            }
         }
 
         return correctedGlyphPosition

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -385,22 +385,26 @@ class SkikoParagraphTest {
     }
 
     @Test
-    fun getOffsetForPosition_insideComplexCharacter_shouldJumpToEnd() {
+    fun getOffsetForPosition_midpointOfComplexCharacter_snapsToClusterStart() {
         val text = "abc\u0915\u094D abc" // "abcक् abc"
         val paragraph = simpleParagraph(text)
 
-        val complexCharStart = 3 // Index of 'क'
+        val complexCharStart = 3 // Index of 'क'; the cluster "क्" spans indices 3..4
         val complexCharBox = paragraph.getBoundingBox(complexCharStart)
 
-        // Try to position the caret inside the complex character
+        // Click exactly in the middle of the complex character's box.
         val insideOffset =
             Offset(complexCharBox.left + complexCharBox.width / 2, complexCharBox.center.y)
         val position = paragraph.getOffsetForPosition(insideOffset)
 
+        // A midpoint click is a tie between the two valid caret positions (before the
+        // cluster = 3, after it = 5). Matching Android's Layout.getOffsetForHorizontal,
+        // the exact-midpoint tie resolves to the before-char side, i.e. the cluster start.
+        // The caret must never land on the internal code-unit index (4).
         assertEquals(
-            5, // after 'क्'
+            3, // start of "क्" (before-char), Android-compatible midpoint tie-break
             position,
-            message = "The position should be at the end of the complex character, not inside it"
+            message = "A midpoint click on a complex cluster should snap to the cluster start (before-char)"
         )
     }
 


### PR DESCRIPTION
Follow-up to [the Skia/Skiko hit-testing fixes for caret positioning. ](https://github.com/JetBrains/skia/pull/20)
This PR must be merged after updating Skia.

- Enabled three previously ignored tests.
- Removed the workaround with the RTL block-position correction in `getOffsetForPosition` (the `correctedGlyphPosition -= 1` branch with the `isNeutralDirection` / `Direction.RTL` check). Skia should return the correct offset for clicks to the right of a line in mixed-direction text now, so the compose-side adjustment is no longer needed.
- Adjusted and removed getOffsetForPosition_insideComplexCharacter_shouldJumpToEnd` →
    `getOffsetForPosition_midpointOfComplexCharacter_snapsToClusterStart`, since it's more accurate and conforms to the Android behavior.

Fixes:
[CMP-8594 Fix `Paragraph.getOffsetForPosition` behavour in corner cases](https://youtrack.jetbrains.com/issue/CMP-8594)


## Testing
There are tests already, however, this better be tested by QA

## Release Notes
N/A
