### PR TITLE
Revert "Fix incorrect event listener target for selection change in Firefox and Safari (#3083)"

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -128,17 +128,11 @@ internal class DomInputStrategy(
                 composeSender.sendEditCommand(SetSelectionCommand(normalizedStart, normalizedEnd))
             }
         }
-        // In Chrome, we need to listen to the selection change on the document
         document.addEventListener("selectionchange", selectionChangeListener)
-        // In Firefox and Safari we listen to the selection change on the input element.
-        // Chrome is expected to dispatch this event too (https://chromium-review.googlesource.com/c/chromium/src/+/5598393),
-        // but it doesn't: https://issuetracker.google.com/issues/518751607
-        htmlInput.addEventListener("selectionchange", selectionChangeListener)
     }
 
     fun dispose() {
         document.removeEventListener("selectionchange", selectionChangeListener)
-        htmlInput.removeEventListener("selectionchange", selectionChangeListener)
         selectionChangeListener = null
     }
 


### PR DESCRIPTION
This reverts commit 77d5cbfad8ff4105d2afc1a9f8429177a059d4f3.

Unfortunately listening event simultanously on both input and document causes troubles in Safari and for now it's just safer to turn this changes off

## Testing
Manual fast delete

## Release Notes
N/A