### PR TITLE
[web] in certain cases deleteContentBackward behaves as deleteWordBackward

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -158,18 +158,12 @@ internal abstract class NativeInputEventsProcessor(
     }
 
     private fun InputEventExt.createDeleteWordCommand(): EditCommand? {
-        val shouldTriggerDelete = when {
-            lastProcessedKeydown?.isBackspace() != true -> false
-            lastProcessedKeydown?.repeat == true -> true
-            else -> false
-        }
+        val keydown = lastProcessedKeydown ?: return null
+        if (!keydown.isBackspace() || !keydown.repeat) return null
+        val layoutResult = composeSender.currentTextLayoutResult() ?: return null
 
-        return if (shouldTriggerDelete) {
-            val layoutResult = composeSender.currentTextLayoutResult() ?: return null
-
-            val offset = layoutResult.getPrevWordOffset(textRangeEnd)
-            DeleteSurroundingTextCommand((textRangeEnd - offset).coerceAtLeast(0), 0)
-        } else null
+        val offset = layoutResult.getPrevWordOffset(textRangeEnd)
+        return DeleteSurroundingTextCommand((textRangeEnd - offset).coerceAtLeast(0), 0)
     }
 
     private fun InputEventExt.process(currentTextFieldValue: TextFieldValue) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.BackspaceCommand
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
+import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
@@ -156,6 +157,21 @@ internal abstract class NativeInputEventsProcessor(
         collectedEvents.clear()
     }
 
+    private fun InputEventExt.createDeleteWordCommand(): EditCommand? {
+        val shouldTriggerDelete = when {
+            lastProcessedKeydown?.isBackspace() != true -> false
+            lastProcessedKeydown?.repeat == true -> true
+            else -> false
+        }
+
+        return if (shouldTriggerDelete) {
+            val layoutResult = composeSender.currentTextLayoutResult() ?: return null
+
+            val offset = layoutResult.getPrevWordOffset(textRangeEnd)
+            DeleteSurroundingTextCommand((textRangeEnd - offset).coerceAtLeast(0), 0)
+        } else null
+    }
+
     private fun InputEventExt.process(currentTextFieldValue: TextFieldValue) {
         val editCommands = when (inputType) {
             "deleteContentBackward" -> buildList {
@@ -168,40 +184,28 @@ internal abstract class NativeInputEventsProcessor(
                         // When Compose TextField has text selection, a good UX for deleteContentBackward would be to emulate Backspace.
                         add(BackspaceCommand())
                     }
-                } else { // Empty selection case.
-                    // This happens when an autocorrection is applied on mobile:
-                    // The system first tells us to delete the old text,
-                    // and then it would send the "insertText" event.
-                    if (textRangeSize > 0) {
-                        // deleteContentBackward can happen under very non-trivial circumstances:
-                        // - for instance, when an input suggestion on Android Chrome is accepted,
-                        // the browser then deletes space after the word just to add space again;
-                        // - or when a browser performs Fast Delete;
-                        add(SetSelectionCommand(textRangeStart, textRangeEnd))
+                } else {
+                    // We skip this branch if the lastProcessedKeydown is Backspace, because Compose must have already processed this.
+                    // Otherwise, under specific circumstance previous symbol can be deleted while inputting the new one
+                    // see https://youtrack.jetbrains.com/issue/CMP-8773
+                    if (lastProcessedKeydown?.isBackspace() != true) {
+                        // This happens when an autocorrection is applied on mobile:
+                        // The system first tells us to delete the old text,
+                        // and then it would send the "insertText" event.
+                        if (textRangeSize > 0) {
+                            add(SetSelectionCommand(textRangeStart, textRangeEnd))
+                        }
+
                         add(BackspaceCommand())
-                    } else if (textRangeSize == 0 && lastProcessedKeydown?.isBackspace() != true) {
-                        // We skip this branch if the lastProcessedKeydown is Backspace, because Compose must have already processed this.
-                        // Otherwise, under specific circumstance previous symbol can be deleted while inputting the new one
-                        // see https://youtrack.jetbrains.com/issue/CMP-8773
-                        add(BackspaceCommand())
+                    } else {
+                        createDeleteWordCommand()?.let { add(it) }
                     }
                 }
             }
 
             "deleteWordBackward" -> buildList {
-                if (lastProcessedKeydown?.isBackspace() != true) return@buildList
-
-                // This would mean event was triggered by long press on mobile device (iOS)
-                if (lastProcessedKeydown?.repeat == true) {
-                    val layoutResult = composeSender.currentTextLayoutResult() ?: return@buildList
-
-
-                    val offset = layoutResult.getPrevWordOffset(textRangeEnd)
-                    val deleteCommand = DeleteSurroundingTextCommand((textRangeEnd - offset).coerceAtLeast(0), 0)
-                    add(deleteCommand)
-                }
+                createDeleteWordCommand()?.let { add(it) }
             }
-
 
             "insertReplacementText" -> buildList {
                 if (data == null) return@buildList

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -179,21 +179,22 @@ internal abstract class NativeInputEventsProcessor(
                         add(BackspaceCommand())
                     }
                 } else {
-                    // We skip this branch if the lastProcessedKeydown is Backspace, because Compose must have already processed this.
-                    // Otherwise, under specific circumstance previous symbol can be deleted while inputting the new one
-                    // see https://youtrack.jetbrains.com/issue/CMP-8773
-                    if (lastProcessedKeydown?.isBackspace() != true) {
-                        // This happens when an autocorrection is applied on mobile:
-                        // The system first tells us to delete the old text,
-                        // and then it would send the "insertText" event.
-                        if (textRangeSize > 0) {
-                            add(SetSelectionCommand(textRangeStart, textRangeEnd))
-                        }
-
+                    // This happens when an autocorrection is applied on mobile:
+                    // The system first tells us to delete the old text,
+                    // and then it would send the "insertText" event.
+                    if (textRangeSize > 0) {
+                        // deleteContentBackward can happen under very non-trivial circumstances:
+                        // - for instance, when an input suggestion on Android Chrome is accepted,
+                        // the browser then deletes space after the word just to add space again;
+                        // - or when a browser performs Fast Delete;
+                        add(SetSelectionCommand(textRangeStart, textRangeEnd))
+                        add(BackspaceCommand())
+                    } else if (textRangeSize == 0 && lastProcessedKeydown?.isBackspace() != true) {
+                        // We skip this branch if the lastProcessedKeydown is Backspace, because Compose must have already processed this.
+                        // Otherwise, under specific circumstance previous symbol can be deleted while inputting the new one
+                        // see https://youtrack.jetbrains.com/issue/CMP-8773
                         add(BackspaceCommand())
                     } else {
-                        // certain keyboard layout trigger deleteContentBackward on fast delete
-                        // https://youtrack.jetbrains.com/issue/CMP-10086
                         createDeleteWordCommand()?.let { add(it) }
                     }
                 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -198,6 +198,8 @@ internal abstract class NativeInputEventsProcessor(
 
                         add(BackspaceCommand())
                     } else {
+                        // certain keyboard layout trigger deleteContentBackward on fast delete
+                        // https://youtrack.jetbrains.com/issue/CMP-10086
                         createDeleteWordCommand()?.let { add(it) }
                     }
                 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/DeleteWordBackwardTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/DeleteWordBackwardTests.kt
@@ -27,7 +27,7 @@ import kotlin.test.Test
 
 class DeleteWordBackwardTests : TextFieldTestSpec, BasicTextFieldWithValue {
 
-    fun sendPhysicalDeleteWordBackward() {
+    private fun sendPhysicalDeleteWordBackward() {
         sendToHtmlInput(
             keyEvent(
                 key = "Backspace",
@@ -39,7 +39,7 @@ class DeleteWordBackwardTests : TextFieldTestSpec, BasicTextFieldWithValue {
         )
     }
 
-    fun sendVirtualDeleteWordBackward() {
+    private fun sendVirtualDeleteWordBackward() {
         sendToHtmlInput(
             keyEvent(
                 key = "Backspace",
@@ -48,6 +48,18 @@ class DeleteWordBackwardTests : TextFieldTestSpec, BasicTextFieldWithValue {
                 repeat = true,
             ),
             beforeInput("deleteWordBackward", null)
+        )
+    }
+
+    private fun sendVirtualFastDeleteAsContentBackward() {
+        sendToHtmlInput(
+            keyEvent(
+                key = "Backspace",
+                code = "Backspace",
+                type = "keydown",
+                repeat = true,
+            ),
+            beforeInput("deleteContentBackward", null)
         )
     }
 
@@ -189,6 +201,21 @@ class DeleteWordBackwardTests : TextFieldTestSpec, BasicTextFieldWithValue {
 
         sendPhysicalDeleteWordBackward()
         textFieldValue.awaitAndAssertTextEquals("천천히 ")
+    }
+
+    @Test
+    fun deletePrevWordVirtualMiddle_viaDeleteContentBackward_CMP_10086() = runApplicationTest {
+        val textFieldValue = createApplicationWithHolder(
+            "here   we     go again!!!",
+            initialSelection = TextRange(14, 14)
+        )
+        awaitAnimationFrame()
+
+        sendVirtualFastDeleteAsContentBackward()
+        textFieldValue.awaitAndAssertTextEquals(
+            "here  go again!!!",
+            "deleteContentBackward with repeating Backspace should behave as deleteWordBackward (CMP-10086)"
+        )
     }
 
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -701,10 +701,15 @@ class NativeInputEventsProcessorTest {
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
-        // The deleteContentBackward event should be ignored since Backspace key was pressed:
-        // Compose already processed the Backspace via the key event, so no edit commands should be produced.
         assertEquals(1, communicator.keyboardEvents.size)
-        assertEquals(0, communicator.editCommands.size)
+        assertEquals(2, communicator.editCommands.size)
+
+        val selectionCommand = communicator.editCommands[0]
+        assertTrue(selectionCommand is SetSelectionCommand)
+        assertEquals(8, selectionCommand.start)
+        assertEquals(12, selectionCommand.end)
+
+        assertEquals("example ", communicator.currentTextFieldValue().text)
     }
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -701,15 +701,10 @@ class NativeInputEventsProcessorTest {
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
+        // The deleteContentBackward event should be ignored since Backspace key was pressed:
+        // Compose already processed the Backspace via the key event, so no edit commands should be produced.
         assertEquals(1, communicator.keyboardEvents.size)
-        assertEquals(2, communicator.editCommands.size)
-
-        val selectionCommand = communicator.editCommands[0]
-        assertTrue(selectionCommand is SetSelectionCommand)
-        assertEquals(8, selectionCommand.start)
-        assertEquals(12, selectionCommand.end)
-
-        assertEquals("example ", communicator.currentTextFieldValue().text)
+        assertEquals(0, communicator.editCommands.size)
     }
 
     @Test


### PR DESCRIPTION
The goal of this PR is to treat deleteContentBackward as deleteWordBackward when we ran out of other options to "guess" what happened.

It also adds dedicated web regression coverage for the repeated-Backspace `deleteContentBackward` path that should fall back to word deletion.

## Testing
Manual + `gradlew testWeb`

## Release Notes
### Fixes - Web
- <a href="https://youtrack.jetbrains.com/issue/CMP-10086">CMP-10086</a> [Web] Mobile. iOS. Cangjie - Traditional. 'Fast delete' doesn't work correctly