### PR TITLE
fix(desktop): touch screen edge cases

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
@@ -62,6 +62,11 @@ internal object OnlyValidPrimaryMouseButtonFilter : AwtEventFilter() {
     private var isPrimaryButtonPressed = false
 
     override fun shouldSendMouseEvent(event: MouseEvent): Boolean {
+        // Touchscreen scroll can arrive as MOUSE_WHEEL with BUTTON1_DOWN_MASK while the
+        // finger is touching the screen. Wheel events are not button state transitions.
+        if (event.id == MouseEvent.MOUSE_WHEEL) {
+            return true
+        }
         val eventReportsPrimaryButtonPressed =
             (event.modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
         if ((event.button == MouseEvent.BUTTON1) &&

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -972,19 +972,37 @@ private val MouseEvent.buttons get() = PointerButtons(
     // info about the pressed mouse button when using touchpad on MacOS 12 (AWT only).
     // When the [Tap to click] feature is activated on Mac OS 12, half of all clicks are not
     // handled because [event.modifiersEx] may not provide info about the pressed mouse button.
-    isPrimaryPressed = ((modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
+    isPrimaryPressed = (isButtonDown(MouseEvent.BUTTON1)
         || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON1))
         && !isMacOsCtrlClick,
-    isSecondaryPressed = (modifiersEx and MouseEvent.BUTTON3_DOWN_MASK) != 0
+    isSecondaryPressed = isButtonDown(MouseEvent.BUTTON3)
         || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON3)
         || isMacOsCtrlClick,
-    isTertiaryPressed = (modifiersEx and MouseEvent.BUTTON2_DOWN_MASK) != 0
+    isTertiaryPressed = isButtonDown(MouseEvent.BUTTON2)
         || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON2),
-    isBackPressed = (modifiersEx and MouseEvent.getMaskForButton(4)) != 0
+    isBackPressed = isButtonDown(4)
         || (id == MouseEvent.MOUSE_PRESSED && button == 4),
-    isForwardPressed = (modifiersEx and MouseEvent.getMaskForButton(5)) != 0
+    isForwardPressed = isButtonDown(5)
         || (id == MouseEvent.MOUSE_PRESSED && button == 5),
 )
+
+/**
+ * Returns whether AWT reports [button] as currently pressed, with one correction for release events.
+ *
+ * In normal mouse input, `modifiersEx` carries `BUTTON*_DOWN_MASK` while the button is down, so
+ * press, drag, move with a pressed button, and wheel while the button is held all return `true`.
+ * A release of a different button also keeps returning `true` for [button] if its mask is still set.
+ *
+ * Some AWT paths, including touchscreen taps on X11/JBR, can send `MOUSE_RELEASED` for [button]
+ * while still leaving that button's down mask in `modifiersEx`. For that event, the release itself
+ * is the more specific state transition, so this helper treats [button] as no longer pressed.
+ *
+ * This helper intentionally does not repair the opposite case where `MOUSE_PRESSED` has no down
+ * mask; callers handle that by also checking `id == MOUSE_PRESSED && button == ...`.
+ */
+private fun MouseEvent.isButtonDown(button: Int): Boolean =
+    (modifiersEx and MouseEvent.getMaskForButton(button)) != 0 &&
+        !(id == MouseEvent.MOUSE_RELEASED && this.button == button)
 
 private val MouseEvent.keyboardModifiers get() = PointerKeyboardModifiers(
     isCtrlPressed = (modifiersEx and InputEvent.CTRL_DOWN_MASK) != 0,
@@ -1002,11 +1020,13 @@ private val MouseEvent.keyboardModifiers get() = PointerKeyboardModifiers(
 private fun Component.subscribeToMouseEvents(mouseAdapter: MouseAdapter) {
     addMouseListener(mouseAdapter)
     addMouseMotionListener(mouseAdapter)
+    addMouseWheelListener(mouseAdapter)
 }
 
 private fun Component.unsubscribeFromMouseEvents(mouseAdapter: MouseAdapter) {
     removeMouseListener(mouseAdapter)
     removeMouseMotionListener(mouseAdapter)
+    removeMouseWheelListener(mouseAdapter)
 }
 
 private fun getLockingKeyStateSafe(
@@ -1020,6 +1040,6 @@ private fun getLockingKeyStateSafe(
 private val MouseEvent.isMacOsCtrlClick
     get() = (
         hostOs.isMacOS &&
-            ((modifiersEx and InputEvent.BUTTON1_DOWN_MASK) != 0) &&
+            isButtonDown(MouseEvent.BUTTON1) &&
             ((modifiersEx and InputEvent.CTRL_DOWN_MASK) != 0)
         )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -174,12 +174,13 @@ fun Container.sendMouseRelease(
     button: Int = MouseEvent.BUTTON1,
     x: Int,
     y: Int,
+    modifiers: Int = 0,
 ): Boolean {
     return sendMouseEvent(
         id = MouseEvent.MOUSE_RELEASED,
         x = x,
         y = y,
-        modifiers = 0,
+        modifiers = modifiers,
         button = button
     )
 }
@@ -219,6 +220,34 @@ fun Container.sendMouseWheelEvent(
     // we use width and height instead of x and y because we can send (-1, -1), but still need
     // the component inside window
     val component = findComponentAt(width / 2, height / 2)
+    val event = MouseWheelEvent(
+        component,
+        MouseWheelEvent.MOUSE_WHEEL,
+        0,
+        modifiers,
+        x,
+        y,
+        x,
+        y,
+        1,
+        false,
+        scrollType,
+        1,
+        wheelRotation.toInt(),
+        wheelRotation
+    )
+    component.dispatchEvent(event)
+    return event.isConsumed
+}
+
+fun Window.sendMouseWheelEventToFocusOwner(
+    x: Int = width / 2,
+    y: Int = height / 2,
+    scrollType: Int = MouseWheelEvent.WHEEL_UNIT_SCROLL,
+    wheelRotation: Double = 0.0,
+    modifiers: Int = 0,
+): Boolean {
+    val component = mostRecentFocusOwner!!
     val event = MouseWheelEvent(
         component,
         MouseWheelEvent.MOUSE_WHEEL,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowInputEventTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,6 +52,7 @@ import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.sendMousePress
 import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.sendMouseWheelEvent
+import androidx.compose.ui.sendMouseWheelEventToFocusOwner
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
@@ -363,6 +365,34 @@ class WindowInputEventTest {
     }
 
     @Test
+    fun `clickable fires when mouse release keeps released button modifier`() =
+        runApplicationTest {
+            lateinit var window: ComposeWindow
+            var clicks = 0
+
+            launchTestApplication {
+                Window(
+                    onCloseRequest = ::exitApplication,
+                    state = rememberWindowState(width = 200.dp, height = 100.dp)
+                ) {
+                    window = this.window
+
+                    Box(Modifier.fillMaxSize().clickable { clicks++ })
+                }
+            }
+
+            awaitIdle()
+
+            window.sendMousePress(BUTTON1, 100, 50)
+            awaitIdle()
+
+            window.sendMouseRelease(BUTTON1, 100, 50, modifiers = BUTTON1_DOWN_MASK)
+            awaitIdle()
+
+            assertThat(clicks).isEqualTo(1)
+        }
+
+    @Test
     fun `catch mouse move`() = runApplicationTest {
         lateinit var window: ComposeWindow
 
@@ -460,6 +490,44 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(deltas.size).isEqualTo(2)
         assertThat(deltas.last()).isEqualTo(Offset(0f, -1f))
+    }
+
+    @Test
+    fun `catch mouse scroll dispatched to focus owner`() = runApplicationTest {
+        lateinit var window: ComposeWindow
+
+        val deltas = mutableListOf<Offset>()
+
+        launchTestApplication {
+            Window(
+                onCloseRequest = ::exitApplication,
+                state = rememberWindowState(width = 200.dp, height = 100.dp)
+            ) {
+                window = this.window
+
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .onPointerEvent(PointerEventType.Scroll) {
+                            deltas.add(it.changes.first().scrollDelta)
+                        }
+                )
+            }
+        }
+
+        awaitIdle()
+        assertThat(deltas.size).isEqualTo(0)
+
+        window.sendMouseWheelEventToFocusOwner(
+            100,
+            50,
+            WHEEL_UNIT_SCROLL,
+            wheelRotation = 1.0,
+            modifiers = BUTTON1_DOWN_MASK,
+        )
+        awaitIdle()
+        assertThat(deltas.size).isEqualTo(1)
+        assertThat(deltas.last()).isEqualTo(Offset(0f, 1f))
     }
 
     @Test


### PR DESCRIPTION
## Issue

I found some issues when I'm using jb-toolbox in my new touch screen laptop. Button click and scroll operations from touch screen are not handled correctly.

- Button clicks by touch are only accepted after a mouse move.
- Drag to scroll is handled as clicks.

## Changes

These changes are done on X11 path.

- Fix button unpress judge.
- Apply `addMouseWheelListener` to collect touch scroll events.

## Testing

I updated the related tests.

Also, I built a small scrollable list demo based on KMP wizard and patched the library with the fixed one. These issues are observed as fixed.

This should be tested by QA.

## Release Notes
### Fixes - Desktop
- Improve the touch event compatibility with xwayland.

