### PR TITLE
Update back gesture progress calculation based on initial gesture offset

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.navigationevent
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.uikit.utils.CMPScreenEdgePanGestureRecognizer
 import androidx.compose.ui.unit.Density
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.width
 import androidx.navigationevent.NavigationEvent
 import kotlin.math.abs
+import kotlin.math.max
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
@@ -147,6 +149,8 @@ internal class UIKitNavigationEventInput(
             get() = this === startEdgePanGestureRecognizer ||
                 (this === endEdgePanGestureRecognizer && endEdgePanGestureBehavior == EndEdgePanGestureBehavior.Back)
 
+        private var initialGestureOffset = Offset.Zero
+
         private fun dispatchOnEventStarted(
             recognizer: UIScreenEdgePanGestureRecognizer,
             event: NavigationEvent
@@ -195,8 +199,8 @@ internal class UIKitNavigationEventInput(
                         return
                     }
                     val touch = recognizer.locationOfTouch(0u, view).toDpOffset()
-                    val eventOffset =
-                        touch.toOffset(density) - getTopLeftOffsetInWindow().toOffset()
+                    val eventOffset = touch.toOffset(density) - getTopLeftOffsetInWindow().toOffset()
+                    initialGestureOffset = eventOffset
                     dispatchOnEventStarted(
                         recognizer,
                         NavigationEvent(
@@ -217,15 +221,18 @@ internal class UIKitNavigationEventInput(
                     if (recognizer.numberOfTouches == 0uL || recognizer.numberOfTouches == NSUIntegerMax) {
                         return
                     }
-                    val touch = recognizer.locationOfTouch(0u, view).toDpOffset()
-                    val eventOffset =
-                        touch.toOffset(density) - getTopLeftOffsetInWindow().toOffset()
+                    val touch = recognizer.locationOfTouch(0u, view).toDpOffset().toOffset(density)
+                    val eventOffset = touch - getTopLeftOffsetInWindow().toOffset()
+
                     val leftEdge = recognizer.edges == UIRectEdgeLeft
-                    val bounds = view.bounds.toDpRect()
+                    val width = with(density) {
+                        view.bounds.toDpRect().width.toPx()
+                    }
+
                     val progress = if (leftEdge) {
-                        touch.x / bounds.width
+                        max(0f, touch.x - initialGestureOffset.x) / width
                     } else {
-                        (bounds.width - touch.x) / bounds.width
+                        max(0f, initialGestureOffset.x - touch.x) / width
                     }
                     dispatchOnEventProgressed(
                         recognizer,


### PR DESCRIPTION
Mimic iOS swipe back behavior when calculating back gesture progress.

Fixes https://youtrack.jetbrains.com/issue/CMP-10250/iOS-Navigation-gesture-anchor-is-centered-causing-a-visual-jump-at-the-start-of-the-animation

## Release Notes
### Fixes - iOS
- Fix content jump at the beginning of a swipe back gesture