### PR TITLE
Show context menu after long press for BTF 1

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
@@ -275,8 +275,7 @@ private class UIKitTextFieldTextDragObserver(
 ) : TextDragObserver {
     private var dragBeginPosition: Offset = Offset.Unspecified
     private var dragTotalDistance: Offset = Offset.Zero
-    private var isSingleLongPress = false
-    private var selectionAtLongPressStart: TextRange = TextRange.Zero
+    private var selectionAtLongPressStart: TextRange? = null
 
     private fun onDragStop(showContextMenu: Boolean) {
         // Only execute clear-up if drag was actually ongoing.
@@ -287,13 +286,13 @@ private class UIKitTextFieldTextDragObserver(
             textFieldSelectionState.directDragGestureInitiator = InputType.None
             textFieldSelectionState.clearHandleDragging()
 
-            val selectionChanged =
-                textFieldSelectionState.textFieldState.visualText.selection != selectionAtLongPressStart
-            if (showContextMenu && isSingleLongPress && !selectionChanged) {
+            val isSelectionUnchanged =
+                textFieldSelectionState.textFieldState.visualText.selection == selectionAtLongPressStart
+            if (showContextMenu && isSelectionUnchanged) {
                 textFieldSelectionState.updateTextToolbarState(Cursor)
             }
         }
-        isSingleLongPress = false
+        selectionAtLongPressStart = null
     }
 
     override fun onDown(point: Offset) = Unit
@@ -313,10 +312,9 @@ private class UIKitTextFieldTextDragObserver(
         dragTotalDistance = Offset.Zero
 
         if (selectionAdjustment != SelectionAdjustment.None) {
-            isSingleLongPress = false
             textFieldSelectionState.doRepeatingTapSelection(startPoint, selectionAdjustment)
+            selectionAtLongPressStart = null
         } else {
-            isSingleLongPress = true
             textFieldSelectionState.moveCaretByLongPress(startPoint)
             selectionAtLongPressStart = textFieldSelectionState.textFieldState.visualText.selection
         }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
@@ -275,8 +275,10 @@ private class UIKitTextFieldTextDragObserver(
 ) : TextDragObserver {
     private var dragBeginPosition: Offset = Offset.Unspecified
     private var dragTotalDistance: Offset = Offset.Zero
+    private var isSingleLongPress = false
+    private var selectionAtLongPressStart: TextRange = TextRange.Zero
 
-    private fun onDragStop() {
+    private fun onDragStop(showContextMenu: Boolean) {
         // Only execute clear-up if drag was actually ongoing.
         if (dragBeginPosition.isSpecified) {
             textFieldSelectionState.clearHandleDragging()
@@ -284,16 +286,23 @@ private class UIKitTextFieldTextDragObserver(
             dragTotalDistance = Offset.Zero
             textFieldSelectionState.directDragGestureInitiator = InputType.None
             textFieldSelectionState.clearHandleDragging()
+
+            val selectionChanged =
+                textFieldSelectionState.textFieldState.visualText.selection != selectionAtLongPressStart
+            if (showContextMenu && isSingleLongPress && !selectionChanged) {
+                textFieldSelectionState.updateTextToolbarState(Cursor)
+            }
         }
+        isSingleLongPress = false
     }
 
     override fun onDown(point: Offset) = Unit
 
     override fun onUp() = Unit
 
-    override fun onStop() = onDragStop()
+    override fun onStop() = onDragStop(showContextMenu = true)
 
-    override fun onCancel() = onDragStop()
+    override fun onCancel() = onDragStop(showContextMenu = false)
 
     override fun onStart(startPoint: Offset, selectionAdjustment: SelectionAdjustment) {
         if (!textFieldSelectionState.enabled) return
@@ -304,9 +313,12 @@ private class UIKitTextFieldTextDragObserver(
         dragTotalDistance = Offset.Zero
 
         if (selectionAdjustment != SelectionAdjustment.None) {
+            isSingleLongPress = false
             textFieldSelectionState.doRepeatingTapSelection(startPoint, selectionAdjustment)
         } else {
+            isSingleLongPress = true
             textFieldSelectionState.moveCaretByLongPress(startPoint)
+            selectionAtLongPressStart = textFieldSelectionState.textFieldState.visualText.selection
         }
     }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -129,12 +129,11 @@ private class CupertinoSelectionGesturesModifierNode(
     private val longPressDragObserver = object : TextDragObserver {
         var dragTotalDistance = Offset.Zero
         var dragBeginOffset = Offset.Zero
-        var shouldUpdateMagnifierPosition = false
+        var isSingleLongPressWithMagnifier = false
 
         override fun onStart(startPoint: Offset, selectionAdjustment: SelectionAdjustment) {
-            val isSingleLongPress = selectionAdjustment == SelectionAdjustment.None
-            shouldUpdateMagnifierPosition = isSingleLongPress
-            if (isSingleLongPress) {
+            isSingleLongPressWithMagnifier = selectionAdjustment == SelectionAdjustment.None
+            if (isSingleLongPressWithMagnifier) {
                 manager.draggingHandle = Handle.SelectionEnd
                 manager.currentDragPosition = startPoint
                 manager.hapticFeedBack?.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -163,7 +162,7 @@ private class CupertinoSelectionGesturesModifierNode(
             dragTotalDistance += delta
             state.layoutResult?.let { layoutResult ->
                 val currentDragPosition = dragBeginOffset + dragTotalDistance
-                if (shouldUpdateMagnifierPosition) {
+                if (isSingleLongPressWithMagnifier) {
                     manager.currentDragPosition = currentDragPosition
                 }
                 TextFieldDelegate.setCursorOffset(
@@ -182,13 +181,17 @@ private class CupertinoSelectionGesturesModifierNode(
         override fun onUp() {}
 
         override fun onStop() {
-            shouldUpdateMagnifierPosition = false
             manager.draggingHandle = null
             manager.currentDragPosition = null
+
+            if (isSingleLongPressWithMagnifier) {
+                manager.enterSelectionMode()
+                isSingleLongPressWithMagnifier = false
+            }
         }
 
         override fun onCancel() {
-            shouldUpdateMagnifierPosition = false
+            isSingleLongPressWithMagnifier = false
             manager.draggingHandle = null
             manager.currentDragPosition = null
         }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -130,6 +130,7 @@ private class CupertinoSelectionGesturesModifierNode(
         var dragTotalDistance = Offset.Zero
         var dragBeginOffset = Offset.Zero
         var isSingleLongPressWithMagnifier = false
+        var selectionAtLongPressStart = TextRange.Zero
 
         override fun onStart(startPoint: Offset, selectionAdjustment: SelectionAdjustment) {
             isSingleLongPressWithMagnifier = selectionAdjustment == SelectionAdjustment.None
@@ -156,6 +157,7 @@ private class CupertinoSelectionGesturesModifierNode(
                 dragBeginOffset = startPoint
             }
             dragTotalDistance = Offset.Zero
+            selectionAtLongPressStart = manager.value.selection
         }
 
         override fun onDrag(delta: Offset) {
@@ -184,10 +186,11 @@ private class CupertinoSelectionGesturesModifierNode(
             manager.draggingHandle = null
             manager.currentDragPosition = null
 
-            if (isSingleLongPressWithMagnifier) {
+            val selectionChanged = manager.value.selection != selectionAtLongPressStart
+            if (isSingleLongPressWithMagnifier && !selectionChanged) {
                 manager.enterSelectionMode()
-                isSingleLongPressWithMagnifier = false
             }
+            isSingleLongPressWithMagnifier = false
         }
 
         override fun onCancel() {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -47,8 +47,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.assertVisibleInContainer
 import androidx.compose.ui.test.findNodeWithLabel
+import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
-import androidx.compose.ui.test.firstNodeOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.hold
 import androidx.compose.ui.test.utils.up
@@ -175,6 +175,79 @@ class TextFieldEditMenuTest {
         waitUntil("Text field should be fully selected") {
             textFieldState.isFullySelected()
         }
+    }
+
+    @Test
+    fun testBasicTextFieldLongPressShowsContextMenu() = runUIKitInstrumentedTest {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        val focusRequester = FocusRequester()
+        val textFieldValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
+        setContent {
+            Column(modifier = Modifier.safeDrawingPadding()) {
+                BasicTextField(
+                    value = textFieldValue.value,
+                    onValueChange = { textFieldValue.value = it },
+                    modifier = Modifier
+                        .testTag("TextField")
+                        .focusRequester(focusRequester)
+                )
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        // A long press positions the cursor and, on release, reveals the context menu.
+        findNodeWithTag("TextField").longPress()
+        waitForContextMenu()
+        findNodeWithLabel("Paste").assertVisibleInContainer()
+
+        // A short tap elsewhere dismisses the context menu.
+        findNodeWithTag("TextField").tap()
+        waitUntil("Context menu should be hidden") {
+            findNodeWithLabelOrNull("Paste") == null
+        }
+
+        // A tap again brings the context menu back.
+        findNodeWithTag("TextField").tap()
+        waitForContextMenu()
+        findNodeWithLabel("Paste").assertVisibleInContainer()
+    }
+
+    @Test
+    fun testBasicTextField2LongPressShowsContextMenu() = runUIKitInstrumentedTest {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        val focusRequester = FocusRequester()
+        val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
+        setContent {
+            Column(modifier = Modifier.safeDrawingPadding()) {
+                BasicTextField(
+                    state = textFieldState,
+                    modifier = Modifier
+                        .testTag("TextField")
+                        .focusRequester(focusRequester)
+                )
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        // A long press positions the cursor and, on release, reveals the context menu.
+        findNodeWithTag("TextField").longPress()
+        waitForContextMenu()
+        findNodeWithLabel("Paste").assertVisibleInContainer()
+
+        // A short tap elsewhere dismisses the context menu.
+        findNodeWithTag("TextField").tap()
+        waitUntil("Context menu should be hidden") {
+            findNodeWithLabelOrNull("Paste") == null
+        }
+
+        // A long press again brings the context menu back.
+        findNodeWithTag("TextField").tap()
+        waitForContextMenu()
+        findNodeWithLabel("Paste").assertVisibleInContainer()
     }
 
     @Test

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -50,9 +50,12 @@ import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.hold
+import androidx.compose.ui.test.utils.isLoupeView
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.test.waitForContextMenu
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
@@ -181,7 +184,7 @@ class TextFieldEditMenuTest {
     fun testBasicTextFieldLongPressShowsContextMenu() = runUIKitInstrumentedTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
         val focusRequester = FocusRequester()
-        val textFieldValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
+        val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4,4)))
         setContent {
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
@@ -198,7 +201,8 @@ class TextFieldEditMenuTest {
         }
 
         // A long press positions the cursor and, on release, reveals the context menu.
-        findNodeWithTag("TextField").longPress()
+        longPressAndAwaitContextMenu("TextField")
+
         waitForContextMenu()
         findNodeWithLabel("Paste").assertVisibleInContainer()
 
@@ -209,8 +213,7 @@ class TextFieldEditMenuTest {
         }
 
         // A tap again brings the context menu back.
-        findNodeWithTag("TextField").tap()
-        waitForContextMenu()
+        longPressAndAwaitContextMenu("TextField")
         findNodeWithLabel("Paste").assertVisibleInContainer()
     }
 
@@ -218,7 +221,7 @@ class TextFieldEditMenuTest {
     fun testBasicTextField2LongPressShowsContextMenu() = runUIKitInstrumentedTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
         val focusRequester = FocusRequester()
-        val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
+        val textFieldState = TextFieldState("Text", TextRange(4,4))
         setContent {
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
@@ -234,8 +237,7 @@ class TextFieldEditMenuTest {
         }
 
         // A long press positions the cursor and, on release, reveals the context menu.
-        findNodeWithTag("TextField").longPress()
-        waitForContextMenu()
+        longPressAndAwaitContextMenu("TextField")
         findNodeWithLabel("Paste").assertVisibleInContainer()
 
         // A short tap elsewhere dismisses the context menu.
@@ -245,8 +247,7 @@ class TextFieldEditMenuTest {
         }
 
         // A long press again brings the context menu back.
-        findNodeWithTag("TextField").tap()
-        waitForContextMenu()
+        longPressAndAwaitContextMenu("TextField")
         findNodeWithLabel("Paste").assertVisibleInContainer()
     }
 
@@ -508,6 +509,15 @@ class TextFieldEditMenuTest {
         findNodeWithTag(textFieldTag).tap()
         delay(500)
         findNodeWithTag(textFieldTag).doubleTap()
+        waitForContextMenu()
+    }
+
+    private fun UIKitInstrumentedTest.longPressAndAwaitContextMenu(textFieldTag: String) {
+        val touch = findNodeWithTag(textFieldTag).touchDown()
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } != null
+        }
+        touch.up()
         waitForContextMenu()
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.test.utils.beginModifierKeyPress
 import androidx.compose.ui.test.utils.beginPress
 import androidx.compose.ui.test.utils.center
 import androidx.compose.ui.test.utils.getTouchesEvent
+import androidx.compose.ui.test.utils.hold
 import androidx.compose.ui.test.utils.mouseDown
 import androidx.compose.ui.test.utils.moveToLocationOnWindow
 import androidx.compose.ui.test.utils.release
@@ -482,6 +483,17 @@ internal class UIKitInstrumentedTest(
     fun AccessibilityTestNode.tap() {
         val frame = frame ?: error("Internal error. Frame is missing.")
         return tap(frame.center())
+    }
+
+    /**
+     * Simulates a long press gesture for a given AccessibilityTestNode.
+     */
+    fun AccessibilityTestNode.longPress(duration: Duration = 1.0.seconds) {
+        val frame = frame ?: error("Internal error. Frame is missing.")
+        val touch = touchDown(frame.center())
+        touch.hold()
+        Companion.delay(duration.inWholeMilliseconds)
+        touch.up()
     }
 
     /**

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -488,7 +488,7 @@ internal class UIKitInstrumentedTest(
     /**
      * Simulates a long press gesture for a given AccessibilityTestNode.
      */
-    fun AccessibilityTestNode.longPress(duration: Duration = 2.0.seconds) {
+    fun AccessibilityTestNode.longPress(duration: Duration = 0.5.seconds) {
         val frame = frame ?: error("Internal error. Frame is missing.")
         val touch = touchDown(frame.center())
         touch.hold()
@@ -566,6 +566,20 @@ internal class UIKitInstrumentedTest(
      */
     fun UITouch.dragBy(dx: Dp = 0.dp, dy: Dp = 0.dp, duration: Duration = 0.5.seconds): UITouch {
         return dragBy(DpOffset(dx, dy), duration)
+    }
+
+    /**
+     * Simulates a drag gesture on the screen, moving the touch from its current location by specified x and y offsets
+     * over a given duration.
+     *
+     * @param x The horizontal destination point. The default value does not change the current horizontal offset.
+     * @param y The vertical destination point. The default value does not change the current vertical offset.
+     * @param duration The duration of the drag gesture, specified as a Duration. Defaults to 0.5 seconds.
+     * @return The same UITouch instance after completing the drag gesture.
+     */
+    fun UITouch.dragTo(x: Dp? = null, y: Dp? = null, duration: Duration = 0.5.seconds): UITouch {
+        val location = locationInView(null).toDpOffset()
+        return dragTo(DpOffset(x ?: location.x, y ?: location.y), duration)
     }
 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -488,7 +488,7 @@ internal class UIKitInstrumentedTest(
     /**
      * Simulates a long press gesture for a given AccessibilityTestNode.
      */
-    fun AccessibilityTestNode.longPress(duration: Duration = 1.0.seconds) {
+    fun AccessibilityTestNode.longPress(duration: Duration = 2.0.seconds) {
         val frame = frame ?: error("Internal error. Frame is missing.")
         val touch = touchDown(frame.center())
         touch.hold()
@@ -736,7 +736,7 @@ internal fun UIKitInstrumentedTest.waitForContextMenu() {
         "UICalloutBar"
     }
     waitForIdle()
-    waitUntil {
+    waitUntil("Waiting for context menu to appear") {
         firstNodeOrNull { node ->
             node.element?.let { it::class.simpleName } == menuClassName
         } != null


### PR DESCRIPTION
Show edit menu when touch gesture ended

Fixes https://youtrack.jetbrains.com/issue/CMP-9775/BasicTextFild-iOS-not-showing-paste-action

## Release Notes
### Fixes - iOS
- Fix issue when `BasicTextField` does not show context menu after long press.
