### PR TITLE
`DeprecationLevel.ERROR` for skiko-specific types in ui-graphics API

### DIFF
--- a/compose/ui/ui-graphics/api/desktop/ui-graphics.api
+++ b/compose/ui/ui-graphics/api/desktop/ui-graphics.api
@@ -316,21 +316,21 @@ public final class androidx/compose/ui/graphics/DegreesKt {
 }
 
 public final class androidx/compose/ui/graphics/DesktopColorFilter_desktopKt {
-	public static final fun asDesktopColorFilter (Landroidx/compose/ui/graphics/ColorFilter;)Lorg/jetbrains/skia/ColorFilter;
-	public static final fun toComposeColorFilter (Lorg/jetbrains/skia/ColorFilter;)Landroidx/compose/ui/graphics/ColorFilter;
+	public static final synthetic fun asDesktopColorFilter (Landroidx/compose/ui/graphics/ColorFilter;)Lorg/jetbrains/skia/ColorFilter;
+	public static final synthetic fun toComposeColorFilter (Lorg/jetbrains/skia/ColorFilter;)Landroidx/compose/ui/graphics/ColorFilter;
 }
 
 public final class androidx/compose/ui/graphics/DesktopImageAsset_desktopKt {
-	public static final fun asDesktopBitmap (Landroidx/compose/ui/graphics/ImageBitmap;)Lorg/jetbrains/skia/Bitmap;
-	public static final fun asImageBitmap (Lorg/jetbrains/skia/Bitmap;)Landroidx/compose/ui/graphics/ImageBitmap;
-	public static final fun asImageBitmap (Lorg/jetbrains/skia/Image;)Landroidx/compose/ui/graphics/ImageBitmap;
+	public static final synthetic fun asDesktopBitmap (Landroidx/compose/ui/graphics/ImageBitmap;)Lorg/jetbrains/skia/Bitmap;
+	public static final synthetic fun asImageBitmap (Lorg/jetbrains/skia/Bitmap;)Landroidx/compose/ui/graphics/ImageBitmap;
+	public static final synthetic fun asImageBitmap (Lorg/jetbrains/skia/Image;)Landroidx/compose/ui/graphics/ImageBitmap;
 }
 
 public final class androidx/compose/ui/graphics/DesktopImageConverters_desktopKt {
-	public static final fun asAwtImage (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/awt/image/BufferedImage;
-	public static final fun asAwtImage-Ug5Nnss (Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;J)Ljava/awt/Image;
+	public static final synthetic fun asAwtImage (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/awt/image/BufferedImage;
+	public static final synthetic fun asAwtImage-Ug5Nnss (Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;J)Ljava/awt/Image;
 	public static synthetic fun asAwtImage-Ug5Nnss$default (Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;JILjava/lang/Object;)Ljava/awt/Image;
-	public static final fun asPainter (Ljava/awt/image/BufferedImage;)Landroidx/compose/ui/graphics/painter/Painter;
+	public static final synthetic fun asPainter (Ljava/awt/image/BufferedImage;)Landroidx/compose/ui/graphics/painter/Painter;
 	public static final fun toAwtImage (Landroidx/compose/ui/graphics/ImageBitmap;)Ljava/awt/image/BufferedImage;
 	public static final fun toAwtImage-Ug5Nnss (Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;J)Ljava/awt/Image;
 	public static synthetic fun toAwtImage-Ug5Nnss$default (Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;JILjava/lang/Object;)Ljava/awt/Image;
@@ -340,11 +340,11 @@ public final class androidx/compose/ui/graphics/DesktopImageConverters_desktopKt
 }
 
 public final class androidx/compose/ui/graphics/DesktopPathEffect_desktopKt {
-	public static final fun asDesktopPathEffect (Landroidx/compose/ui/graphics/PathEffect;)Lorg/jetbrains/skia/PathEffect;
+	public static final synthetic fun asDesktopPathEffect (Landroidx/compose/ui/graphics/PathEffect;)Lorg/jetbrains/skia/PathEffect;
 }
 
 public final class androidx/compose/ui/graphics/DesktopPath_desktopKt {
-	public static final fun asDesktopPath (Landroidx/compose/ui/graphics/Path;)Lorg/jetbrains/skia/Path;
+	public static final synthetic fun asDesktopPath (Landroidx/compose/ui/graphics/Path;)Lorg/jetbrains/skia/Path;
 }
 
 public abstract interface annotation class androidx/compose/ui/graphics/ExperimentalGraphicsApi : java/lang/annotation/Annotation {
@@ -959,7 +959,7 @@ public final class androidx/compose/ui/graphics/RenderEffectKt {
 }
 
 public final class androidx/compose/ui/graphics/RenderEffect_desktopKt {
-	public static final fun asDesktopImageFilter (Landroidx/compose/ui/graphics/RenderEffect;)Lorg/jetbrains/skia/ImageFilter;
+	public static final synthetic fun asDesktopImageFilter (Landroidx/compose/ui/graphics/RenderEffect;)Lorg/jetbrains/skia/ImageFilter;
 }
 
 public final class androidx/compose/ui/graphics/Shader {

--- a/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Canvas.kt
+++ b/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Canvas.kt
@@ -27,7 +27,11 @@ fun Canvas(image: ImageBitmap): Canvas = ActualCanvas(image)
 
 internal expect fun ActualCanvas(image: ImageBitmap): Canvas
 
-@Deprecated("Use direct reference to platform type instead of typealias") expect class NativeCanvas
+@Deprecated(
+    message = "Use direct reference to platform type instead of typealias",
+    level = DeprecationLevel.ERROR,
+)
+expect class NativeCanvas
 
 /**
  * Saves a copy of the current transform and clip on the save stack and executes the provided lambda

--- a/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Paint.kt
+++ b/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Paint.kt
@@ -19,13 +19,20 @@ package androidx.compose.ui.graphics
 /** Default alpha value used on [Paint]. This value will draw source content fully opaque. */
 const val DefaultAlpha: Float = 1.0f
 
-@Deprecated("Use direct reference to platform type instead of typealias") expect class NativePaint
+@Deprecated(
+    message = "Use direct reference to platform type instead of typealias",
+    level = DeprecationLevel.ERROR,
+)
+expect class NativePaint
 
 expect fun Paint(): Paint
 
 interface Paint {
-    @Suppress("DEPRECATION")
-    @Deprecated("Use platform-specific extension to get platform reference")
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated(
+        message = "Use platform-specific extension to get platform reference",
+        level = DeprecationLevel.ERROR,
+    )
     fun asFrameworkPaint(): NativePaint {
         throw NotImplementedError()
     }

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopColorFilter.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopColorFilter.desktop.kt
@@ -24,7 +24,7 @@ import org.jetbrains.skia.ColorFilter as SkColorFilter
 @Deprecated(
     message = "Use asSkiaColorFilter()",
     replaceWith = ReplaceWith("asSkiaColorFilter()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun ColorFilter.asDesktopColorFilter(): SkColorFilter = nativeColorFilter
 
@@ -34,6 +34,6 @@ fun ColorFilter.asDesktopColorFilter(): SkColorFilter = nativeColorFilter
 @Deprecated(
     message = "Use asComposeColorFilter()",
     replaceWith = ReplaceWith("asComposeColorFilter()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun SkColorFilter.toComposeColorFilter(): ColorFilter = ColorFilter(this)

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageAsset.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageAsset.desktop.kt
@@ -29,7 +29,7 @@ import org.jetbrains.skia.Image
 @Deprecated(
     message = "Use asComposeImageBitmap",
     replaceWith = ReplaceWith("asComposeImageBitmap()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun Bitmap.asImageBitmap(): ImageBitmap = asComposeImageBitmap()
 
@@ -39,7 +39,7 @@ fun Bitmap.asImageBitmap(): ImageBitmap = asComposeImageBitmap()
 @Deprecated(
     message = "Use toComposeImageBitmap",
     replaceWith = ReplaceWith("toComposeImageBitmap()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun Image.asImageBitmap(): ImageBitmap = toComposeImageBitmap()
 
@@ -50,7 +50,7 @@ fun Image.asImageBitmap(): ImageBitmap = toComposeImageBitmap()
 @Deprecated(
     message = "Use asSkiaBitmap()",
     replaceWith = ReplaceWith("asSkiaBitmap()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun ImageBitmap.asDesktopBitmap(): Bitmap = asSkiaBitmap()
 

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
@@ -51,7 +51,7 @@ import org.jetbrains.skia.ImageInfo
 @Deprecated(
     message = "Use toPainter",
     replaceWith = ReplaceWith("toPainter()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun BufferedImage.asPainter(): Painter = BufferedImagePainter(this)
 
@@ -94,7 +94,7 @@ private class BufferedImagePainter(val image: BufferedImage) : Painter() {
 @Deprecated(
     "Use toAwtImage",
     replaceWith = ReplaceWith("toAwtImage(density, layoutDirection, size)"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun Painter.asAwtImage(
     density: Density,
@@ -212,7 +212,7 @@ private class PainterImage(
 @Deprecated(
     message = "use toAwtImage",
     replaceWith = ReplaceWith("toAwtImage"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun ImageBitmap.asAwtImage(): BufferedImage = toAwtImage()
 

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPath.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPath.desktop.kt
@@ -20,6 +20,6 @@ package androidx.compose.ui.graphics
 @Deprecated(
     message = "Use asSkiaPath()",
     replaceWith = ReplaceWith("asSkiaPath()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 inline fun Path.asDesktopPath(): org.jetbrains.skia.Path = asSkiaPath()

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPathEffect.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPathEffect.desktop.kt
@@ -24,6 +24,6 @@ import org.jetbrains.skia.PathEffect as SkPathEffect
 @Deprecated(
     message = "Use asSkiaPathEffect()",
     replaceWith = ReplaceWith("asSkiaPathEffect()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 fun PathEffect.asDesktopPathEffect(): SkPathEffect = asSkiaPathEffect()

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
@@ -23,4 +23,5 @@ import org.jetbrains.skia.ImageFilter
     replaceWith = ReplaceWith("asSkiaImageFilter()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION_ERROR")
 fun RenderEffect.asDesktopImageFilter(): ImageFilter = asSkiaImageFilter()

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
@@ -21,7 +21,7 @@ import org.jetbrains.skia.ImageFilter
 @Deprecated(
     message = "Use asSkiaImageFilter()",
     replaceWith = ReplaceWith("asSkiaImageFilter()"),
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
 )
 @Suppress("DEPRECATION_ERROR")
 fun RenderEffect.asDesktopImageFilter(): ImageFilter = asSkiaImageFilter()

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -38,6 +38,7 @@ import org.jetbrains.skia.impl.use
 @Deprecated(
     message = "Use direct reference to org.jetbrains.skia.Canvas instead of typealias",
     replaceWith = ReplaceWith("Canvas", "org.jetbrains.skia.Canvas"),
+    level = DeprecationLevel.ERROR,
 )
 actual typealias NativeCanvas = SkCanvas
 
@@ -71,8 +72,7 @@ val Canvas.skiaCanvas: SkCanvas
     message = "Naming alignment to avoid ambiguity: use [Canvas.skiaCanvas] extension instead",
     replaceWith = ReplaceWith("skiaCanvas", "androidx.compose.ui.graphics.skiaCanvas"),
 )
-@Suppress("DEPRECATION")
-val Canvas.nativeCanvas: NativeCanvas
+val Canvas.nativeCanvas: SkCanvas
     get() = skiaCanvas
 
 // This was added for internal usage from old render layers (another submodule),

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
@@ -24,6 +24,7 @@ import org.jetbrains.skia.PaintStrokeJoin as SkPaintStrokeJoin
 @Deprecated(
     message = "Use org.jetbrains.skia.Paint directly instead",
     replaceWith = ReplaceWith("org.jetbrains.skia.Paint"),
+    level = DeprecationLevel.ERROR,
 )
 actual typealias NativePaint = SkPaint
 
@@ -55,6 +56,7 @@ internal class SkiaBackedPaint(
     @Deprecated(
         message = "Use [Paint.nativePaint] extension instead",
         replaceWith = ReplaceWith("skiaPaint", "androidx.compose.ui.graphics.skiaPaint"),
+        level = DeprecationLevel.ERROR,
     )
     override fun asFrameworkPaint(): SkPaint = internalSkiaPaint
 

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedRenderEffect.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedRenderEffect.skiko.kt
@@ -50,6 +50,7 @@ actual sealed class RenderEffect actual constructor() {
     @Deprecated(
         message = "Use [RenderEffect.skiaImageFilter] extension instead",
         replaceWith = ReplaceWith("skiaImageFilter", "androidx.compose.ui.graphics.skiaImageFilter"),
+        level = DeprecationLevel.ERROR,
     )
     fun asSkiaImageFilter(): ImageFilter = internalSkiaImageFilter
 


### PR DESCRIPTION
[CMP-10333](https://youtrack.jetbrains.com/issue/CMP-10333) DeprecationLevel.ERROR for skiko-specific types in ui-graphics API

It touches common in fork to move deprecation level in 1.12. This part will be synchronized back during 1.13 release cycle

Also, old desktop-only deprecations changed to `DeprecationLevel.HIDDEN` (no release notes as it's deprecated since 1.5 and there are no known usages).

## Release Notes
### Migration Notes - Multiple Platforms
- Deprecation level of `NativeCanvas`, `NativePaint` typealiases and related methods has been changed to `ERROR`