### PR TITLE
Fix `getMinimumSize` and `getMaximumSize` in `ComposePanel`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -237,8 +237,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     @OptIn(ExperimentalUnitApi::class)
     @Suppress("RedundantNullableReturnType")  // https://youtrack.jetbrains.com/issue/KT-31094
     override fun getMinimumSize(): Dimension? {
-        val size = if (isMinimumSizeSet) super.getMinimumSize() else UnspecifiedDimension()
-        return size.actualize()
+        return super.getMinimumSize().actualize()
     }
 
     /**
@@ -275,8 +274,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     @OptIn(ExperimentalUnitApi::class)
     @Suppress("RedundantNullableReturnType")  // https://youtrack.jetbrains.com/issue/KT-31094
     override fun getMaximumSize(): Dimension? {
-        val size = if (isMaximumSizeSet) super.getMaximumSize() else UnspecifiedDimension()
-        return size.actualize()
+        return super.getMaximumSize().actualize()
     }
 
     override fun setBackground(bg: Color?) {


### PR DESCRIPTION
Don't return measured size of content in infinite constraints by default in ComposePanel's `getMinimumSize` and `getMaximumSize`.

The measured size in infinite constraints is how we determine the "preferred" size. But min/max should not (by default) return it. Specifically, if someone sets `preferredSize` manually, it can cause the maximum size to be smaller than the preferred size.

Fixes [[Desktop] ComposePanel doesn't render the configured background color](https://youtrack.jetbrains.com/issue/CMP-10303) 

## Testing
Tested manually with the reproducer from https://youtrack.jetbrains.com/issue/CMP-10303

This should be tested by QA

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fixed `getMinimumSize` and `getMaximumSize` in `ComposePanel` to not assume `UnspecifiedDimension` by default.