### PR TITLE
Fix incorrect frames order on high load

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.m
@@ -184,23 +184,7 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
 
 - (void)presentDrawable:(CMPDrawable *)drawable
               onDisplay:(void (^)(void))displayHandler {
-    [_drawablesLock lock];
-
-    if (!CGSizeEqualToSize(drawable.textureSize, _drawableSize)) {
-        // Invalid drawable size. Ignoring.
-        [drawable dispose];
-        [_drawablesLock unlock];
-        return;
-    }
-
-    if (_lastPresentedDrawable != nil) {
-        [_availableDrawables addObject:_lastPresentedDrawable];
-    }
-
-    _lastPresentedDrawable = drawable;
     drawable.presentedTime = CACurrentMediaTime();
-
-    [_drawablesLock unlock];
 
     if ([NSThread isMainThread]) {
         [self presentOnMainThread:drawable onDisplay: displayHandler];
@@ -215,16 +199,27 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
                   onDisplay:(void (^)(void))displayHandler {
     NSAssert([NSThread isMainThread], @"presentOnMainThread - must be called on main thread");
 
+    if (!CGSizeEqualToSize(drawable.textureSize, _drawableSize)) {
+        [drawable dispose];
+        // Invalid drawable size. Disposing.
+        return;
+    }
+
     if (_lastDrawablePresentedTime > drawable.presentedTime) {
+        [self releaseDrawable:drawable];
         // Drop drawable that was scheduled before the already presented one
         return;
     }
-    if (!CGSizeEqualToSize(drawable.textureSize, _drawableSize)) {
-        // Invalid drawable size. Ignoring.
-        return;
-    }
-    
+
     _lastDrawablePresentedTime = drawable.presentedTime;
+
+    [_drawablesLock lock];
+    if (_lastPresentedDrawable != nil) {
+        [_availableDrawables addObject:_lastPresentedDrawable];
+    }
+    _lastPresentedDrawable = drawable;
+    [_drawablesLock unlock];
+
     [self setNeedsDisplay]; // Prevents frame drops during touch events
 
     [CATransaction begin];

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPMetalLayerTests.swift
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPMetalLayerTests.swift
@@ -459,6 +459,9 @@ final class CMPMetalLayerTests: XCTestCase {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 expectation.fulfill()
             }
+            // The test blocks main thread.
+            // Perform scheduled tasks to let the layer free used buffers.
+            RunLoop.main.run(until: Date())
         }
         
         // Should not crash


### PR DESCRIPTION
The issue occurred because the `[_availableDrawables addObject:_lastPresentedDrawable];` was called too early that allowed to reuse the buffer before or during the presentation.
The fix moves the releasing logic closer to the point of the buffer usage.

Test: Benchmarks did not reveal any performance degradation.

Fixes https://youtrack.jetbrains.com/issue/CMP-10208/Compose-may-change-frames-order-under-load

## Release Notes
### Fixes - iOS
- Fix incorrect frames order during high load rendering