### PR TITLE
Expose properties that used for platform integration as `@InternalComposeUiApi`

### DIFF
--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -201,6 +201,7 @@ androidXMultiplatform {
 
         // TODO: Align it with AOSP or make explicit
         configureEach {
+            languageSettings.optIn("androidx.compose.ui.InternalComposeUiApi")
             languageSettings.optIn("androidx.compose.ui.text.ExperimentalTextApi")
         }
     }

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/style/LineHeightStyle.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/style/LineHeightStyle.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.text.style
 
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.text.PlatformParagraphStyle
 import androidx.compose.ui.text.internal.checkPrecondition
 import kotlin.jvm.JvmInline
@@ -206,11 +207,13 @@ class LineHeightStyle(val alignment: Alignment, val trim: Trim, val mode: Mode) 
             val None = Trim(0)
         }
 
-        internal fun isTrimFirstLineTop(): Boolean {
+        @InternalComposeUiApi
+        fun isTrimFirstLineTop(): Boolean {
             return value and FlagTrimTop > 0
         }
 
-        internal fun isTrimLastLineBottom(): Boolean {
+        @InternalComposeUiApi
+        fun isTrimLastLineBottom(): Boolean {
             return value and FlagTrimBottom > 0
         }
     }
@@ -222,7 +225,7 @@ class LineHeightStyle(val alignment: Alignment, val trim: Trim, val mode: Mode) 
      *   0f (inclusive) and 1f (inclusive).
      */
     @kotlin.jvm.JvmInline
-    value class Alignment constructor(internal val topRatio: Float) {
+    value class Alignment constructor(@property:InternalComposeUiApi val topRatio: Float) {
 
         init {
             checkPrecondition(topRatio in 0f..1f || topRatio == -1f) {


### PR DESCRIPTION
⚠️ needs to be upstreamed and syncronized back during 1.13
To avoid hacks in #3126

## Release Notes
N/A
