### PR TITLE
Guard scene/owner lifecycle against use-after-dispose and detached components

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
@@ -35,7 +35,7 @@ class SkiaGraphicsContext(
         private set
 
     fun dispose() {
-        check(!isClosed) { "GraphicsContext is already closed" }
+        require(!isClosed) { "GraphicsContext is already closed" }
         isClosed = true
         renderNodeContext.close()
     }
@@ -48,7 +48,7 @@ class SkiaGraphicsContext(
         ambientShadowAlpha: Float = 0f,
         spotShadowAlpha: Float = 0f
     ) {
-        check(!isClosed) { "GraphicsContext is already closed" }
+        require(!isClosed) { "GraphicsContext is already closed" }
         renderNodeContext.setLightingInfo(
             centerX,
             centerY,
@@ -60,7 +60,7 @@ class SkiaGraphicsContext(
     }
 
     override fun createGraphicsLayer(): GraphicsLayer {
-        check(!isClosed) { "GraphicsContext is already closed" }
+        require(!isClosed) { "GraphicsContext is already closed" }
         activeGraphicsLayersCount++
         return GraphicsLayer(
             renderNode = RenderNode(renderNodeContext)

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
@@ -28,12 +28,15 @@ class SkiaGraphicsContext(
     private val renderNodeContext = RenderNodeContext(
         measureDrawBounds = measureDrawBounds,
     )
+    private var isClosed = false
 
     // Temporary workaround to disable state tracking workaround inside old internal layers
     var activeGraphicsLayersCount = 0
         private set
 
     fun dispose() {
+        check(!isClosed) { "GraphicsContext is already closed" }
+        isClosed = true
         renderNodeContext.close()
     }
 
@@ -45,6 +48,7 @@ class SkiaGraphicsContext(
         ambientShadowAlpha: Float = 0f,
         spotShadowAlpha: Float = 0f
     ) {
+        check(!isClosed) { "GraphicsContext is already closed" }
         renderNodeContext.setLightingInfo(
             centerX,
             centerY,
@@ -56,6 +60,7 @@ class SkiaGraphicsContext(
     }
 
     override fun createGraphicsLayer(): GraphicsLayer {
+        check(!isClosed) { "GraphicsContext is already closed" }
         activeGraphicsLayersCount++
         return GraphicsLayer(
             renderNode = RenderNode(renderNodeContext)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -25,12 +25,10 @@ import androidx.compose.ui.util.fastRoundToInt
 import java.awt.Component
 import java.awt.EventQueue
 import java.awt.Graphics
-import java.awt.Point
 import java.awt.Rectangle
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JLayeredPane
 import javax.swing.RootPaneContainer
-import javax.swing.SwingUtilities
 import kotlin.math.ceil
 import kotlin.math.floor
 import org.jetbrains.skiko.OS
@@ -45,15 +43,6 @@ internal fun Component.isParentOf(component: Component?): Boolean {
         parent = parent.parent
     }
     return false
-}
-
-internal fun Component.locationOn(component: Component?): Point {
-    if (component == null) return Point(0, 0)
-    return  SwingUtilities.convertPoint(
-        /* source = */ this,
-        /* aPoint = */ Point(0, 0),
-        /* destination = */ component,
-    )
 }
 
 internal fun toAwtRectangle(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -25,10 +25,12 @@ import androidx.compose.ui.util.fastRoundToInt
 import java.awt.Component
 import java.awt.EventQueue
 import java.awt.Graphics
+import java.awt.Point
 import java.awt.Rectangle
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JLayeredPane
 import javax.swing.RootPaneContainer
+import javax.swing.SwingUtilities
 import kotlin.math.ceil
 import kotlin.math.floor
 import org.jetbrains.skiko.OS
@@ -43,6 +45,15 @@ internal fun Component.isParentOf(component: Component?): Boolean {
         parent = parent.parent
     }
     return false
+}
+
+internal fun Component.locationOn(component: Component?): Point {
+    if (component == null) return Point(0, 0)
+    return  SwingUtilities.convertPoint(
+        /* source = */ this,
+        /* aPoint = */ Point(0, 0),
+        /* destination = */ component,
+    )
 }
 
 internal fun toAwtRectangle(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.awt.locationOn
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.unit.roundToIntSize
@@ -67,11 +68,26 @@ internal class PlatformWindowContext {
         _windowInfo.containerDpSize = component.size.toDpSize()
     }
 
-    fun convertLocalToWindowPosition(container: Component, localPosition: Offset) =
-        localPosition + offsetInWindow(container).toDpOffset().toOffset(container.density)
+    private inline fun withOffsetInWindowOrUnspecified(
+        component: Component,
+        block: (offsetInWindow: Offset) -> Offset
+    ): Offset {
+        if (!component.isDisplayable) return Offset.Unspecified
 
-    fun convertWindowToLocalPosition(container: Component, positionInWindow: Offset) =
-        positionInWindow - offsetInWindow(container).toDpOffset().toOffset(container.density)
+        return block(component.locationOn(_windowContainer).toDpOffset().toOffset(component.density))
+    }
+
+    fun convertLocalToWindowPosition(container: Component, localPosition: Offset): Offset {
+        return withOffsetInWindowOrUnspecified(container) {
+            localPosition + it
+        }
+    }
+
+    fun convertWindowToLocalPosition(container: Component, positionInWindow: Offset): Offset {
+        return withOffsetInWindowOrUnspecified(container) {
+            positionInWindow - it
+        }
+    }
 
     /**
      * If the [component]'s location on screen is undefined, returns [Offset.Unspecified]; otherwise
@@ -105,17 +121,13 @@ internal class PlatformWindowContext {
     }
 
     /**
-     * Calculates the offset of the given [container] within the window.
+     * Calculates the offset of the given [component] within the window.
      * It uses [_windowContainer] as a reference for window coordinate space.
      *
-     * @param container The container component whose offset needs to be calculated.
+     * @param component The container component whose offset needs to be calculated.
      * @return The offset of the container within the window as an [Point] object.
      */
-    fun offsetInWindow(container: Component): Point {
-        return if (_windowContainer != null) {
-            SwingUtilities.convertPoint(container, Point(0, 0), _windowContainer)
-        } else {
-            Point(0, 0)
-        }
+    fun locationOnWindow(component: Component): Point {
+        return component.locationOn(_windowContainer)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -19,16 +19,15 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.awt.locationOn
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.toDpOffset
-import androidx.compose.ui.window.toDpSize
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
+import androidx.compose.ui.window.toDpOffset
+import androidx.compose.ui.window.toDpSize
 import java.awt.Component
 import java.awt.Container
 import java.awt.Frame
@@ -72,9 +71,10 @@ internal class PlatformWindowContext {
         component: Component,
         block: (offsetInWindow: Offset) -> Offset
     ): Offset {
-        if (!component.isDisplayable) return Offset.Unspecified
-
-        return block(component.locationOn(_windowContainer).toDpOffset().toOffset(component.density))
+        if (_windowContainer == null || SwingUtilities.getWindowAncestor(component) == null) {
+            return Offset.Unspecified
+        }
+        return block(locationInWindow(component).toDpOffset().toOffset(component.density))
     }
 
     fun convertLocalToWindowPosition(container: Component, localPosition: Offset): Offset {
@@ -124,10 +124,15 @@ internal class PlatformWindowContext {
      * Calculates the offset of the given [component] within the window.
      * It uses [_windowContainer] as a reference for window coordinate space.
      *
-     * @param component The container component whose offset needs to be calculated.
-     * @return The offset of the container within the window as an [Point] object.
+     * @param component The component whose offset needs to be calculated.
+     * @return The offset of the component within the window as an [Point] object.
      */
-    fun locationOnWindow(component: Component): Point {
-        return component.locationOn(_windowContainer)
+    fun locationInWindow(component: Component): Point {
+        if (_windowContainer == null) return Point(0, 0)
+        return  SwingUtilities.convertPoint(
+            /* source = */ component,
+            /* aPoint = */ Point(0, 0),
+            /* destination = */ _windowContainer,
+        )
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -622,7 +622,7 @@ internal class ComposeSceneMediator(
     }
 
     fun onComponentAttached() {
-        check(!isDisposed) { "ComposeSceneMediator is already disposed" }
+        require(!isDisposed) { "ComposeSceneMediator is already disposed" }
         isComponentAttached = true
         onChangeDensity()
 
@@ -634,7 +634,7 @@ internal class ComposeSceneMediator(
     }
 
     fun onComponentDetached() {
-        check(!isDisposed) { "ComposeSceneMediator is already disposed" }
+        require(!isDisposed) { "ComposeSceneMediator is already disposed" }
         isComponentAttached = false
         architectureComponentsOwner.navigationEventDispatcherOwner
             .navigationEventDispatcher.removeInput(navigationEventInput)
@@ -690,7 +690,7 @@ internal class ComposeSceneMediator(
     fun onComponentPositionChanged() = catchExceptions {
         if (!container.isDisplayable) return
 
-        offsetInWindow = windowContext.locationOnWindow(container)
+        offsetInWindow = windowContext.locationInWindow(container)
     }
 
     fun onContainerSizeChanged() = catchExceptions {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -622,6 +622,7 @@ internal class ComposeSceneMediator(
     }
 
     fun onComponentAttached() {
+        check(!isDisposed) { "ComposeSceneMediator is already disposed" }
         isComponentAttached = true
         onChangeDensity()
 
@@ -633,6 +634,7 @@ internal class ComposeSceneMediator(
     }
 
     fun onComponentDetached() {
+        check(!isDisposed) { "ComposeSceneMediator is already disposed" }
         isComponentAttached = false
         architectureComponentsOwner.navigationEventDispatcherOwner
             .navigationEventDispatcher.removeInput(navigationEventInput)
@@ -688,7 +690,7 @@ internal class ComposeSceneMediator(
     fun onComponentPositionChanged() = catchExceptions {
         if (!container.isDisplayable) return
 
-        offsetInWindow = windowContext.offsetInWindow(container)
+        offsetInWindow = windowContext.locationOnWindow(container)
     }
 
     fun onContainerSizeChanged() = catchExceptions {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
@@ -90,7 +90,8 @@ class ComposeContainerLifecycleOwnerTest {
             }
 
             // close window
-            pane.container.dispose()
+            window.contentPane.remove(pane)
+            pane.dispose()
             allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
             allEvents.waitFor(Lifecycle.Event.ON_STOP)
             allEvents.waitFor(Lifecycle.Event.ON_DESTROY)
@@ -227,7 +228,7 @@ class ComposeContainerLifecycleOwnerTest {
     }
 
     private class TestComposePanel(window: JFrame, observer: LifecycleEventObserver) : JLayeredPane() {
-        val container: ComposeContainer = ComposeContainer(
+        private val container: ComposeContainer = ComposeContainer(
             container = this,
             skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
             window = window,
@@ -244,8 +245,12 @@ class ComposeContainerLifecycleOwnerTest {
         }
 
         override fun removeNotify() {
-            super.removeNotify()
             container.removeNotify()
+            super.removeNotify()
+        }
+
+        fun dispose() {
+            container.dispose()
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -183,7 +183,7 @@ internal class RootNodeOwner(
     }
 
     fun dispose() {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         coroutineScope.cancel()
         platformContext.rootForTestListener?.onRootForTestDisposed(rootForTest)
         snapshotObserver.stopObserving()
@@ -205,7 +205,7 @@ internal class RootNodeOwner(
      * Measures the Owner's content with given [constraints] and returns the resulting size.
      */
     fun measureContentWithConstraints(constraints: Constraints): IntSize {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         return measuringRootWithConstraints(constraints) {
             val outerCoordinator = it.outerCoordinator
             IntSize(outerCoordinator.measuredWidth, outerCoordinator.measuredHeight)
@@ -220,7 +220,7 @@ internal class RootNodeOwner(
         constraints: Constraints,
         block: (LayoutNode) -> T
     ): T {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         return try {
             // TODO: is it possible to measure without reassigning root constraints?
             measureAndLayoutDelegate.updateRootConstraints(constraints)
@@ -232,7 +232,7 @@ internal class RootNodeOwner(
     }
 
     fun measureAndLayout() {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         owner.measureAndLayout(sendPointerUpdate = true)
         updatePositionCacheAndDispatch()
     }
@@ -281,17 +281,17 @@ internal class RootNodeOwner(
     }
 
     fun invalidatePositionInWindow() {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         updatePositionCacheAndDispatch()
     }
 
     fun invalidatePositionOnScreen() {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         updatePositionCacheAndDispatch()
     }
 
     fun draw(canvas: Canvas) {
-        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        require(!isDisposed) { "RootNodeOwner is already disposed" }
         trace("RootNodeOwner:draw") {
             ownedLayerManager.draw(canvas)
             clearInvalidObservations()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -205,6 +205,7 @@ internal class RootNodeOwner(
      * Measures the Owner's content with given [constraints] and returns the resulting size.
      */
     fun measureContentWithConstraints(constraints: Constraints): IntSize {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
         return measuringRootWithConstraints(constraints) {
             val outerCoordinator = it.outerCoordinator
             IntSize(outerCoordinator.measuredWidth, outerCoordinator.measuredHeight)
@@ -219,6 +220,7 @@ internal class RootNodeOwner(
         constraints: Constraints,
         block: (LayoutNode) -> T
     ): T {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
         return try {
             // TODO: is it possible to measure without reassigning root constraints?
             measureAndLayoutDelegate.updateRootConstraints(constraints)
@@ -230,6 +232,7 @@ internal class RootNodeOwner(
     }
 
     fun measureAndLayout() {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
         owner.measureAndLayout(sendPointerUpdate = true)
         updatePositionCacheAndDispatch()
     }
@@ -278,17 +281,22 @@ internal class RootNodeOwner(
     }
 
     fun invalidatePositionInWindow() {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
         updatePositionCacheAndDispatch()
     }
 
     fun invalidatePositionOnScreen() {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
         updatePositionCacheAndDispatch()
     }
 
-    fun draw(canvas: Canvas) = trace("RootNodeOwner:draw") {
-        ownedLayerManager.draw(canvas)
-        clearInvalidObservations()
-        owner.rectManager.dispatchCallbacks()
+    fun draw(canvas: Canvas) {
+        check(!isDisposed) { "RootNodeOwner is already disposed" }
+        trace("RootNodeOwner:draw") {
+            ownedLayerManager.draw(canvas)
+            clearInvalidObservations()
+            owner.rectManager.dispatchCallbacks()
+        }
     }
 
     fun setRootModifier(modifier: Modifier) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -102,6 +102,8 @@ interface PlatformContext {
      * the containing window.
      * If the [ComposeScene] is rotated, scaled, or otherwise transformed relative to the window,
      * this will not be a simple translation.
+     *
+     * Note: It might return [Offset.Unspecified] if it's not attached to a window.
      */
     fun convertLocalToWindowPosition(localPosition: Offset): Offset =
         localPosition
@@ -111,6 +113,8 @@ interface PlatformContext {
      * the [ComposeScene].
      * If the [ComposeScene] is rotated, scaled, or otherwise transformed relative to the window,
      * this will not be a simple translation.
+     *
+     * Note: It might return [Offset.Unspecified] if it's not attached to a window.
      */
     fun convertWindowToLocalPosition(positionInWindow: Offset): Offset =
         positionInWindow
@@ -118,6 +122,8 @@ interface PlatformContext {
     /**
      * Converts [localPosition] relative to the [ComposeScene] into an [Offset] relative to
      * the device's screen.
+     *
+     * Note: It might return [Offset.Unspecified] if it's not attached to a window.
      */
     fun convertLocalToScreenPosition(localPosition: Offset): Offset =
         convertLocalToWindowPosition(localPosition)
@@ -125,6 +131,8 @@ interface PlatformContext {
     /**
      * Converts [positionOnScreen] relative to the device's screen into an [Offset] relative to
      * the [ComposeScene].
+     *
+     * Note: It might return [Offset.Unspecified] if it's not attached to a window.
      */
     fun convertScreenToLocalPosition(positionOnScreen: Offset): Offset =
         convertWindowToLocalPosition(positionOnScreen)


### PR DESCRIPTION
Prevents use-after-free issues with explicit checks in `RootNodeOwner`, `SkiaGraphicsContext`, `ComposeSceneMediator`.
Also prevents issues when a detached `ComposePanel` was queried for its window position.

## Release Notes
N/A