### PR TITLE
Treat Web pixel wheel events as precise

### DIFF
--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/gestures/JsScrollable.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/gestures/JsScrollable.web.kt
@@ -18,6 +18,7 @@
 
 package androidx.compose.foundation.gestures
 
+import androidx.compose.ui.dom.domEventOrNull
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFold
+import org.w3c.dom.events.WheelEvent
 
 internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig(): ScrollConfig = JsConfig
 
@@ -38,6 +40,9 @@ private object JsConfig : ScrollConfig {
         // However, keep in mind that any modifications would also necessitate adjustments to the corresponding tests.
         return event.totalScrollDelta * -1.dp.toPx()
     }
+
+    override fun isPreciseWheelScroll(event: PointerEvent): Boolean =
+        (event.domEventOrNull as? WheelEvent)?.deltaMode == WheelEvent.DOM_DELTA_PIXEL
 }
 
 private val PointerEvent.totalScrollDelta

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -4913,6 +4913,10 @@ final val androidx.compose.ui.dom/domEventOrNull // androidx.compose.ui.dom/domE
     final fun (androidx.compose.ui.input.key/KeyEvent).<get-domEventOrNull>(): org.w3c.dom.events/KeyboardEvent? // androidx.compose.ui.dom/domEventOrNull.<get-domEventOrNull>|<get-domEventOrNull>@androidx.compose.ui.input.key.KeyEvent(){}[0]
 
 // Targets: [js, wasmJs]
+final val androidx.compose.ui.dom/domEventOrNull // androidx.compose.ui.dom/domEventOrNull|@androidx.compose.ui.input.pointer.PointerEvent{}domEventOrNull[0]
+    final fun (androidx.compose.ui.input.pointer/PointerEvent).<get-domEventOrNull>(): org.w3c.dom.events/Event? // androidx.compose.ui.dom/domEventOrNull.<get-domEventOrNull>|<get-domEventOrNull>@androidx.compose.ui.input.pointer.PointerEvent(){}[0]
+
+// Targets: [js, wasmJs]
 final val androidx.compose.ui.input.pointer/androidx_compose_ui_input_pointer_DummyPointerIcon$stableprop // androidx.compose.ui.input.pointer/androidx_compose_ui_input_pointer_DummyPointerIcon$stableprop|#static{}androidx_compose_ui_input_pointer_DummyPointerIcon$stableprop[0]
 
 // Targets: [js, wasmJs]

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/dom/Events.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/dom/Events.web.kt
@@ -18,6 +18,8 @@ package androidx.compose.ui.dom
 
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.internal
+import androidx.compose.ui.input.pointer.PointerEvent
+import org.w3c.dom.events.Event
 import org.w3c.dom.events.KeyboardEvent
 
 
@@ -31,3 +33,16 @@ import org.w3c.dom.events.KeyboardEvent
  */
 val KeyEvent.domEventOrNull: KeyboardEvent?
     get() = internal.nativeEvent as? KeyboardEvent?
+
+/**
+ * The original raw native DOM event.
+ *
+ * Null if:
+ * - the native event is sent by another framework (when Compose UI is embed into it)
+ * - there is no native event (in tests, for example)
+ * - the event is a synthetic event sent by Compose
+ *
+ * Always check for null, when you want to handle the native event
+ */
+val PointerEvent.domEventOrNull: Event?
+    get() = nativeEvent as? Event?

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/WheelEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/WheelEventTests.kt
@@ -62,6 +62,36 @@ class WheelEventTests : OnCanvasTests {
     }
 
     @Test
+    fun pixelModeWheelScrollIsAppliedImmediately() = runTest {
+        val verticalScrollState = ScrollState(initial = 0)
+
+        createComposeWindow {
+            CompositionLocalProvider(LocalDensity provides Density(2f)) {
+                Box(
+                    modifier = Modifier.size(100.dp).verticalScroll(verticalScrollState)
+                ) {
+                    Column(modifier = Modifier.size(400.dp)) { }
+                }
+            }
+        }
+
+        assertEquals(0, verticalScrollState.value)
+
+        getCanvas().dispatchEvent(
+            WheelEvent(
+                "wheel",
+                WheelEventInit(deltaY = 100.0, deltaMode = WheelEvent.DOM_DELTA_PIXEL)
+            )
+        )
+
+        assertEquals(
+            200,
+            verticalScrollState.value,
+            "pixel-mode wheel scroll should apply immediately"
+        )
+    }
+
+    @Test
     fun horizontalScroll() = runTest {
         val horizontalScrollState = ScrollState(initial = 0)
 


### PR DESCRIPTION
## Summary

Treat Web `WheelEvent.DOM_DELTA_PIXEL` scroll events as precise wheel input in the platform scroll config.

## Issue

https://youtrack.jetbrains.com/issue/CMP-10297

## Root cause

Web wheel events already carry browser/device pixel deltas, including high-resolution touchpad momentum. The Web scroll config did not mark these events as precise, so large pixel-mode wheel deltas went through the common smooth mouse-wheel animation path instead of being applied immediately.

That path first applies only the animation threshold, then animates the remaining delta. In the regression test added here, a `deltaY = 100.0` pixel-mode event at density `2f` applied only `12px` before this change instead of the expected `200px`.

## Change

- Expose the raw Web DOM event for `PointerEvent` via `domEventOrNull`, matching the existing Web `KeyEvent` accessor and other platform native-event accessors.
- Use that accessor in the Web scroll config to classify `WheelEvent.DOM_DELTA_PIXEL` as precise.
- Add a Web wheel regression test that verifies a large pixel-mode wheel delta is applied immediately.

## Validation

- `./gradlew :compose:foundation:foundation:compileWebMainKotlinMetadata --warning-mode all`
- `./gradlew :compose:ui:ui:jsBrowserTest --tests androidx.compose.ui.window.WheelEventTests.pixelModeWheelScrollIsAppliedImmediately --warning-mode all`
- `./gradlew :compose:ui:ui:wasmJsBrowserTest --tests androidx.compose.ui.window.WheelEventTests.pixelModeWheelScrollIsAppliedImmediately --warning-mode all`
- `./gradlew :compose:ui:ui:jsBrowserTest :compose:ui:ui:wasmJsBrowserTest --tests androidx.compose.ui.window.WheelEventTests --warning-mode all`

## Release Notes

### Fixes - Web

- Fixed pixel-mode wheel events on Web being treated as animated mouse-wheel input, improving precision trackpad scrolling responsiveness.
