### PR TITLE
Update GitHub Actions to use newer iOS simulators

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,8 +4,6 @@ runs:
   steps:
     # List of available Xcode versions:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
-    # Note that explicit download is required due to updated support policy:
-    # https://github.com/actions/runner-images/issues/12758#issuecomment-3206748945
     - name: Setup Xcode version
       shell: bash
       run: |

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -3,13 +3,13 @@ runs:
   using: "composite"
   steps:
     # List of available Xcode versions:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode
     # Note that explicit download is required due to updated support policy:
     # https://github.com/actions/runner-images/issues/12758#issuecomment-3206748945
     - name: Setup Xcode version
       shell: bash
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.3.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
         /usr/bin/xcodebuild -version
 
     - name: Cache Xcode DerivedData

--- a/.github/workflows/check-public-api.yml
+++ b/.github/workflows/check-public-api.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-public-api:
-    runs-on: macos-15-xlarge
+    runs-on: macos-26-xlarge
     name: Check Public API
     steps:
       - name: Checkout Repository

--- a/.github/workflows/compose-publish-dry-run.yml
+++ b/.github/workflows/compose-publish-dry-run.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   compose-native-publish:
-    runs-on: macos-15-xlarge
+    runs-on: macos-26-xlarge
     name: Dry Run Compose Publish Darwin + Native Linux
     steps:
       - name: Checkout Repository

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -102,7 +102,7 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             -scheme CMPUIKitUtilsTests \
             -project CMPUIKitUtils.xcodeproj \
-            -destination 'platform=iOS Simulator,name=iPhone 16'
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -135,12 +135,12 @@ jobs:
         shell: bash
         run: |
           DEVICE_NAME="${{ matrix.device }}"
-          DEVICE_VERSION="26.5"
-          
-          DEVICE_DASH="${DEVICE_VERSION//./-}"   # e.g. 26.5 -> 26-5
+          DEVICE_VERSION="26.2"
+
+          DEVICE_DASH="${DEVICE_VERSION//./-}"   # e.g. 26.2 -> 26-2
           
           echo "Looking for device: '$DEVICE_NAME' ($DEVICE_VERSION)"
-          
+
           SIMULATOR_ID=$(xcrun simctl list devices available -j \
           | jq -r --arg device "$DEVICE_NAME" --arg vdot "$DEVICE_VERSION" --arg vdash "$DEVICE_DASH" '
           .devices

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: [ 'iPhone 16', 'iPad Pro 11-inch (M4)' ]
+        device: [ 'iPhone 17', 'iPad Pro 11-inch (M5)' ]
     name: Compose iOS Instrumented Tests ${{ matrix.device }}
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
@@ -135,9 +135,9 @@ jobs:
         shell: bash
         run: |
           DEVICE_NAME="${{ matrix.device }}"
-          DEVICE_VERSION="18.6"
+          DEVICE_VERSION="26.5"
           
-          DEVICE_DASH="${DEVICE_VERSION//./-}"   # 16.0 -> 16-0
+          DEVICE_DASH="${DEVICE_VERSION//./-}"   # e.g. 26.5 -> 26-5
           
           echo "Looking for device: '$DEVICE_NAME' ($DEVICE_VERSION)"
           

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -52,7 +52,7 @@ jobs:
         if: always()
 
   compose-ios-tests:
-    runs-on: macos-15-xlarge
+    runs-on: macos-26-xlarge
     name: Compose iOS Tests
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
@@ -79,7 +79,7 @@ jobs:
         if: always()
 
   compose-ios-utils-tests:
-    runs-on: macos-15-xlarge
+    runs-on: macos-26-xlarge
     name: Compose iOS Utils Tests
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
@@ -112,7 +112,7 @@ jobs:
           path: compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/TestResults.xcresult
 
   compose-ios-instrumented-tests:
-    runs-on: macos-15-xlarge
+    runs-on: macos-26-xlarge
     strategy:
       fail-fast: false
       matrix:
@@ -135,9 +135,9 @@ jobs:
         shell: bash
         run: |
           DEVICE_NAME="${{ matrix.device }}"
-          DEVICE_VERSION="26.2"
+          DEVICE_VERSION="26.5"
 
-          DEVICE_DASH="${DEVICE_VERSION//./-}"   # e.g. 26.2 -> 26-2
+          DEVICE_DASH="${DEVICE_VERSION//./-}"   # e.g. 26.5 -> 26-5
           
           echo "Looking for device: '$DEVICE_NAME' ($DEVICE_VERSION)"
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/HapticFeedbackSelectionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/HapticFeedbackSelectionTest.kt
@@ -25,11 +25,14 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -126,6 +129,7 @@ class HapticFeedbackSelectionTest {
     fun testBasicTextFieldValue_DoubleTap_DoesNotTriggerHaptic() = runUIKitInstrumentedTest {
         val hapticFeedback = TestHapticFeedback()
         var textFieldValue by mutableStateOf(TextFieldValue("Hello-LongLongLongLongLongLong-text"))
+        val focusRequester = FocusRequester()
 
         setContent {
             WithTestHapticFeedback(hapticFeedback) {
@@ -137,20 +141,21 @@ class HapticFeedbackSelectionTest {
                             .align(Alignment.Center)
                             .testTag("TextField")
                             .padding(16.dp)
+                            .focusRequester(focusRequester)
                     )
                 }
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
             }
         }
 
         // Perform double tap
-        selectWithDoubleTap("TextField")
+        findNodeWithTag("TextField").doubleTap()
 
         waitForIdle()
-
         // Verify that haptic feedback was NOT triggered
         hapticFeedback.assertNoHaptic()
-
-        assertFalse(textFieldValue.selection.collapsed)
     }
 
     @Test
@@ -190,6 +195,7 @@ class HapticFeedbackSelectionTest {
     fun testBasicTextFieldState_DoubleTap_DoesNotTriggerHaptic() = runUIKitInstrumentedTest {
         val hapticFeedback = TestHapticFeedback()
         val textFieldState = TextFieldState("Hello-LongLongLongLongLongLong-text")
+        val focusRequester = FocusRequester()
 
         setContent {
             WithTestHapticFeedback(hapticFeedback) {
@@ -200,19 +206,20 @@ class HapticFeedbackSelectionTest {
                             .align(Alignment.Center)
                             .testTag("TextField")
                             .padding(16.dp)
+                            .focusRequester(focusRequester)
                     )
                 }
             }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
         }
 
-        selectWithDoubleTap("TextField")
+        findNodeWithTag("TextField").doubleTap()
 
         waitForIdle()
-
         // Verify that haptic feedback was NOT triggered
         hapticFeedback.assertNoHaptic()
-
-        assertFalse(textFieldState.selection.collapsed)
     }
 
     @Test
@@ -277,12 +284,5 @@ class HapticFeedbackSelectionTest {
 
         // Verify that haptic feedback was NOT triggered
         hapticFeedback.assertNoHaptic()
-    }
-
-    private fun UIKitInstrumentedTest.selectWithDoubleTap(textFieldTag: String) {
-        findNodeWithTag(textFieldTag).tap()
-        delay(500)
-        findNodeWithTag(textFieldTag).doubleTap()
-        waitForIdle()
     }
 }


### PR DESCRIPTION

## Issues Fixed

Fixes: [CMP-10293](https://youtrack.jetbrains.com/issue/CMP-10293) Update GitHub Actions to use newer iOS simulators for compose tests.
26.5 was not available so 26.2 was set.

## Release Notes
N/A