### PR TITLE
Make actionable nodes merge inner semantics

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -234,8 +234,7 @@ private sealed interface AccessibilityNode {
             get() = semanticsNode.contentDescription
 
         override val shouldMergeDescription: Boolean
-            get() = semanticsNode.unmergedConfig.isMergingSemanticsOfDescendants &&
-                semanticsNode.canBeAccessibilityElement()
+            get() = semanticsNode.canBeAccessibilityElement()
 
         override val accessibilityIdentifier: String?
             get() = cachedConfig.getOrNull(SemanticsProperties.TestTag)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -291,11 +291,19 @@ private fun LinkAnnotation.getTag(): String? =
 
 internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
     if (isHiddenFromAccessibility || isFake) return false
-    if (unmergedConfig.isActionableNode || unmergedConfig.isMergingSemanticsOfDescendants) return true
-
-    if (!unmergedConfig.isSpeakingNode) return false
+    if (unmergedConfig.isMergingSemanticsOfDescendants) return true
 
     val hasReplacedChildren = replacedChildren.isNotEmpty()
+
+    if (unmergedConfig.isActionableNode) {
+        return if (unmergedConfig.isSpeakingNode) {
+            true
+        } else {
+            hasReplacedChildren && isInsideMergingContext
+        }
+    }
+
+    if (!unmergedConfig.isSpeakingNode) return false
 
     var currentNode = layoutNode.parent
     while (currentNode != null) {
@@ -309,7 +317,7 @@ internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
             return true
         }
         if (currentNode.semanticsConfiguration?.isActionableNode == true) {
-            return false
+            return !SemanticsNode(currentNode, mergingEnabled = false).canBeAccessibilityElement()
         }
         currentNode = currentNode.parent
     }
@@ -317,7 +325,7 @@ internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
     return replacedChildren.isEmpty()
 }
 
-internal val SemanticsConfiguration.isActionableNode: Boolean
+private val SemanticsConfiguration.isActionableNode: Boolean
     get() = (contains(SemanticsActions.RequestFocus) ||
         contains(SemanticsActions.OnClick) ||
         contains(SemanticsActions.OnLongClick) ||
@@ -334,7 +342,7 @@ internal val SemanticsConfiguration.isActionableNode: Boolean
         contains(SemanticsActions.Dismiss) ||
         contains(SemanticsActions.CustomActions))
 
-internal val SemanticsConfiguration.isSpeakingNode: Boolean get() {
+private val SemanticsConfiguration.isSpeakingNode: Boolean get() {
     return contains(SemanticsProperties.ContentDescription) ||
         contains(SemanticsProperties.EditableText) ||
         contains(SemanticsProperties.Text) ||
@@ -342,6 +350,20 @@ internal val SemanticsConfiguration.isSpeakingNode: Boolean get() {
         contains(SemanticsProperties.ToggleableState) ||
         contains(SemanticsProperties.Selected) ||
         contains(SemanticsProperties.ProgressBarRangeInfo)
+}
+
+private val SemanticsNode.isInsideMergingContext: Boolean get() {
+    var currentNode = parent
+    while (currentNode != null) {
+        if (currentNode.unmergedConfig.isMergingSemanticsOfDescendants) {
+            return true
+        }
+        if (currentNode.unmergedConfig.getOrNull(SemanticsProperties.IsTraversalGroup) == true) {
+            return false
+        }
+        currentNode = currentNode.parent
+    }
+    return false
 }
 
 @Suppress("DEPRECATION")

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -290,14 +290,10 @@ private fun LinkAnnotation.getTag(): String? =
     }
 
 internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
-    return !isHiddenFromAccessibility &&
-        (unmergedConfig.isMergingSemanticsOfDescendants || isUnmergedSpeakingNode)
-}
+    if (isHiddenFromAccessibility || isFake) return false
+    if (unmergedConfig.isActionableNode || unmergedConfig.isMergingSemanticsOfDescendants) return true
 
-internal val SemanticsNode.isUnmergedSpeakingNode: Boolean get() {
-    if (isFake) return false
     if (!unmergedConfig.isSpeakingNode) return false
-    if (unmergedConfig.isActionableNode) return true
 
     val hasReplacedChildren = replacedChildren.isNotEmpty()
 
@@ -311,6 +307,9 @@ internal val SemanticsNode.isUnmergedSpeakingNode: Boolean get() {
         }
         if (currentNode.semanticsConfiguration?.getOrNull(SemanticsProperties.IsTraversalGroup) == true) {
             return true
+        }
+        if (currentNode.semanticsConfiguration?.isActionableNode == true) {
+            return false
         }
         currentNode = currentNode.parent
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -1358,6 +1358,39 @@ class ComponentsAccessibilitySemanticTest {
     }
 
     @Test
+    fun testSemanticsWithoutMergingInsideFocusableNodes() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier
+                    .testTag("ContentBox")
+                    .focusable()
+            ) {
+                Box {
+                    Text("Text 1")
+                }
+                Text("Text 2")
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = false
+                identifier = "ContentBox"
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Text 1"
+                traits(UIAccessibilityTraitStaticText)
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Text 2"
+                traits(UIAccessibilityTraitStaticText)
+            }
+        }
+    }
+
+    @Test
     fun testSemanticsMergingWithProgressIndicators() = runUIKitInstrumentedTest {
         setContent {
             Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -1318,6 +1318,46 @@ class ComponentsAccessibilitySemanticTest {
     }
 
     @Test
+    fun testSemanticsMergingInsideFocusableNodes() = runUIKitInstrumentedTest {
+        setContent {
+            Column(modifier = Modifier.clickable {}) {
+                Text("Line 1")
+                Column(modifier = Modifier.focusable()) {
+                    Text("Line 2")
+                    Text("Line 3")
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                label = "Line 1"
+                traits(UIAccessibilityTraitButton)
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 1"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Line 2, Line 3"
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 2"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 3"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+        }
+    }
+
+    @Test
     fun testSemanticsMergingWithProgressIndicators() = runUIKitInstrumentedTest {
         setContent {
             Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {


### PR DESCRIPTION
Mimic the Android TalkBack behavior where actionable nodes can merge inner semantics during announcement

Fixes https://youtrack.jetbrains.com/issue/CMP-9677/iOS-VoiceOver-Incorrect-reading-of-component-current-state

## Release Notes
### Fixes - iOS
- Focusable nodes inside merged semantics remain focusable