### PR TITLE
Improve AccessibilityLiveRegionTest stability

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
@@ -240,16 +240,20 @@ class AccessibilityLiveRegionTest {
         getAccessibilityTree()
         waitForIdle()
 
-        var last = lastAccessibilityNotification
-        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
-        assertEquals("Label, Value", last?.message)
+        val announcementNotification1 = accessibilityNotifications.last {
+            it.notification == UIAccessibilityAnnouncementNotification
+        }
+        assertNotNull(announcementNotification1)
+        assertEquals("Label, Value", announcementNotification1.message)
 
         label = "New Label"
         value = "New Value"
         waitForIdle()
 
-        last = lastAccessibilityNotification
-        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
-        assertEquals("New Label, New Value", last?.message)
+        val announcementNotification2 = accessibilityNotifications.last {
+            it.notification == UIAccessibilityAnnouncementNotification
+        }
+        assertNotNull(announcementNotification2)
+        assertEquals("New Label, New Value", announcementNotification2.message)
     }
 }


### PR DESCRIPTION
Improve tests stability caused by race conditions in the accessibility notifications order.

## Release Notes
N/A