### PR TITLE
Add public API to create Locale using platform NSLocale

### DIFF
--- a/compose/ui/ui-text/api/ui-text.klib.api
+++ b/compose/ui/ui-text/api/ui-text.klib.api
@@ -1,5 +1,6 @@
 // Klib ABI Dump
 // Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
+// Alias: apple => [iosArm64, iosSimulatorArm64, macosArm64]
 // Alias: ios => [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
@@ -2055,6 +2056,9 @@ final inline fun <#A: kotlin/Any> (androidx.compose.ui.text/AnnotatedString.Buil
 final inline fun <#A: kotlin/Any> (androidx.compose.ui.text/AnnotatedString.Builder).androidx.compose.ui.text/withStyle(androidx.compose.ui.text/SpanStyle, kotlin/Function1<androidx.compose.ui.text/AnnotatedString.Builder, #A>): #A // androidx.compose.ui.text/withStyle|withStyle@androidx.compose.ui.text.AnnotatedString.Builder(androidx.compose.ui.text.SpanStyle;kotlin.Function1<androidx.compose.ui.text.AnnotatedString.Builder,0:0>){0§<kotlin.Any>}[0]
 final inline fun <#A: kotlin/Any?> androidx.compose.ui.text.platform/synchronized(androidx.compose.ui.text.platform/SynchronizedObject, kotlin/Function0<#A>): #A // androidx.compose.ui.text.platform/synchronized|synchronized(androidx.compose.ui.text.platform.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 final inline fun androidx.compose.ui.text/buildAnnotatedString(kotlin/Function1<androidx.compose.ui.text/AnnotatedString.Builder, kotlin/Unit>): androidx.compose.ui.text/AnnotatedString // androidx.compose.ui.text/buildAnnotatedString|buildAnnotatedString(kotlin.Function1<androidx.compose.ui.text.AnnotatedString.Builder,kotlin.Unit>){}[0]
+
+// Targets: [apple]
+final fun (platform.Foundation/NSLocale).androidx.compose.ui.text.intl/toComposeLocale(): androidx.compose.ui.text.intl/Locale // androidx.compose.ui.text.intl/toComposeLocale|toComposeLocale@platform.Foundation.NSLocale(){}[0]
 
 // Targets: [ios]
 final val androidx.compose.ui.text.input/androidx_compose_ui_text_input_PlatformImeOptionsConfiguration$stableprop // androidx.compose.ui.text.input/androidx_compose_ui_text_input_PlatformImeOptionsConfiguration$stableprop|#static{}androidx_compose_ui_text_input_PlatformImeOptionsConfiguration$stableprop[0]

--- a/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
+++ b/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
@@ -32,8 +32,10 @@ internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     }
 
 @Immutable
-actual class Locale(
-    internal val platformLocale: NSLocale
+actual class Locale private constructor(
+    internal val platformLocale: NSLocale,
+    // parameter to avoid clash between constructor and extension function
+    @Suppress("UNUSED_PARAMETER") unused: Boolean
 ) {
     // Strip NSLocale-specific keyword suffixes so toLanguageTag stays BCP47-compatible.
     private val languageTag: String =
@@ -64,10 +66,17 @@ actual class Locale(
     actual companion object {
         actual val current: Locale
             get() = platformLocaleDelegate.current[0]
+
+        internal fun fromPlatformLocale(platformLocale: NSLocale): Locale = Locale(platformLocale, false)
     }
 
-    actual constructor(languageTag: String): this(NSLocale(languageTag))
+    actual constructor(languageTag: String): this(NSLocale(languageTag), false)
 }
+
+/**
+ * Create a [Locale] object from [NSLocale].
+ */
+fun Locale(platformLocale: NSLocale): Locale = Locale.fromPlatformLocale(platformLocale)
 
 private fun NSLocale.isRtl(): Boolean =
     NSLocale.characterDirectionForLanguage(languageCode) == NSLocaleLanguageDirectionRightToLeft

--- a/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
+++ b/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
@@ -31,21 +31,22 @@ internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
             get() = LocaleList(NSLocale.preferredLanguages.map { Locale(NSLocale(it as String)) })
     }
 
-internal fun NSLocale.isRtl(): Boolean =
-    NSLocale.characterDirectionForLanguage(languageCode) == NSLocaleLanguageDirectionRightToLeft
-
-
-// TODO: https://youtrack.jetbrains.com/issue/CMP-9697/Add-public-API-to-create-a-Compose-Locale-instance-via-NSLocale
 @Immutable
-actual class Locale internal constructor(internal val platformLocale: NSLocale) {
-    private val languageTag: String = platformLocale.languageIdentifier
+actual class Locale(
+    internal val platformLocale: NSLocale
+) {
+    // Strip NSLocale-specific keyword suffixes so toLanguageTag stays BCP47-compatible.
+    private val languageTag: String =
+        NSLocale.canonicalLanguageIdentifierFromString(
+            platformLocale.localeIdentifier.substringBefore("@")
+        )
 
     actual val language: String
         get() = platformLocale.languageCode
     actual val script: String
         get() = platformLocale.scriptCode.orEmpty()
     actual val region: String
-        get() = platformLocale.countryCode ?: "US"
+        get() = platformLocale.countryCode.orEmpty()
 
     actual fun toLanguageTag(): String = languageTag
 
@@ -67,6 +68,9 @@ actual class Locale internal constructor(internal val platformLocale: NSLocale) 
 
     actual constructor(languageTag: String): this(NSLocale(languageTag))
 }
+
+private fun NSLocale.isRtl(): Boolean =
+    NSLocale.characterDirectionForLanguage(languageCode) == NSLocaleLanguageDirectionRightToLeft
 
 internal actual fun Locale.isRtl(): Boolean {
     return platformLocale.isRtl()

--- a/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
+++ b/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.darwin.kt
@@ -32,10 +32,8 @@ internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     }
 
 @Immutable
-actual class Locale private constructor(
+actual class Locale internal constructor(
     internal val platformLocale: NSLocale,
-    // parameter to avoid clash between constructor and extension function
-    @Suppress("UNUSED_PARAMETER") unused: Boolean
 ) {
     // Strip NSLocale-specific keyword suffixes so toLanguageTag stays BCP47-compatible.
     private val languageTag: String =
@@ -66,17 +64,15 @@ actual class Locale private constructor(
     actual companion object {
         actual val current: Locale
             get() = platformLocaleDelegate.current[0]
-
-        internal fun fromPlatformLocale(platformLocale: NSLocale): Locale = Locale(platformLocale, false)
     }
 
-    actual constructor(languageTag: String): this(NSLocale(languageTag), false)
+    actual constructor(languageTag: String): this(NSLocale(languageTag))
 }
 
 /**
- * Create a [Locale] object from [NSLocale].
+ * Creates [Locale] object from platform specific [NSLocale].
  */
-fun Locale(platformLocale: NSLocale): Locale = Locale.fromPlatformLocale(platformLocale)
+fun NSLocale.toComposeLocale(): Locale = Locale(this)
 
 private fun NSLocale.isRtl(): Boolean =
     NSLocale.characterDirectionForLanguage(languageCode) == NSLocaleLanguageDirectionRightToLeft

--- a/compose/ui/ui-text/src/darwinTest/kotlin/androidx/compose/ui/text/intl/LocaleTest.kt
+++ b/compose/ui/ui-text/src/darwinTest/kotlin/androidx/compose/ui/text/intl/LocaleTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.intl
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import platform.Foundation.NSLocale
+
+class LocaleTest {
+    @Test
+    fun platformLocale_sharesTheAttributes() {
+        val platformLocale = NSLocale("sr-Latn-SR")
+        val locale = Locale(platformLocale)
+
+        assertEquals(platformLocale, locale.platformLocale)
+        assertEquals("sr", locale.language)
+        assertEquals("Latn", locale.script)
+        assertEquals("SR", locale.region)
+        assertEquals("sr-Latn-SR", locale.toLanguageTag())
+    }
+
+    @Test
+    fun forLanguageTag_withoutRegion() {
+        val locale = Locale("ja")
+
+        assertEquals("ja", locale.language)
+        assertEquals("", locale.script)
+        assertEquals("", locale.region)
+        assertEquals("ja", locale.toLanguageTag())
+    }
+
+    @Test
+    fun forLanguageTag_withScript() {
+        val locale = Locale("zh-Hant-TW")
+
+        assertEquals("zh", locale.language)
+        assertEquals("Hant", locale.script)
+        assertEquals("TW", locale.region)
+        assertEquals("zh-Hant-TW", locale.toLanguageTag())
+    }
+}

--- a/compose/ui/ui-text/src/darwinTest/kotlin/androidx/compose/ui/text/intl/LocaleTest.kt
+++ b/compose/ui/ui-text/src/darwinTest/kotlin/androidx/compose/ui/text/intl/LocaleTest.kt
@@ -24,7 +24,7 @@ class LocaleTest {
     @Test
     fun platformLocale_sharesTheAttributes() {
         val platformLocale = NSLocale("sr-Latn-SR")
-        val locale = Locale(platformLocale)
+        val locale = platformLocale.toComposeLocale()
 
         assertEquals(platformLocale, locale.platformLocale)
         assertEquals("sr", locale.language)


### PR DESCRIPTION
Adds public API to create `Locale` using platform `NSLocale`

Fixes [CMP-9697](https://youtrack.jetbrains.com/issue/CMP-9697) Add public API to create a Compose Locale instance via NSLocale

## Testing
Adds `LocaleTest` test suite

## Release Notes
### Features - iOS
- Add `NSLocale.toComposeLocale()` API to create `Locale` from platform `NSLocale`
