### PR TITLE
Implement Select text exit menu

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/ContextMenu.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/ContextMenu.ios.kt
@@ -292,6 +292,7 @@ private class ContextMenuToolbarProvider(
                             copy = it.copy,
                             cut = it.cut,
                             paste = it.paste,
+                            select = null,
                             selectAll = it.selectAll,
                             customActions = it.customActions.map { action ->
                                 CMPEditMenuCustomAction(action.title, action.action)

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -32,6 +32,7 @@
 - (void)updateAvailableSystemActions:(void (^)(void))copyBlock
                                  cut:(void (^)(void))cutBlock
                                paste:(void (^)(void))pasteBlock
+                              select:(void (^)(void))selectBlock
                            selectAll:(void (^)(void))selectAllBlock;
 
 - (void)hideEditMenu;

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -25,12 +25,7 @@
                       copy:(void (^)(void))copyBlock
                        cut:(void (^)(void))cutBlock
                      paste:(void (^)(void))pasteBlock
-                 selectAll:(void (^)(void))selectAllBlock;
-
-- (void)showEditMenuAtRect:(CGRect)targetRect
-                      copy:(void (^)(void))copyBlock
-                       cut:(void (^)(void))cutBlock
-                     paste:(void (^)(void))pasteBlock
+                    select:(void (^)(void))selectBlock
                  selectAll:(void (^)(void))selectAllBlock
              customActions:(NSArray<CMPEditMenuCustomAction *> *)customActions;
 

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -75,6 +75,7 @@
 @property (copy, nonatomic, nullable) void (^systemCopyBlock)(void);
 @property (copy, nonatomic, nullable) void (^systemCutBlock)(void);
 @property (copy, nonatomic, nullable) void (^systemPasteBlock)(void);
+@property (copy, nonatomic, nullable) void (^systemSelectBlock)(void);
 @property (copy, nonatomic, nullable) void (^systemSelectAllBlock)(void);
 
 @property (strong, nonatomic, nullable) dispatch_block_t showContextMenuBlock;
@@ -142,10 +143,12 @@ id _editInteraction;
 - (void)updateAvailableSystemActions:(void (^)(void))copyBlock
                                  cut:(void (^)(void))cutBlock
                                paste:(void (^)(void))pasteBlock
+                              select:(void (^)(void))selectBlock
                            selectAll:(void (^)(void))selectAllBlock {
     self.systemCopyBlock = copyBlock;
     self.systemCutBlock = cutBlock;
     self.systemPasteBlock = pasteBlock;
+    self.systemSelectBlock = selectBlock;
     self.systemSelectAllBlock = selectAllBlock;
 }
 
@@ -374,6 +377,8 @@ id _editInteraction;
 - (void)select:(id)sender {
     if (self.selectBlock != nil) {
         self.selectBlock();
+    } else if (self.systemSelectBlock != nil) {
+        self.systemSelectBlock();
     }
 }
 

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -66,6 +66,7 @@
 @property (copy, nonatomic, nullable) void (^copyBlock)(void);
 @property (copy, nonatomic, nullable) void (^cutBlock)(void);
 @property (copy, nonatomic, nullable) void (^pasteBlock)(void);
+@property (copy, nonatomic, nullable) void (^selectBlock)(void);
 @property (copy, nonatomic, nullable) void (^selectAllBlock)(void);
 @property (copy, nonatomic, nullable) NSArray<CMPEditMenuCustomAction *> *customActions;
 
@@ -87,24 +88,13 @@ id _editInteraction;
                       copy:(void (^)(void))copyBlock
                        cut:(void (^)(void))cutBlock
                      paste:(void (^)(void))pasteBlock
-                 selectAll:(void (^)(void))selectAllBlock {
-    [self showEditMenuAtRect:targetRect
-                        copy:copyBlock
-                         cut:cutBlock
-                       paste:pasteBlock
-                   selectAll:selectAllBlock
-               customActions:@[]];
-}
-
-- (void)showEditMenuAtRect:(CGRect)targetRect
-                      copy:(void (^)(void))copyBlock
-                       cut:(void (^)(void))cutBlock
-                     paste:(void (^)(void))pasteBlock
+                    select:(void (^)(void))selectBlock
                  selectAll:(void (^)(void))selectAllBlock
              customActions:(NSArray<CMPEditMenuCustomAction *> *)customActions {
     BOOL contextMenuItemsChanged = [self contextMenuItemsChangedCopy:copyBlock
                                                                  cut:cutBlock
                                                                paste:pasteBlock
+                                                              select:selectBlock
                                                            selectAll:selectAllBlock
                                                        customActions:customActions];
     BOOL positionChanged = !CGRectEqualToRect(self.targetRect, targetRect);
@@ -119,6 +109,7 @@ id _editInteraction;
     self.copyBlock = copyBlock;
     self.cutBlock = cutBlock;
     self.pasteBlock = pasteBlock;
+    self.selectBlock = selectBlock;
     self.selectAllBlock = selectAllBlock;
     self.customActions = customActions;
 
@@ -291,11 +282,13 @@ id _editInteraction;
 - (BOOL)contextMenuItemsChangedCopy:(void (^)(void))copyBlock
                                 cut:(void (^)(void))cutBlock
                               paste:(void (^)(void))pasteBlock
+                             select:(void (^)(void))selectBlock
                           selectAll:(void (^)(void))selectAllBlock
                       customActions:(NSArray<CMPEditMenuCustomAction *> *)customActions {
     return ((self.copyBlock == nil) != (copyBlock == nil) ||
             (self.cutBlock == nil) != (cutBlock == nil) ||
             (self.pasteBlock == nil) != (pasteBlock == nil) ||
+            (self.selectBlock == nil) != (selectBlock == nil) ||
             (self.selectAllBlock == nil) != (selectAllBlock == nil) ||
             (![self.customActions isEqualToArray:customActions]));
 }
@@ -309,6 +302,9 @@ id _editInteraction;
     }
     if (@selector(cut:) == action) {
         return self.cutBlock != nil;
+    }
+    if (@selector(select:) == action) {
+        return self.selectBlock != nil;
     }
     if (@selector(selectAll:) == action) {
         return self.selectAllBlock != nil;
@@ -343,6 +339,12 @@ id _editInteraction;
 - (void)cut:(id)sender {
     if (self.cutBlock != nil) {
         self.cutBlock();
+    }
+}
+
+- (void)select:(id)sender {
+    if (self.selectBlock != nil) {
+        self.selectBlock();
     }
 }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.toCGRect
 import kotlinx.cinterop.CValue
 import org.jetbrains.skia.BreakIterator
+import org.jetbrains.skia.BreakIterator.Companion.makeWordInstance
 import platform.CoreGraphics.CGRect
 import platform.Foundation.NSCharacterSet
 import platform.UIKit.NSWritingDirection
@@ -216,6 +217,74 @@ internal interface NativeTextEditingDelegate : TextEditingDelegate {
      */
     fun positionWithinRange(range: TextRange, farthestInDirection: PlatformTextLayoutDirection): Int?
 }
+
+internal fun TextEditingDelegate.selectTextNearCursor() {
+    val selection = getSelectedTextRange() ?: return
+    val text = textInRange(TextRange(0, endOfDocument())) ?: return
+
+    val range = wordSelectionRangeForCursor(text, selection.start) ?: return
+    if (range == selection) return
+
+    setSelectedTextRange(range)
+}
+
+/**
+ * Computes the range that the "Select" edit action should select for a collapsed caret at
+ * [cursor]: The behavior must mimic iOS Select text field action:
+ *
+ * 1. If a visible (non-whitespace) character immediately follows the caret, the word that
+ *    character belongs to is selected.
+ * 2. Otherwise, if a word precedes the caret, that word is selected together with any space
+ *    characters between the word's end and the caret (newlines excluded).
+ * 3. Otherwise (no word precedes the caret), the run of space characters following the caret,
+ *    up to the first visible character, is selected (newlines excluded).
+ *
+ * Returns `null` if there is nothing to select.
+ */
+private fun wordSelectionRangeForCursor(text: String, cursor: Int): TextRange? {
+    // Condition 1
+    if (cursor < text.length && text[cursor].isVisibleForSelection()) {
+        return wordRangeContaining(text, cursor)
+    }
+
+    // Condition 2
+    var wordEnd = cursor
+    while (wordEnd > 0 && text[wordEnd - 1].isSelectableSpace()) {
+        wordEnd--
+    }
+    if (wordEnd > 0 && text[wordEnd - 1].isVisibleForSelection()) {
+        val wordStart = wordStartPreceding(text, wordEnd)
+        return TextRange(wordStart, cursor)
+    }
+
+    // Condition 3
+    var spacesEnd = cursor
+    while (spacesEnd < text.length && text[spacesEnd].isSelectableSpace()) {
+        spacesEnd++
+    }
+    return if (spacesEnd > cursor) TextRange(cursor, spacesEnd) else null
+}
+
+/** Returns the boundaries of the word containing the visible character at [offset]. */
+private fun wordRangeContaining(text: String, offset: Int): TextRange {
+    val iterator = makeWordInstance()
+    iterator.setText(text)
+    val end = iterator.following(offset).takeIf { it != BreakIterator.DONE } ?: text.length
+    val start = iterator.preceding(end).takeIf { it != BreakIterator.DONE } ?: 0
+    return TextRange(start, end)
+}
+
+/** Returns the start boundary of the word that ends at [wordEnd]. */
+private fun wordStartPreceding(text: String, wordEnd: Int): Int {
+    val iterator = makeWordInstance()
+    iterator.setText(text)
+    return iterator.preceding(wordEnd).takeIf { it != BreakIterator.DONE } ?: 0
+}
+
+private fun Char.isNewlineForSelection(): Boolean =
+    NSCharacterSet.newlineCharacterSet.characterIsMember(code.toUShort())
+private fun Char.isSelectableSpace(): Boolean = isWhitespace() && !isNewlineForSelection()
+private fun Char.isVisibleForSelection(): Boolean = !isWhitespace()
 
 internal class TextInputPosition(val position: Int = 0) : UITextPosition() {
     override fun description(): String {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -21,13 +21,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.scene.ComposeSceneFocusManager
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ComposeTextInputConnection
+import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.NativeTextInputConnection
 import androidx.compose.ui.text.input.SelectionContainerConnection
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextEditorState
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TextInputConnection
 import androidx.compose.ui.text.input.stateSnapshot
 import androidx.compose.ui.text.input.usingNativeTextInput
@@ -150,14 +159,34 @@ internal class UIKitTextInputService(
                     // Note: start() is intentionally not called here — it establishes a text editing
                     // session (requiring a PlatformTextInputMethodRequest) which is not applicable for
                     // SelectionContainer.
-                    val connection = SelectionContainerConnection(
+                    currentInputConnection = SelectionContainerConnection(
                         view = view,
                         coroutineScope = coroutineScope,
                         viewConfiguration = viewConfiguration,
                         focusManager = focusManager
                     )
-                    currentInputConnection = connection
-                    connection.attachInputToView()
+                    currentInputConnection?.start(
+                        object : PlatformTextInputMethodRequest {
+                            override val value: () -> TextFieldValue get() = { TextFieldValue() }
+                            override val state: TextEditorState = object : TextEditorState {
+                                override val selection: TextRange get() = TextRange(0, 0)
+                                override val composition: TextRange? get() = null
+                                override val length: Int get() = 0
+                                override fun get(index: Int): Char = ' '
+                                override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = ""
+                                override val text: String get() = ""
+                            }
+                            override val imeOptions: ImeOptions get() = ImeOptions.Default
+                            override val onEditCommand: (List<EditCommand>) -> Unit get() = { _ -> }
+                            override val onImeAction: ((ImeAction) -> Unit)? get() = null
+                            override val textLayoutResult: () -> TextLayoutResult? get() = { null }
+                            override val focusedRectInRoot: () -> Rect? get() = { null }
+                            override val textFieldRectInRoot: () -> Rect? get() = { null }
+                            override val textClippingRectInRoot: () -> Rect? get() = { null }
+                            override val unclippedTextOffsetInRoot: () -> Offset? get() = { null }
+                            override val editText: (block: TextEditingScope.() -> Unit) -> Unit get() = { _ -> }
+                        }
+                    )
                 }
                 (currentInputConnection as? ComposeTextInputConnection)?.showToolbarMenu(
                     rect = rect,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -148,12 +148,21 @@ internal class UIKitTextInputService(
                     // Note: start() is intentionally not called here — it establishes a text editing
                     // session (requiring a PlatformTextInputMethodRequest) which is not applicable for
                     // SelectionContainer.
-                    currentInputConnection = SelectionContainerConnection(
-                        view, coroutineScope, viewConfiguration, focusManager
+                    val connection = SelectionContainerConnection(
+                        view = view,
+                        coroutineScope = coroutineScope,
+                        viewConfiguration = viewConfiguration,
+                        focusManager = focusManager
                     )
+                    currentInputConnection = connection
+                    connection.attachInputToView()
                 }
                 (currentInputConnection as? TextToolbar)?.showMenu(
-                    rect, onCopyRequested, onPasteRequested, onCutRequested, onSelectAllRequested
+                    rect = rect,
+                    onCopyRequested = onCopyRequested,
+                    onPasteRequested = onPasteRequested,
+                    onCutRequested = onCutRequested,
+                    onSelectAllRequested = onSelectAllRequested
                 )
             }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -136,6 +136,7 @@ internal open class ComposeTextInputConnection(
                     copy = onCopyRequested,
                     cut = onCutRequested,
                     paste = onPasteRequested,
+                    select = null,
                     selectAll = onSelectAllRequested,
                     customActions = emptyList<CMPEditMenuCustomAction>()
                 )

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -86,7 +86,7 @@ internal open class ComposeTextInputConnection(
                 view.removeFromSuperview()
             }
         }
-        textInputView.updateAvailableSystemActions(null, null, null, null)
+        textInputView.updateAvailableSystemActions(null, null, null, null, null)
     }
 
     override fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean) {
@@ -124,6 +124,7 @@ internal open class ComposeTextInputConnection(
             copyBlock = copy,
             cut = cut,
             paste = paste,
+            select = null,
             selectAll = selectAll
         )
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
@@ -39,4 +39,8 @@ internal class SelectionContainerConnection(
         textInputView.resignFirstResponder()
         super.stop()
     }
+
+    public override fun attachInputToView() {
+        super.attachInputToView()
+    }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
@@ -35,12 +35,11 @@ internal class SelectionContainerConnection(
     null,
     focusManager
 ) {
-    override fun stop() {
-        textInputView.resignFirstResponder()
-        super.stop()
+    override fun showKeyboard() {
+        // Does nothing. Keyboard is not needed for the selection container
     }
 
-    public override fun attachInputToView() {
-        super.attachInputToView()
+    override fun dismissKeyboard() {
+        // Does nothing. Keyboard is not needed for the selection container
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -99,11 +99,11 @@ internal abstract class TextInputConnection(
 
     protected abstract fun detachView()
 
-    fun showKeyboard() {
+    open fun showKeyboard() {
         focusedViewsList?.addAndFocus(textInputView)
     }
 
-    fun dismissKeyboard() {
+    open fun dismissKeyboard() {
         focusedViewsList?.remove(textInputView, delayMillis = CLEAR_FOCUS_DELAY)
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -126,6 +126,8 @@ internal class ComposeTextInputView(
             this.select()
         }.takeIf { selectAll != null && showSelectMenu }
 
+        println(">>> Show edit menu 1 copy: $copy cut: $cut paste: $paste select: $patchedSelect selectAll: $selectAll customActions: $customActions")
+
         super.showEditMenuAtRect(
             targetRect = targetRect,
             copy = copy,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.TextInputRange
 import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.TextEditingDelegate
+import androidx.compose.ui.platform.selectTextNearCursor
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.text.TextRange
@@ -50,7 +51,6 @@ import platform.UIKit.NSWritingDirectionNatural
 import platform.UIKit.UIKeyInputProtocol
 import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardType
-import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
@@ -111,6 +111,39 @@ internal class ComposeTextInputView(
 
     override fun endFloatingCursor() {
         input?.endFloatingCursor()
+    }
+
+    override fun showEditMenuAtRect(
+        targetRect: CValue<CGRect>,
+        copy: (() -> Unit)?,
+        cut: (() -> Unit)?,
+        paste: (() -> Unit)?,
+        select: (() -> Unit)?,
+        selectAll: (() -> Unit)?,
+        customActions: List<*>?
+    ) {
+        val patchedSelect = select ?: {
+            this.select()
+        }.takeIf { selectAll != null && showSelectMenu }
+
+        super.showEditMenuAtRect(
+            targetRect = targetRect,
+            copy = copy,
+            cut = cut,
+            paste = paste,
+            select = patchedSelect,
+            selectAll = selectAll,
+            customActions = customActions,
+        )
+    }
+
+    private val showSelectMenu: Boolean
+        get() = input?.getSelectedTextRange()?.length == 0 && input?.hasText() == true
+
+    private fun select() {
+        selectionWillChange()
+        input?.selectTextNearCursor()
+        selectionDidChange()
     }
 
     /**

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -126,8 +126,6 @@ internal class ComposeTextInputView(
             this.select()
         }.takeIf { selectAll != null && showSelectMenu }
 
-        println(">>> Show edit menu 1 copy: $copy cut: $cut paste: $paste select: $patchedSelect selectAll: $selectAll customActions: $customActions")
-
         super.showEditMenuAtRect(
             targetRect = targetRect,
             copy = copy,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.PlatformTextLayoutDirection
 import androidx.compose.ui.platform.NativeTextEditingDelegate
 import androidx.compose.ui.platform.SkikoUITextInputTraits
+import androidx.compose.ui.platform.selectTextNearCursor
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
 import androidx.compose.ui.text.TextRange
@@ -74,7 +75,6 @@ import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardType
 import platform.UIKit.UIMenu
 import platform.UIKit.UIMenuElement
-import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UIScrollView
 import platform.UIKit.UITextAutocapitalizationType
@@ -586,16 +586,28 @@ internal class NativeTextInputView
         onCut?.invoke()
     }
 
+    override fun select(sender: Any?) {
+        selectionWillChange()
+        input?.selectTextNearCursor()
+        selectionDidChange()
+    }
+
     override fun selectAll(sender: Any?) {
         onSelectAll?.invoke()
     }
+
+    // On iOS Select and Select All buttons appear only when text selection is empty.
+    // The presence of the onSelectAll lambda indicates that the select action is available.
+    private val showSelectAndSelectAllMenus: Boolean get() =
+        onSelectAll != null && hasText() && input?.getSelectedTextRange()?.length == 0
 
     override fun canPerformAction(action: COpaquePointer?, withSender: Any?): Boolean =
         when (NSStringFromSelector(action)) {
             "copy:" -> onCopy != null
             "paste:" -> onPaste != null
             "cut:" -> onCut != null
-            "selectAll:" -> onSelectAll != null
+            "selectAll:" -> showSelectAndSelectAllMenus
+            "select:" -> showSelectAndSelectAllMenus
             else -> super.canPerformAction(action, withSender)
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui
 
-import androidx.compose.ui.interaction.TextFieldEditMenuTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -24,7 +23,6 @@ import platform.XCTest.XCTestSuite
 @Suppress("unused")
 @OptIn(ExperimentalForeignApi::class)
 fun testSuite(): XCTestSuite = setupXCTestSuite(
-    TextFieldEditMenuTest::class,
     // Run all test cases from the tests
     // BasicInteractionTest::class,
     // LayersAccessibilityTest::class,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui
 
-import androidx.compose.ui.interaction.TextFieldEditMenuTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -24,8 +23,6 @@ import platform.XCTest.XCTestSuite
 @Suppress("unused")
 @OptIn(ExperimentalForeignApi::class)
 fun testSuite(): XCTestSuite = setupXCTestSuite(
-    TextFieldEditMenuTest::testBasicTextFieldToolbar
-
     // Run all test cases from the tests
     // BasicInteractionTest::class,
     // LayersAccessibilityTest::class,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui
 
+import androidx.compose.ui.interaction.TextFieldEditMenuTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -23,6 +24,7 @@ import platform.XCTest.XCTestSuite
 @Suppress("unused")
 @OptIn(ExperimentalForeignApi::class)
 fun testSuite(): XCTestSuite = setupXCTestSuite(
+    TextFieldEditMenuTest::class,
     // Run all test cases from the tests
     // BasicInteractionTest::class,
     // LayersAccessibilityTest::class,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui
 
+import androidx.compose.ui.interaction.TextFieldEditMenuTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -23,6 +24,8 @@ import platform.XCTest.XCTestSuite
 @Suppress("unused")
 @OptIn(ExperimentalForeignApi::class)
 fun testSuite(): XCTestSuite = setupXCTestSuite(
+    TextFieldEditMenuTest::testBasicTextFieldToolbar
+
     // Run all test cases from the tests
     // BasicInteractionTest::class,
     // LayersAccessibilityTest::class,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -75,13 +75,16 @@ class TextFieldEditMenuTest {
     @Test
     fun testBasicTextFieldToolbar() = runContextMenuTest(false) {
         UIPasteboard.generalPasteboard().string = "Paste text"
+        val textValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
         setContent {
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField("Hello-LongLongLongLongLongLong-text", {}, modifier = Modifier.testTag("TextField"))
+                BasicTextField(textValue.value, { textValue.value = it }, modifier = Modifier.testTag("TextField"))
             }
         }
 
         openToolbar(textFieldTag = "TextField")
+
+        println(">>> SELECTION: ${textValue.value.selection}")
 
         verifyFullToolbarPresent()
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.firstNodeOrNull
+import androidx.compose.ui.test.getAccessibilityTree
 import androidx.compose.ui.test.isVisibleInContainer
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.hold
@@ -477,12 +478,20 @@ class TextFieldEditMenuTest {
         val selectionNode =
             findNodeWithLabelOrNull("Select All")?.takeIf { it.isVisibleInContainer }
                 ?: findNodeWithLabelOrNull("Select")?.takeIf { it.isVisibleInContainer }
-                ?: fail("Cannot find node with Select All or Select label")
 
-        assertNotNull(
-            selectionNode,
-            "Either Select or Select All context menu button must be visible"
-        )
+        if (selectionNode == null) {
+            println(">---------------------------------------------------------<")
+            println(">---------------------------------------------------------<")
+
+            println(getAccessibilityTree().printTree())
+
+            println(">---------------------------------------------------------<")
+            println(">---------------------------------------------------------<")
+        }
+
+        selectionNode ?: fail("Cannot find node with Select All or Select label")
+
+
         assertTrue(selectionNode.isAccessibilityElement ?: false)
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -84,8 +84,6 @@ class TextFieldEditMenuTest {
 
         openToolbar(textFieldTag = "TextField")
 
-        println(">>> SELECTION: ${textValue.value.selection}")
-
         verifyFullToolbarPresent()
     }
 
@@ -477,25 +475,10 @@ class TextFieldEditMenuTest {
             assertTrue(it.isAccessibilityElement ?: false)
         }
 
-        // On small screens it might be not enough space to fit both menus.
-        val selectionNode =
-            findNodeWithLabelOrNull("Select All")?.takeIf { it.isVisibleInContainer }
-                ?: findNodeWithLabelOrNull("Select")?.takeIf { it.isVisibleInContainer }
-
-        if (selectionNode == null) {
-            println(">---------------------------------------------------------<")
-            println(">---------------------------------------------------------<")
-
-            println(getAccessibilityTree().printTree())
-
-            println(">---------------------------------------------------------<")
-            println(">---------------------------------------------------------<")
+        findNodeWithLabel("Select All").let {
+            it.assertVisibleInContainer()
+            assertTrue(it.isAccessibilityElement ?: false)
         }
-
-        selectionNode ?: fail("Cannot find node with Select All or Select label")
-
-
-        assertTrue(selectionNode.isAccessibilityElement ?: false)
     }
 
     private fun UIKitInstrumentedTest.tapContextMenuButton(label: String) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.assertVisibleInContainer
 import androidx.compose.ui.test.findNodeWithLabel
+import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.firstNodeOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
@@ -59,6 +60,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.jetbrains.skiko.OS
@@ -469,7 +471,11 @@ class TextFieldEditMenuTest {
             assertTrue(it.isAccessibilityElement ?: false)
         }
 
-        findNodeWithLabel("Select All").let {
+        // On small screens it might be not enough space to fit both menus.
+        val selectionNode =
+            findNodeWithLabelOrNull("Select All") ?: findNodeWithLabelOrNull("Select")
+            ?: fail("Cannot find node with Select All or Select label")
+        selectionNode.let {
             it.assertVisibleInContainer()
             assertTrue(it.isAccessibilityElement ?: false)
         }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.TextField
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -77,8 +78,16 @@ class TextFieldEditMenuTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
         val textValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textValue.value, { textValue.value = it }, modifier = Modifier.testTag("TextField"))
+                BasicTextField(
+                    textValue.value,
+                    { textValue.value = it },
+                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
+                )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -92,8 +101,15 @@ class TextFieldEditMenuTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
         val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField"))
+                BasicTextField(
+                    textFieldState,
+                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
+                )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -106,8 +122,12 @@ class TextFieldEditMenuTest {
     fun testBasicTextFieldToolbarNewContextMenu() = runContextMenuTest(true) {
         UIPasteboard.generalPasteboard().string = "Paste text"
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                TextField("Hello-LongLongLongLongLong-text", {}, modifier = Modifier.testTag("TextField"))
+                TextField("Hello-LongLongLongLongLong-text", {}, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -121,8 +141,12 @@ class TextFieldEditMenuTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
         val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField"))
+                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -135,12 +159,16 @@ class TextFieldEditMenuTest {
     fun testBasicTextFieldToolbarInteraction() = runUIKitInstrumentedTest {
         val textFieldValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     value = textFieldValue.value,
                     onValueChange = { textFieldValue.value = it },
-                    modifier = Modifier.testTag("TextField")
+                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
                 )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -163,8 +191,12 @@ class TextFieldEditMenuTest {
     fun testBasicTextField2ToolbarInteraction() = runUIKitInstrumentedTest {
         val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField"))
+                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -186,9 +218,9 @@ class TextFieldEditMenuTest {
     @Test
     fun testBasicTextFieldLongPressShowsContextMenu() = runUIKitInstrumentedTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
-        val focusRequester = FocusRequester()
         val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4,4)))
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     value = textFieldValue.value,
@@ -198,7 +230,7 @@ class TextFieldEditMenuTest {
                         .focusRequester(focusRequester)
                 )
             }
-            LaunchedEffect(Unit) {
+            LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
             }
         }
@@ -223,9 +255,9 @@ class TextFieldEditMenuTest {
     @Test
     fun testBasicTextField2LongPressShowsContextMenu() = runUIKitInstrumentedTest {
         UIPasteboard.generalPasteboard().string = "Paste text"
-        val focusRequester = FocusRequester()
         val textFieldState = TextFieldState("Text", TextRange(4,4))
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     state = textFieldState,
@@ -234,7 +266,7 @@ class TextFieldEditMenuTest {
                         .focusRequester(focusRequester)
                 )
             }
-            LaunchedEffect(Unit) {
+            LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
             }
         }
@@ -396,12 +428,14 @@ class TextFieldEditMenuTest {
         var customItemClicked = false
         val textFieldValue = mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     value = textFieldValue.value,
                     onValueChange = { textFieldValue.value = it },
                     modifier = Modifier
                         .testTag("TextField")
+                        .focusRequester(focusRequester)
                         .appendTextContextMenuComponents {
                             item(key = "CustomKey", label = "Custom Action") {
                                 customItemClicked = true
@@ -413,6 +447,9 @@ class TextFieldEditMenuTest {
                             component.key == "CustomKey"
                         }
                 )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 
@@ -436,11 +473,13 @@ class TextFieldEditMenuTest {
         var customItemClicked = false
         val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
         setContent {
+            val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     state = textFieldState,
                     modifier = Modifier
                         .testTag("TextField")
+                        .focusRequester(focusRequester)
                         .appendTextContextMenuComponents {
                             item(key = "CustomKey", label = "Custom Action") {
                                 customItemClicked = true
@@ -452,6 +491,9 @@ class TextFieldEditMenuTest {
                             component.key == "CustomKey"
                         }
                 )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
             }
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.firstNodeOrNull
+import androidx.compose.ui.test.isVisibleInContainer
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.hold
 import androidx.compose.ui.test.utils.up
@@ -59,6 +60,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
@@ -473,12 +475,15 @@ class TextFieldEditMenuTest {
 
         // On small screens it might be not enough space to fit both menus.
         val selectionNode =
-            findNodeWithLabelOrNull("Select All") ?: findNodeWithLabelOrNull("Select")
-            ?: fail("Cannot find node with Select All or Select label")
-        selectionNode.let {
-            it.assertVisibleInContainer()
-            assertTrue(it.isAccessibilityElement ?: false)
-        }
+            findNodeWithLabelOrNull("Select All")?.takeIf { it.isVisibleInContainer }
+                ?: findNodeWithLabelOrNull("Select")?.takeIf { it.isVisibleInContainer }
+                ?: fail("Cannot find node with Select All or Select label")
+
+        assertNotNull(
+            selectionNode,
+            "Either Select or Select All context menu button must be visible"
+        )
+        assertTrue(selectionNode.isAccessibilityElement ?: false)
     }
 
     private fun UIKitInstrumentedTest.tapContextMenuButton(label: String) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -329,7 +329,7 @@ internal fun AccessibilityTestNode.normalized(): AccessibilityTestNode? {
     }
 }
 
-internal fun AccessibilityTestNode.assertVisibleInContainer() {
+internal val AccessibilityTestNode.isVisibleInContainer: Boolean get() {
     var frame = this.frame ?: DpRectZero()
     var iterator = parent
     while (iterator != null && iterator.element !is UIWindow) {
@@ -337,8 +337,12 @@ internal fun AccessibilityTestNode.assertVisibleInContainer() {
         iterator = iterator.parent
     }
 
+    return frame.width >= 1.dp && frame.height >= 1.dp
+}
+
+internal fun AccessibilityTestNode.assertVisibleInContainer() {
     assertTrue(
-        frame.width >= 1.dp && frame.height >= 1.dp,
+        isVisibleInContainer,
         "Element with frame ${this.frame} ($frame) is not visible or has very small size"
     )
 }


### PR DESCRIPTION
Implement custom logic to mimic the "Select" ios text field menu item behavior

Fixes https://youtrack.jetbrains.com/issue/CMP-1618/Support-iOS-17-context-menu-items

## Release Notes
### Features - iOS
- Add the 'Select' item on the context menu for the text fields