### PR TITLE
[web] remove pointer event validation hack in favour of common synthetic event approach

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -605,10 +605,9 @@ internal class ComposeWindow(
         if (isMouseEvent(event)) {
             keyboardModeState = KeyboardModeState.Hardware
 
-            // validate event before sending it further - see
-            // https://youtrack.jetbrains.com/issue/CMP-8430/Sequence-of-Move-PointerInputEvents-cancel-out-press-PointerInputEvent-under-certain-conditions
-
-            var isValidEvent = true
+            // Track active mouse buttons. Used as a fallback for unreliable
+            // `buttons` in wheel events (see CMP-9900) and to reset state on
+            // `dragend` in Safari (see CMP-10102).
             when (eventType) {
                 PointerEventType.Press -> {
                     actualActivePointerButtons = event.composeButtons
@@ -616,12 +615,7 @@ internal class ComposeWindow(
                 PointerEventType.Release -> {
                     actualActivePointerButtons = null
                 }
-                PointerEventType.Move -> {
-                    isValidEvent = actualActivePointerButtons == null || actualActivePointerButtons == event.composeButtons
-                }
             }
-
-            if (!isValidEvent) return
 
             scene.sendPointerEvent(
                 eventType = eventType,

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -236,4 +236,47 @@ class MouseEventsTest : OnCanvasTests {
         assertEquals(PointerEventType.Move, pointerEvents[3].type)
         assertEquals(PointerEventType.Release, pointerEvents[4].type)
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-10185/Send-missing-input-events-in-Web-Target
+    @Test
+    fun testMouseMoveUnpressingButtonsSendsReleaseEvent() = runTest {
+        val pointerEvents = mutableListOf<ComposePointerEvent>()
+
+        createComposeWindow {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (isActive) {
+                                pointerEvents.add(awaitPointerEvent())
+                            }
+                        }
+                    }
+            ) {}
+        }
+
+        dispatchEvents(
+            PointerEvent("pointerenter", PointerEventInit(clientX = 100, clientY = 100, pointerType = "mouse")),
+            PointerEvent("pointerdown", PointerEventInit(clientX = 100, clientY = 100, button = 0, buttons = 1, pointerType = "mouse")),
+            PointerEvent("pointermove", PointerEventInit(clientX = 100, clientY = 100, buttons = 1, pointerType = "mouse")),
+        )
+
+        val countBefore = pointerEvents.count { it.type == PointerEventType.Release }
+        assertEquals(0, countBefore, "Release event sent too early")
+
+        // Move while the button is no longer pressed -> a synthetic Release should be emitted.
+        dispatchEvents(
+            PointerEvent("pointermove", PointerEventInit(clientX = 100, clientY = 100, buttons = 0, pointerType = "mouse")),
+        )
+
+        assertEquals(1, pointerEvents.count { it.type == PointerEventType.Release }, "Release event not sent")
+
+        // Make sure we don't send an extra release event afterward.
+        dispatchEvents(
+            PointerEvent("pointerup", PointerEventInit(clientX = 100, clientY = 100, button = 0, buttons = 0, pointerType = "mouse")),
+        )
+
+        assertEquals(1, pointerEvents.count { it.type == PointerEventType.Release }, "Extra release event sent")
+    }
 }


### PR DESCRIPTION
The abovementioned hack is obsolete after introduction of fixes to common logic (in 6cbdd5691f8)

## Testing
`./gradlew testWeb` plus manually with magic mouse 

## Release Notes
N/A