### PR TITLE
[web] don't process NativeInputEventsProcessor events that were not registered in DomInputStrategy

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -82,7 +82,7 @@ internal class DomInputStrategy(
     private val tabKeyCode = Key.Tab.keyCode.toInt()
 
     private fun initEvents() {
-
+        // Whenever new type of event is processed, don't forget to sync the NativeInputEventsProcessor::runCheckpoint isIME check
         htmlInput.addEventListener("keydown", { evt ->
             nativeInputEventsProcessor.registerEvent(evt as KeyboardEvent)
 
@@ -109,10 +109,6 @@ internal class DomInputStrategy(
 
                 nativeInputEventsProcessor.registerEvent(evt)
             }
-        })
-
-        htmlInput.addEventListener("compositionstart", { evt ->
-            nativeInputEventsProcessor.registerEvent(evt as CompositionEvent)
         })
 
         htmlInput.addEventListener("compositionend", { evt ->

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -102,9 +102,7 @@ internal abstract class NativeInputEventsProcessor(
         collectedEvents.sortBy { it.timeStamp.toInt() }
 
         val isInIMEComposition = collectedEvents.fastAny {
-            it.type == "compositionstart"
-                || it.type == "compositionupdate"
-                || it.type == "compositionend"
+                it.type == "compositionend"
                 || it.type == "keydown" && (it as KeyboardEvent).isComposing
                 || it.type == "beforeinput" && (it as InputEvent).isComposing
         }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -508,10 +508,9 @@ class NativeInputEventsProcessorTest {
         assertEquals(0, communicator.keyboardEvents.size)
 
         // 2. Simulate arrow navigation through accent options
-        processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight"))
-        processor.registerEvent(compositionStart())
+        processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
         processor.registerEvent(
-            beforeInput("insertText", "è").asInputEventExt().apply {
+            beforeInput("insertText", "è", isComposing = true).asInputEventExt().apply {
                 textRangeStart = 0
                 textRangeEnd = 1
             }


### PR DESCRIPTION
The goal of this PR is to remove `compositionstart` and `copmositionupdate`-related logic in NativeInputSrategy since we actually don't need to process this events in DomInputStrategy

## Testing
`./gradlew testWeb`

## Release Notes
N/A
