### PR TITLE
Update wasm Demo run configuration settings

### DIFF
--- a/.run/mpp/demo/wasm-Demo.run.xml
+++ b/.run/mpp/demo/wasm-Demo.run.xml
@@ -2,22 +2,26 @@
   <configuration default="false" name="wasm Demo" type="GradleRunConfiguration" factoryName="Gradle" folderName="mpp/demo">
     <ExternalSystemSettings>
       <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/mpp/demo" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--no-parallel" />
+      <option name="scriptParameters" value="--no-parallel --continuous" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="wasmJsBrowserDevelopmentRun" />
+          <option value=":compose:mpp:demo:wasmJsBrowserDevelopmentRun" />
         </list>
       </option>
       <option name="vmOptions" />
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
     <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
Small change to Wasm Demo run config to run with hot reload by default. Changes made and saved in the repo during development will trigger a reload. This improves DX as there is no need to rerun the run config again (and it incrementally rebuilds the project)
## Release Notes
N/A


