### PR TITLE
Fix incorrect event listener target for selection change in Firefox and Safari

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -136,7 +136,7 @@ internal class DomInputStrategy(
         document.addEventListener("selectionchange", selectionChangeListener)
         // In Firefox and Safari we listen to the selection change on the input element.
         // Chrome is expected to dispatch this event too (https://chromium-review.googlesource.com/c/chromium/src/+/5598393),
-        // but it doesn't: https://partnerissuetracker.corp.google.com/issues/518751607
+        // but it doesn't: https://issuetracker.google.com/issues/518751607
         htmlInput.addEventListener("selectionchange", selectionChangeListener)
     }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -132,11 +132,17 @@ internal class DomInputStrategy(
                 composeSender.sendEditCommand(SetSelectionCommand(normalizedStart, normalizedEnd))
             }
         }
+        // In Chrome, we need to listen to the selection change on the document
         document.addEventListener("selectionchange", selectionChangeListener)
+        // In Firefox and Safari we listen to the selection change on the input element.
+        // Chrome is expected to dispatch this event too (https://chromium-review.googlesource.com/c/chromium/src/+/5598393),
+        // but it doesn't: https://partnerissuetracker.corp.google.com/issues/518751607
+        htmlInput.addEventListener("selectionchange", selectionChangeListener)
     }
 
     fun dispose() {
         document.removeEventListener("selectionchange", selectionChangeListener)
+        htmlInput.removeEventListener("selectionchange", selectionChangeListener)
         selectionChangeListener = null
     }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9803/Web-Mobile.-Android.-Firefox.-Moving-cursor-with-spacebar-doesnt-work

## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fix cursor control using spacebar sliding gesture in Firefox mobile


