### PR TITLE
Fix lifecycle state handling for ComposeContainer

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.window.ComposeContainerView
 import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.MetalView
 import androidx.compose.ui.window.SceneActiveStateListener
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.enableSavedStateHandles
 import androidx.savedstate.SavedState
@@ -98,7 +99,7 @@ internal class ComposeContainer(
     private val viewModelStore = ViewModelStore()
     private var savedState: SavedState? = null
     private var mediatorComponentsOwner: DefaultArchitectureComponentsOwner? = null
-    val architectureComponentsOwner: DefaultArchitectureComponentsOwner
+    private val architectureComponentsOwner: DefaultArchitectureComponentsOwner
         get() = mediatorComponentsOwner
             ?: error("ArchitectureComponentsOwner is not initialized yet.")
 
@@ -122,6 +123,9 @@ internal class ComposeContainer(
     private val systemThemeState: MutableState<SystemTheme> = mutableStateOf(SystemTheme.Unknown)
 
     private val focusedViewsList = FocusedViewsList()
+
+    val currentLifecycleState: Lifecycle.State get() =
+        architectureComponentsOwner.lifecycle.currentState
 
     init {
         if (configuration.enforceStrictPlistSanityCheck) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.window.ComposeContainerView
 import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.MetalView
 import androidx.compose.ui.window.SceneActiveStateListener
+import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.enableSavedStateHandles
 import androidx.savedstate.SavedState
 import kotlin.coroutines.CoroutineContext
@@ -94,9 +95,10 @@ internal class ComposeContainer(
         // The `initializeComposeScene` must be called to set the active `sceneJob`.
         it.cancel()
     }
+    private val viewModelStore = ViewModelStore()
     private var savedState: SavedState? = null
     private var mediatorComponentsOwner: DefaultArchitectureComponentsOwner? = null
-    private val architectureComponentsOwner: DefaultArchitectureComponentsOwner
+    val architectureComponentsOwner: DefaultArchitectureComponentsOwner
         get() = mediatorComponentsOwner
             ?: error("ArchitectureComponentsOwner is not initialized yet.")
 
@@ -217,7 +219,10 @@ internal class ComposeContainer(
             layersHolder = it
         }
 
-        mediatorComponentsOwner = DefaultArchitectureComponentsOwner(savedState)
+        mediatorComponentsOwner = DefaultArchitectureComponentsOwner(
+            savedState = savedState,
+            viewModelStore = viewModelStore
+        )
         architectureComponentsOwner.enableSavedStateHandles()
         lifecycleDelegate.onLifecycleStateUpdated = architectureComponentsOwner::setLifecycleState
 
@@ -265,12 +270,12 @@ internal class ComposeContainer(
     }
 
     fun disposeComposeScene() {
-        sceneJob.cancel()
         // Store the current state in the local savedState property. It is used to
         // provide the saved state to the next Compose scene when the container re-enters
         // the window hierarchy.
         savedState = architectureComponentsOwner.saveState()
-        lifecycleDelegate.onLifecycleStateUpdated = null
+
+        sceneJob.cancel()
 
         view.updateMetalView(metalView = null)
         navigationEventInput.onDidMoveToWindow(null, view)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -56,7 +56,7 @@ internal class ComposeHostingView(
     // Used for testing
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
     fun hasInvalidations(): Boolean = container.hasInvalidations()
-    val lifecycleState: Lifecycle.State get() = container.architectureComponentsOwner.lifecycle.currentState
+    val lifecycleState: Lifecycle.State get() = container.currentLifecycleState
 
     init {
         addSubview(container.view)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.scene
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.uikit.ComposeUIViewConfiguration
@@ -53,9 +54,13 @@ internal class ComposeHostingView(
         lifecycleDelegate = lifecycleDelegate
     )
 
-    // Used for testing
+    @VisibleForTesting
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
+
+    @VisibleForTesting
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+
+    @VisibleForTesting
     val lifecycleState: Lifecycle.State get() = container.currentLifecycleState
 
     init {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dpSize
 import androidx.compose.ui.window.ComposeContainerLifecycleDelegate
 import androidx.compose.ui.window.DisplayLinkListener
 import androidx.compose.ui.window.MetalRedrawer
+import androidx.lifecycle.Lifecycle
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.abs
 import kotlinx.cinterop.BetaInteropApi
@@ -55,6 +56,7 @@ internal class ComposeHostingView(
     // Used for testing
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+    val lifecycleState: Lifecycle.State get() = container.architectureComponentsOwner.lifecycle.currentState
 
     init {
         addSubview(container.view)
@@ -106,11 +108,13 @@ internal class ComposeHostingView(
     }
 
     override fun viewDidAppear() {
+        lifecycleDelegate.composeContainerWillAppear()
         container.sceneDidAppear()
     }
 
     override fun viewDidDisappear() {
         container.sceneWillDisappear()
+        lifecycleDelegate.composeContainerDidDisappear()
     }
 
     override fun userInterfaceStyleDidChange() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -108,13 +108,11 @@ internal class ComposeHostingView(
     }
 
     override fun viewDidAppear() {
-        lifecycleDelegate.composeContainerWillAppear()
         container.sceneDidAppear()
     }
 
     override fun viewDidDisappear() {
         container.sceneWillDisappear()
-        lifecycleDelegate.composeContainerDidDisappear()
     }
 
     override fun userInterfaceStyleDidChange() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.scene
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.platform.PlatformWindowContext
@@ -56,9 +57,13 @@ internal class ComposeHostingViewController(
         lifecycleDelegate = lifecycleDelegate
     )
 
-    // Used for testing
+    @VisibleForTesting
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
+
+    @VisibleForTesting
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+
+    @VisibleForTesting
     val lifecycleState: Lifecycle.State get() = container.currentLifecycleState
 
     @Suppress("DEPRECATION")

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -116,7 +116,6 @@ internal class ComposeHostingViewController(
     override fun viewWillAppear(animated: Boolean) {
         super.viewWillAppear(animated)
 
-        lifecycleDelegate.composeContainerWillAppear()
         configuration.delegate.viewWillAppear(animated)
     }
 
@@ -144,7 +143,6 @@ internal class ComposeHostingViewController(
         super.viewDidDisappear(animated)
 
         configuration.delegate.viewDidDisappear(animated)
-        lifecycleDelegate.composeContainerDidDisappear()
     }
 
     override fun viewControllerDidEnterWindowHierarchy() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.window.ComposeContainerLifecycleDelegate
 import androidx.compose.ui.window.ComposeContainerView
 import androidx.compose.ui.window.DisplayLinkListener
 import androidx.compose.ui.window.MetalRedrawer
+import androidx.lifecycle.Lifecycle
 import kotlin.coroutines.CoroutineContext
 import kotlin.native.runtime.NativeRuntimeApi
 import kotlin.time.Duration
@@ -58,6 +59,7 @@ internal class ComposeHostingViewController(
     // Used for testing
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+    val lifecycleState: Lifecycle.State get() = container.architectureComponentsOwner.lifecycle.currentState
 
     @Suppress("DEPRECATION")
     override fun preferredStatusBarStyle(): UIStatusBarStyle =
@@ -114,6 +116,7 @@ internal class ComposeHostingViewController(
     override fun viewWillAppear(animated: Boolean) {
         super.viewWillAppear(animated)
 
+        lifecycleDelegate.composeContainerWillAppear()
         configuration.delegate.viewWillAppear(animated)
     }
 
@@ -141,6 +144,7 @@ internal class ComposeHostingViewController(
         super.viewDidDisappear(animated)
 
         configuration.delegate.viewDidDisappear(animated)
+        lifecycleDelegate.composeContainerDidDisappear()
     }
 
     override fun viewControllerDidEnterWindowHierarchy() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -59,7 +59,7 @@ internal class ComposeHostingViewController(
     // Used for testing
     val rootRedrawer: MetalRedrawer? get() = container.view.redrawer
     fun hasInvalidations(): Boolean = container.hasInvalidations()
-    val lifecycleState: Lifecycle.State get() = container.architectureComponentsOwner.lifecycle.currentState
+    val lifecycleState: Lifecycle.State get() = container.currentLifecycleState
 
     @Suppress("DEPRECATION")
     override fun preferredStatusBarStyle(): UIStatusBarStyle =

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformOwnerProvider.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformOwnerProvider.skiko.kt
@@ -54,8 +54,8 @@ interface PlatformArchitectureComponentsOwner {
 @InternalComposeUiApi
 class DefaultArchitectureComponentsOwner(
     savedState: SavedState? = null,
+    override val viewModelStore: ViewModelStore = ViewModelStore(),
     enforceMainThread: Boolean = true,
-    override val viewModelStore: ViewModelStore = ViewModelStore()
 ) : PlatformArchitectureComponentsOwner,
     LifecycleOwner,
     ViewModelStoreOwner,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformOwnerProvider.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformOwnerProvider.skiko.kt
@@ -34,6 +34,7 @@ import androidx.savedstate.SavedState
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.read
 import androidx.savedstate.savedState
 
 /**
@@ -53,7 +54,8 @@ interface PlatformArchitectureComponentsOwner {
 @InternalComposeUiApi
 class DefaultArchitectureComponentsOwner(
     savedState: SavedState? = null,
-    enforceMainThread: Boolean = true
+    enforceMainThread: Boolean = true,
+    override val viewModelStore: ViewModelStore = ViewModelStore()
 ) : PlatformArchitectureComponentsOwner,
     LifecycleOwner,
     ViewModelStoreOwner,
@@ -69,7 +71,6 @@ class DefaultArchitectureComponentsOwner(
     } else {
         LifecycleRegistry.createUnsafe(this)
     }
-    override val viewModelStore = ViewModelStore()
     override val navigationEventDispatcher = NavigationEventDispatcher()
 
     private val savedStateController = SavedStateRegistryController.create(this)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/lifecycle/ComposeContainerLifecycleTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/lifecycle/ComposeContainerLifecycleTest.kt
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.lifecycle
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.scene.ComposeHostingView
+import androidx.compose.ui.scene.ComposeHostingViewController
+import androidx.compose.ui.test.MockAppDelegate
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.waitForIdle
+import androidx.compose.ui.uikit.embedSubview
+import androidx.compose.ui.window.ComposeUIView
+import androidx.compose.ui.window.ComposeUIViewController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.autoreleasepool
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import platform.Foundation.NSDate
+import platform.Foundation.NSRunLoop
+import platform.Foundation.dateWithTimeIntervalSinceNow
+import platform.Foundation.runUntilDate
+import platform.UIKit.UIView
+import platform.UIKit.UIViewController
+import platform.UIKit.addChildViewController
+import platform.UIKit.didMoveToParentViewController
+import platform.UIKit.removeFromParentViewController
+import platform.UIKit.willMoveToParentViewController
+
+@OptIn(NativeRuntimeApi::class, BetaInteropApi::class)
+class ComposeContainerLifecycleTest {
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewControllerLifecycleResumed() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        var launchesCount = 0
+        var disposedCount = 0
+
+        run {
+            val compose = ComposeUIViewController({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                DisposableEffect(Unit) {
+                    launchesCount++
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+            } as ComposeHostingViewController
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(Lifecycle.State.RESUMED, compose.lifecycleState)
+            assertEquals(1, launchesCount)
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+            assertEquals(Lifecycle.State.CREATED, compose.lifecycleState)
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(Lifecycle.State.RESUMED, compose.lifecycleState)
+            assertEquals(2, launchesCount)
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+            assertEquals(Lifecycle.State.CREATED, compose.lifecycleState)
+        }
+
+        appDelegate.cleanUp()
+    }
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewLifecycleResumed() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        var launchesCount = 0
+        var disposedCount = 0
+
+        run {
+            val compose = ComposeUIView({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                DisposableEffect(Unit) {
+                    launchesCount++
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+            } as ComposeHostingView
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(Lifecycle.State.RESUMED, compose.lifecycleState)
+            assertEquals(1, launchesCount)
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+            assertEquals(Lifecycle.State.CREATED, compose.lifecycleState)
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(Lifecycle.State.RESUMED, compose.lifecycleState)
+            assertEquals(2, launchesCount)
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+            assertEquals(Lifecycle.State.CREATED, compose.lifecycleState)
+        }
+
+        appDelegate.cleanUp()
+    }
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewControllerViewModelInitialisedAndCleared() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        val viewModel = TestViewModel()
+        var disposedCount = 0
+
+        run {
+            val compose = ComposeUIViewController({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                val vm = viewModel {
+                    viewModel.also { it.createdCount++ }
+                }
+                DisposableEffect(Unit) {
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+                Text("${vm.hashCode()}")
+            } as ComposeHostingViewController
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(1, viewModel.createdCount, "View models must be initialized")
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(1, viewModel.createdCount, "View models should not be re-created")
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+        }
+
+        appDelegate.cleanUp()
+
+        awaitTrue {
+            GC.collect()
+            viewModel.cleared
+        }
+    }
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewViewModelInitialisedAndCleared() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        val viewModel = TestViewModel()
+        var disposedCount = 0
+
+        run {
+            val compose = ComposeUIView({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                val vm = viewModel {
+                    viewModel.also { it.createdCount++ }
+                }
+                DisposableEffect(Unit) {
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+                Text("${vm.hashCode()}")
+            } as ComposeHostingView
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(1, viewModel.createdCount, "View models must be initialized")
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(1, viewModel.createdCount, "View models should not be re-created")
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+        }
+
+        appDelegate.cleanUp()
+
+        awaitTrue {
+            GC.collect()
+            viewModel.cleared
+        }
+    }
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewControllerSavedStateRestored() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        var disposedCount = 0
+        var rememberedValue = 0
+        var rememberedSavableValue = 0
+
+        run {
+            val compose = ComposeUIViewController({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                DisposableEffect(Unit) {
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+                var value1 by remember { mutableStateOf(0) }
+                var value2 by rememberSaveable { mutableStateOf(0) }
+                LaunchedEffect(Unit) {
+                    value1++
+                    value2++
+
+                    rememberedValue = value1
+                    rememberedSavableValue = value2
+                }
+            } as ComposeHostingViewController
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(1, rememberedValue)
+            assertEquals(1, rememberedSavableValue)
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+
+            testViewController.showChildViewController(compose)
+            compose.waitForIdle()
+            assertEquals(1, rememberedValue)
+            assertEquals(2, rememberedSavableValue)
+
+            testViewController.hideChildViewController()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+        }
+
+        appDelegate.cleanUp()
+    }
+
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun composeViewSavedStateRestored() = runBlocking {
+        val testViewController = TestContainerViewController()
+        val appDelegate = MockAppDelegate()
+        appDelegate.setUpWindow(testViewController)
+        var disposedCount = 0
+        var rememberedValue = 0
+        var rememberedSavableValue = 0
+
+        run {
+            val compose = ComposeUIView({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                DisposableEffect(Unit) {
+                    onDispose {
+                        disposedCount++
+                    }
+                }
+                val value1 = remember { mutableStateOf(0) }
+                val value2 = rememberSaveable { mutableStateOf(0) }
+                LaunchedEffect(Unit) {
+                    value1.value++
+                    value2.value++
+
+                    rememberedValue = value1.value
+                    rememberedSavableValue = value2.value
+                }
+            } as ComposeHostingView
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(1, rememberedValue)
+            assertEquals(1, rememberedSavableValue)
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 1 }
+
+            testViewController.showChildView(compose)
+            compose.waitForIdle()
+            assertEquals(1, rememberedValue)
+            assertEquals(2, rememberedSavableValue)
+
+            testViewController.hideChildView()
+            UIKitInstrumentedTest.waitUntil { disposedCount == 2 }
+        }
+
+        appDelegate.cleanUp()
+    }
+
+    private suspend inline fun awaitTrue(statement: () -> Boolean) {
+        val duration = 100.milliseconds
+        val timeout = 5.seconds
+        repeat((timeout / duration).toInt()) {
+            NSRunLoop.currentRunLoop().runUntilDate(
+                limitDate = NSDate.dateWithTimeIntervalSinceNow(
+                    secs = duration.toDouble(DurationUnit.SECONDS)
+                )
+            )
+            delay(duration.inWholeMilliseconds)
+            if (statement()) return
+        }
+
+        val result = autoreleasepool {
+            statement()
+        }
+        assertTrue(result)
+    }
+}
+
+private class TestContainerViewController: UIViewController(nibName = null, bundle = null) {
+
+    private var childViewController: UIViewController? = null
+    private var childView: UIView? = null
+
+    fun showChildView(child: UIView) {
+        if (childView === child) return
+        hideChildView()
+
+        view.embedSubview(child)
+        childView = child
+    }
+
+    fun hideChildView() {
+        val child = childView ?: return
+
+        child.removeFromSuperview()
+        childView = null
+    }
+
+    fun showChildViewController(child: UIViewController) {
+        if (childViewController === child) return
+        hideChildViewController()
+
+        addChildViewController(child)
+        view.embedSubview(child.view)
+        child.didMoveToParentViewController(this)
+        childViewController = child
+    }
+
+    fun hideChildViewController() {
+        val child = childViewController ?: return
+
+        child.willMoveToParentViewController(null)
+        child.view.removeFromSuperview()
+        child.removeFromParentViewController()
+        child.didMoveToParentViewController(null)
+        childViewController = null
+    }
+}
+
+class TestViewModel: androidx.lifecycle.ViewModel() {
+    var createdCount = 0
+    var cleared = false
+
+    override fun onCleared() {
+        cleared = true
+    }
+}
+


### PR DESCRIPTION
Make the ViewModelStore lifetime extended to the lifetime of the corresponding Compose Container.

Fixes https://youtrack.jetbrains.com/issue/CMP-10175/iOS-ViewModel.onCleared-never-called-when-ComposeUIViewController-is-popped
Fixes https://youtrack.jetbrains.com/issue/CMP-10159/Lifecycle-is-stuck-in-RESUMED

## Release Notes
### Fixes - iOS
- `ViewModel` now receives `onCleared` call when Compose Container is deallocated.