### PR TITLE
Fix crash in method setComposingRegion

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -196,7 +196,16 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
     }
 
     override fun setComposingRegion(start: Int, end: Int) {
-        buffer.setComposition(start, end)
+        // Sanitize the input: reverse if reversed, clamp into valid range, ignore empty range.
+        val clampedStart = start.coerceIn(0, buffer.length)
+        val clampedEnd = end.coerceIn(0, buffer.length)
+        if (clampedStart == clampedEnd) {
+            // do nothing. empty composition range is not allowed.
+        } else if (clampedStart < clampedEnd) {
+            buffer.setComposition(clampedStart, clampedEnd)
+        } else {
+            buffer.setComposition(clampedEnd, clampedStart)
+        }
     }
 
     override fun setComposingText(text: CharSequence, newCursorPosition: Int) {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextInputSessionTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextInputSessionTest.kt
@@ -296,6 +296,42 @@ class TextInputSessionTest {
     }
 
     @Test
+    fun setComposingRegion_reversed_setsCoercedComposition() = runSessionTest(
+        initialText = "abcde",
+        initialSelection = TextRange(5),
+    ) { state, request ->
+        request.editText {
+            setComposingRegion(start = 4, end = 1)
+        }
+
+        assertThat(state.composition).isEqualTo(TextRange(1, 4))
+    }
+
+    @Test
+    fun setComposingRegion_outOfBounds_setsCoercedComposition() = runSessionTest(
+        initialText = "abcde",
+        initialSelection = TextRange(5),
+    ) { state, request ->
+        request.editText {
+            setComposingRegion(start = -1, end = 10)
+        }
+
+        assertThat(state.composition).isEqualTo(TextRange(0, 5))
+    }
+
+    @Test
+    fun setComposingRegion_emptyRange_doesNotSetComposition() = runSessionTest(
+        initialText = "abcde",
+        initialSelection = TextRange(5),
+    ) { state, request ->
+        request.editText {
+            setComposingRegion(start = 2, end = 2)
+        }
+
+        assertThat(state.composition).isNull()
+    }
+
+    @Test
     fun setComposingText_insertsAndMarksComposition() = runSessionTest(
         initialText = "abef",
         initialSelection = TextRange(2, 2),


### PR DESCRIPTION
Align implementation with the `SetComposingRegionCommand`.

Fixes https://youtrack.jetbrains.com/issue/CMP-10281

## Release Notes
### Fixes - Multiple Platforms
- Fix crash in method setComposingRegion when calling it with inverted or invalid region