### PR TITLE
Fix centred text alignment with letter spacing (CMP-8469)

### DIFF
--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -711,6 +711,23 @@ class DesktopParagraphTest {
         assertThat(measureLines(TextAlign.Justify, TextDirection.Rtl)).isEqualTo(listOf(1830, 1950, 1900, 1980))
     }
 
+    @Test
+    fun centredText_withLetterSpacing_isVisuallyCentred() {
+        val containerWidth = 400f
+        val paragraph = simpleParagraph(
+            text = "Hello",
+            style = TextStyle(
+                textAlign = TextAlign.Center,
+                letterSpacing = 10.sp,
+                fontSize = 20.sp
+            ),
+            width = containerWidth
+        )
+        val bounds = paragraph.getPathForRange(0, "Hello".length).getBounds()
+        val visualCenter = (bounds.left + bounds.right) / 2f
+        assertThat(visualCenter).isWithin(1f).of(containerWidth / 2f)
+    }
+
     private fun simpleParagraph(
         text: String = "",
         style: TextStyle? = null,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
 import kotlin.math.floor
 import org.jetbrains.skia.FontMetrics
@@ -584,6 +585,26 @@ internal class SkiaParagraph(
         return paragraph.getWordBoundary(offset).toTextRange()
     }
 
+    /**
+     * Skia includes trailing letter spacing in LineMetrics.width, causing centred text to appear
+     * shifted left by letterSpacing / 2. This returns the x offset to compensate.
+     * https://youtrack.jetbrains.com/issue/CMP-8469
+     */
+    private fun centreAlignmentPaintOffset(): Float {
+        if (layouter.textStyle.textAlign != TextAlign.Center) return 0f
+        val letterSpacing = layouter.textStyle.letterSpacing
+        if (!letterSpacing.isSpecified || letterSpacing.value == 0f) return 0f
+        val fontSize = layouter.textStyle.fontSize
+        val letterSpacingPx: Float = with(layouter.density) {
+            when {
+                letterSpacing.isSp -> letterSpacing.toPx()
+                letterSpacing.isEm && fontSize.isSpecified -> letterSpacing.value * fontSize.toPx()
+                else -> return 0f
+            }
+        }
+        return letterSpacingPx / 2f
+    }
+
     override fun paint(
         canvas: Canvas,
         color: Color,
@@ -600,7 +621,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, centreAlignmentPaintOffset(), 0.0f)
     }
 
     @ExperimentalTextApi
@@ -624,7 +645,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, centreAlignmentPaintOffset(), 0.0f)
     }
 
     @ExperimentalTextApi
@@ -653,7 +674,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, centreAlignmentPaintOffset(), 0.0f)
     }
 
     /**

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -112,6 +112,7 @@ internal class ParagraphLayouter(
 
     val defaultFont get() = builder.defaultFont
     val textStyle get() = builder.textStyle
+    val density: Density get() = builder.density
 
     private fun invalidateParagraph(onlyForeground: Boolean = false) {
         // skia's updateForegroundPaint applies the same style to every span,


### PR DESCRIPTION
## Summary

Centre-aligned text rendered with non-zero `letterSpacing` appears shifted to the left. Skia includes the trailing letter spacing of the last glyph in `LineMetrics.width`, so when the paragraph is centred the extra `letterSpacing` of trailing space pushes the visual content left by roughly `letterSpacing / 2`.

This compensates at paint time: when the text is centre-aligned and letter spacing is specified, the paint x-position is offset by `letterSpacing / 2` to re-centre the visible glyphs.

Fixes [CMP-8469](https://youtrack.jetbrains.com/issue/CMP-8469).

## Changes

- `SkiaParagraph.skiko.kt`: add `centreAlignmentPaintOffset()` and apply it as the x offset in all three `paint()` overloads (handles both `sp` and `em` letter spacing).
- `ParagraphLayouter.skiko.kt`: expose `density` so the offset can be computed in px.
- `DesktopParagraphTest.kt`: add `centredText_withLetterSpacing_isVisuallyCentred` asserting the rendered glyph bounds are centred within the container.

## Testing

> [!NOTE]
> The change was verified by inspection (symbols/imports checked against existing code) but the test was **not** executed locally — this working copy is a sparse/partial checkout without the Gradle wrapper. Please run `./gradlew :compose:ui:ui-text:desktopTest --tests "*.DesktopParagraphTest"` in a full checkout before merging.