### PR TITLE
iOS instrumented tests for textfield menu items availability

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -65,7 +65,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.jetbrains.skiko.OS
@@ -392,6 +391,42 @@ class TextFieldEditMenuTest {
             textFieldKind = EditableTextFieldKind.BasicTextField2,
             visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
             hiddenActions = listOf("Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextFieldEditableFullSelectionClipboardText() = runContextMenuTest(false) {
+        verifyEditableFullSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Cut", "Copy", "Paste"),
+            hiddenActions = listOf("Select", "Select All")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextField2EditableFullSelectionClipboardText() = runContextMenuTest(false) {
+        verifyEditableFullSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Cut", "Copy", "Paste"),
+            hiddenActions = listOf("Select", "Select All")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldEditableFullSelectionClipboardText() = runContextMenuTest(true) {
+        verifyEditableFullSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Cut", "Copy", "Paste"),
+            hiddenActions = listOf("Select", "Select All")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextField2EditableFullSelectionClipboardText() = runContextMenuTest(true) {
+        verifyEditableFullSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Cut", "Copy", "Paste"),
+            hiddenActions = listOf("Select", "Select All")
         )
     }
 
@@ -731,6 +766,75 @@ class TextFieldEditMenuTest {
         )
 
         openToolbar("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private fun UIKitInstrumentedTest.verifyEditableFullSelectionClipboardTextContextMenu(
+        textFieldKind: EditableTextFieldKind,
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        when (textFieldKind) {
+            EditableTextFieldKind.BasicTextField -> {
+                val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4, 4)))
+                setContent {
+                    val focusRequester = remember { FocusRequester() }
+                    Column(modifier = Modifier.safeDrawingPadding()) {
+                        BasicTextField(
+                            value = textFieldValue.value,
+                            onValueChange = { textFieldValue.value = it },
+                            modifier = Modifier
+                                .testTag("TextField")
+                                .focusRequester(focusRequester)
+                        )
+                    }
+                    LaunchedEffect(focusRequester) {
+                        focusRequester.requestFocus()
+                    }
+                }
+
+                longPressAndAwaitContextMenu("TextField")
+                tapContextMenuButton("Select All")
+                waitUntil("Text field should be fully selected") {
+                    textFieldValue.value.selection.start == 0 &&
+                        textFieldValue.value.selection.end == textFieldValue.value.text.length
+                }
+            }
+            EditableTextFieldKind.BasicTextField2 -> {
+                val textFieldState = TextFieldState("Text", TextRange(4, 4))
+                setContent {
+                    val focusRequester = remember { FocusRequester() }
+                    Column(modifier = Modifier.safeDrawingPadding()) {
+                        BasicTextField(
+                            state = textFieldState,
+                            modifier = Modifier
+                                .testTag("TextField")
+                                .focusRequester(focusRequester)
+                        )
+                    }
+                    LaunchedEffect(focusRequester) {
+                        focusRequester.requestFocus()
+                    }
+                }
+
+           //     delay(60000)
+
+                longPressAndAwaitContextMenu("TextField")
+                tapContextMenuButton("Select All")
+                waitUntil("Text field should be fully selected") {
+                    textFieldState.selection.start == 0 &&
+                        textFieldState.selection.end == textFieldState.text.length
+                }
+            }
+        }
+
+        waitUntil("Context menu should update for full selection") {
+            visibleActions.all { findNodeWithLabelOrNull(it) != null } &&
+                hiddenActions.all { findNodeWithLabelOrNull(it) == null }
+        }
 
         verifyContextMenuItemsVisible(visibleActions)
         verifyContextMenuItemsHidden(hiddenActions)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -304,6 +304,22 @@ class TextFieldEditMenuTest {
     }
 
     @Test
+    fun testOldContextMenuEditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
+        verifyEditableCollapsedClipboardEmptyContextMenu(
+            visibleActions = listOf("Select", "Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuEditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardEmptyContextMenu(
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
     fun testTapsCountingWithMultiTouch() = runUIKitInstrumentedTest {
         var touchesDown = 0
         var touchesUp = 0
@@ -587,7 +603,30 @@ class TextFieldEditMenuTest {
         visibleActions: List<String>,
         hiddenActions: List<String>,
     ) {
-        UIPasteboard.generalPasteboard().string = "Paste text"
+        verifyEditableCollapsedContextMenu(
+            clipboardText = "Paste text",
+            visibleActions = visibleActions,
+            hiddenActions = hiddenActions
+        )
+    }
+
+    private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardEmptyContextMenu(
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        verifyEditableCollapsedContextMenu(
+            clipboardText = null,
+            visibleActions = visibleActions,
+            hiddenActions = hiddenActions
+        )
+    }
+
+    private fun UIKitInstrumentedTest.verifyEditableCollapsedContextMenu(
+        clipboardText: String?,
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = clipboardText
         val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4,4)))
         setContent {
             val focusRequester = remember { FocusRequester() }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -360,6 +360,42 @@ class TextFieldEditMenuTest {
     }
 
     @Test
+    fun testOldContextMenuBasicTextFieldEditablePartialSelectionClipboardText() = runContextMenuTest(false) {
+        verifyEditablePartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
+            hiddenActions = listOf("Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextField2EditablePartialSelectionClipboardText() = runContextMenuTest(false) {
+        verifyEditablePartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
+            hiddenActions = listOf("Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldEditablePartialSelectionClipboardText() = runContextMenuTest(true) {
+        verifyEditablePartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
+            hiddenActions = listOf("Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextField2EditablePartialSelectionClipboardText() = runContextMenuTest(true) {
+        verifyEditablePartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
+            hiddenActions = listOf("Select")
+        )
+    }
+
+    @Test
     fun testTapsCountingWithMultiTouch() = runUIKitInstrumentedTest {
         var touchesDown = 0
         var touchesUp = 0
@@ -672,13 +708,45 @@ class TextFieldEditMenuTest {
         hiddenActions: List<String>,
     ) {
         UIPasteboard.generalPasteboard().string = clipboardText
+        setEditableTextFieldContent(
+            textFieldKind = textFieldKind,
+            initialValue = TextFieldValue("Text", TextRange(4, 4))
+        )
+
+        longPressAndAwaitContextMenu("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private fun UIKitInstrumentedTest.verifyEditablePartialSelectionClipboardTextContextMenu(
+        textFieldKind: EditableTextFieldKind,
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        setEditableTextFieldContent(
+            textFieldKind = textFieldKind,
+            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT)
+        )
+
+        openToolbar("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private fun UIKitInstrumentedTest.setEditableTextFieldContent(
+        textFieldKind: EditableTextFieldKind,
+        initialValue: TextFieldValue,
+    ) {
         setContent {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 when (textFieldKind) {
                     EditableTextFieldKind.BasicTextField -> {
                         val textFieldValue = remember {
-                            mutableStateOf(TextFieldValue("Text", TextRange(4, 4)))
+                            mutableStateOf(initialValue)
                         }
                         BasicTextField(
                             value = textFieldValue.value,
@@ -690,7 +758,7 @@ class TextFieldEditMenuTest {
                     }
                     EditableTextFieldKind.BasicTextField2 -> {
                         val textFieldState = remember {
-                            TextFieldState("Text", TextRange(4, 4))
+                            TextFieldState(initialValue.text, initialValue.selection)
                         }
                         BasicTextField(
                             state = textFieldState,
@@ -705,16 +773,15 @@ class TextFieldEditMenuTest {
                 focusRequester.requestFocus()
             }
         }
-
-        longPressAndAwaitContextMenu("TextField")
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
     }
 
     private enum class EditableTextFieldKind {
         BasicTextField,
         BasicTextField2
+    }
+
+    private companion object {
+        private const val PARTIAL_SELECTION_TEXT = "accomplishment extraordinary magnificent establishment"
     }
 
     @OptIn(ExperimentalFoundationApi::class)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -581,26 +581,18 @@ class TextFieldEditMenuTest {
     }
 
     @OptIn(ExperimentalForeignApi::class)
+    private fun UIKitInstrumentedTest.verifyContextMenuItemsVisible(labels: List<String>) {
+        labels.forEach { label ->
+            findNodeWithLabel(label).let {
+                it.assertVisibleInContainer()
+                assertTrue(it.isAccessibilityElement ?: false)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
     private fun UIKitInstrumentedTest.verifyFullToolbarPresent() {
-        findNodeWithLabel("Cut").let {
-            it.assertVisibleInContainer()
-            assertTrue(it.isAccessibilityElement ?: false)
-        }
-
-        findNodeWithLabel("Copy").let {
-            it.assertVisibleInContainer()
-            assertTrue(it.isAccessibilityElement ?: false)
-        }
-
-        findNodeWithLabel("Paste").let {
-            it.assertVisibleInContainer()
-            assertTrue(it.isAccessibilityElement ?: false)
-        }
-
-        findNodeWithLabel("Select All").let {
-            it.assertVisibleInContainer()
-            assertTrue(it.isAccessibilityElement ?: false)
-        }
+        verifyContextMenuItemsVisible(listOf("Cut", "Copy", "Paste", "Select All"))
     }
 
     private fun UIKitInstrumentedTest.tapContextMenuButton(label: String) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -431,6 +430,78 @@ class TextFieldEditMenuTest {
     }
 
     @Test
+    fun testOldContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() = runContextMenuTest(false) {
+        verifyReadOnlyCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() = runContextMenuTest(false) {
+        verifyReadOnlyCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() = runContextMenuTest(true) {
+        verifyReadOnlyCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() = runContextMenuTest(true) {
+        verifyReadOnlyCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() = runContextMenuTest(false) {
+        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Copy", "Select All"),
+            hiddenActions = listOf("Cut", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() = runContextMenuTest(false) {
+        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Copy", "Select All"),
+            hiddenActions = listOf("Cut", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() = runContextMenuTest(true) {
+        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Copy", "Select All"),
+            hiddenActions = listOf("Cut", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() = runContextMenuTest(true) {
+        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Copy", "Select All"),
+            hiddenActions = listOf("Cut", "Paste", "Select")
+        )
+    }
+
+    @Test
     fun testTapsCountingWithMultiTouch() = runUIKitInstrumentedTest {
         var touchesDown = 0
         var touchesUp = 0
@@ -743,9 +814,10 @@ class TextFieldEditMenuTest {
         hiddenActions: List<String>,
     ) {
         UIPasteboard.generalPasteboard().string = clipboardText
-        setEditableTextFieldContent(
+        setTextFieldContent(
             textFieldKind = textFieldKind,
-            initialValue = TextFieldValue("Text", TextRange(4, 4))
+            initialValue = TextFieldValue("Text", TextRange(4, 4)),
+            readOnly = false
         )
 
         longPressAndAwaitContextMenu("TextField")
@@ -760,9 +832,46 @@ class TextFieldEditMenuTest {
         hiddenActions: List<String>,
     ) {
         UIPasteboard.generalPasteboard().string = "Paste text"
-        setEditableTextFieldContent(
+        setTextFieldContent(
             textFieldKind = textFieldKind,
-            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT)
+            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
+            readOnly = false
+        )
+
+        openToolbar("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private fun UIKitInstrumentedTest.verifyReadOnlyCollapsedClipboardTextContextMenu(
+        textFieldKind: EditableTextFieldKind,
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        setTextFieldContent(
+            textFieldKind = textFieldKind,
+            initialValue = TextFieldValue("Text", TextRange(4, 4)),
+            readOnly = true
+        )
+
+        longPressAndAwaitContextMenu("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private fun UIKitInstrumentedTest.verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+        textFieldKind: EditableTextFieldKind,
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        setTextFieldContent(
+            textFieldKind = textFieldKind,
+            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
+            readOnly = true
         )
 
         openToolbar("TextField")
@@ -840,9 +949,10 @@ class TextFieldEditMenuTest {
         verifyContextMenuItemsHidden(hiddenActions)
     }
 
-    private fun UIKitInstrumentedTest.setEditableTextFieldContent(
+    private fun UIKitInstrumentedTest.setTextFieldContent(
         textFieldKind: EditableTextFieldKind,
         initialValue: TextFieldValue,
+        readOnly: Boolean,
     ) {
         setContent {
             val focusRequester = remember { FocusRequester() }
@@ -857,7 +967,8 @@ class TextFieldEditMenuTest {
                             onValueChange = { textFieldValue.value = it },
                             modifier = Modifier
                                 .testTag("TextField")
-                                .focusRequester(focusRequester)
+                                .focusRequester(focusRequester),
+                            readOnly = readOnly
                         )
                     }
                     EditableTextFieldKind.BasicTextField2 -> {
@@ -868,7 +979,8 @@ class TextFieldEditMenuTest {
                             state = textFieldState,
                             modifier = Modifier
                                 .testTag("TextField")
-                                .focusRequester(focusRequester)
+                                .focusRequester(focusRequester),
+                            readOnly = readOnly
                         )
                     }
                 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -293,11 +293,13 @@ class TextFieldEditMenuTest {
             )
 
             longPressAndAwaitContextMenu("TextField")
-            verifyContextMenuItemsVisible(labels = if (newContextMenu) {
-                listOf("Paste", "Select All")
-            } else {
-                listOf("Paste", "Select", "Select All")
-            })
+            verifyContextMenuItemsVisible(
+                labels = if (newContextMenu) {
+                    listOf("Paste", "Select All")
+                } else {
+                    listOf("Paste", "Select", "Select All")
+                }
+            )
 
             verifyContextMenuItemsHidden(
                 labels = if (newContextMenu) {
@@ -319,145 +321,165 @@ class TextFieldEditMenuTest {
     }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() =
-        runEditableCollapsedClipboardEmptyContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
+    fun testEditableCollapsedClipboardEmpty() =
+        runComplexTextFieldTest { textFieldKind, newContextMenu ->
+            UIPasteboard.generalPasteboard().string = null
+            setTextFieldContent(
+                textFieldKind = textFieldKind,
+                initialValue = TextFieldValue("Text", TextRange(4, 4)),
+                readOnly = false
+            )
+
+            longPressAndAwaitContextMenu("TextField")
+            verifyContextMenuItemsVisible(
+                labels = if (newContextMenu) {
+                    listOf("Select All")
+                } else {
+                    listOf("Select", "Select All")
+                }
+            )
+
+            verifyContextMenuItemsHidden(
+                labels = if (newContextMenu) {
+                    listOf("Cut", "Copy", "Paste", "Select")
+                } else {
+                    listOf("Cut", "Copy", "Paste")
+                }
+            )
+        }
 
     @Test
-    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardEmpty() =
-        runEditableCollapsedClipboardEmptyContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
+    fun testEditablePartialSelectionClipboardText() =
+        runComplexTextFieldTest { textFieldKind, _ ->
+            UIPasteboard.generalPasteboard().string = "Paste text"
+            setTextFieldContent(
+                textFieldKind = textFieldKind,
+                initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
+                readOnly = false
+            )
+
+            openToolbar("TextField")
+            verifyContextMenuItemsVisible(labels = listOf("Cut", "Copy", "Paste", "Select All"))
+            verifyContextMenuItemsHidden(labels = listOf("Select"))
+        }
 
     @Test
-    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() =
-        runEditableCollapsedClipboardEmptyContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
+    fun testEditableFullSelectionClipboardTextBasicTextField() {
+        for (newContextMenuEnabled in arrayOf(false, true)) {
+            runEditableFullSelectionClipboardTextTest(newContextMenuEnabled) {
+                val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4, 4)))
+                setContent {
+                    val focusRequester = remember { FocusRequester() }
+                    Column(modifier = Modifier.safeDrawingPadding()) {
+                        BasicTextField(
+                            value = textFieldValue.value,
+                            onValueChange = { textFieldValue.value = it },
+                            modifier = textFieldModifier(focusRequester)
+                        )
+                    }
+                    LaunchedEffect(focusRequester) {
+                        focusRequester.requestFocus()
+                    }
+                }
+
+                val isFullySelected = {
+                    val selection = textFieldValue.value.selection
+                    selection.start == 0 && selection.end == textFieldValue.value.text.length
+                }
+                isFullySelected
+            }
+        }
+    }
 
     @Test
-    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardEmpty() =
-        runEditableCollapsedClipboardEmptyContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextFieldEditablePartialSelectionClipboardText() =
-        runEditablePartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextField2EditablePartialSelectionClipboardText() =
-        runEditablePartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextFieldEditablePartialSelectionClipboardText() =
-        runEditablePartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextField2EditablePartialSelectionClipboardText() =
-        runEditablePartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextFieldEditableFullSelectionClipboardText() =
-        runEditableFullSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextField2EditableFullSelectionClipboardText() =
-        runEditableFullSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextFieldEditableFullSelectionClipboardText() =
-        runEditableFullSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
+    fun testEditableFullSelectionClipboardTextBasicTextField2OldContextMenu() =
+        runEditableFullSelectionClipboardTextTest(newContextMenuEnabled = false) {
+            runEditableFullSelectionClipboardTextBasicTextField2()
+        }
 
     @Test
     @Ignore // CMP-10301: Menu is not shown after tap on Select All
-    fun testNewContextMenuBasicTextField2EditableFullSelectionClipboardText() =
-        runEditableFullSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
+    fun testEditableFullSelectionClipboardTextBasicTextField2NewContextMenu() =
+        runEditableFullSelectionClipboardTextTest(newContextMenuEnabled = true) {
+            runEditableFullSelectionClipboardTextBasicTextField2()
+        }
+
+    private fun UIKitInstrumentedTest.runEditableFullSelectionClipboardTextBasicTextField2(): () -> Boolean {
+        val textFieldState = TextFieldState("Text", TextRange(4, 4))
+        setContent {
+            val focusRequester = remember { FocusRequester() }
+            Column(modifier = Modifier.safeDrawingPadding()) {
+                BasicTextField(
+                    state = textFieldState,
+                    modifier = textFieldModifier(focusRequester)
+                )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        return {
+            val selection = textFieldState.selection
+            selection.start == 0 && selection.end == textFieldState.text.length
+        }
+    }
+
+    private fun runEditableFullSelectionClipboardTextTest(
+        newContextMenuEnabled: Boolean,
+        setContentAndGetIsFullySelected: UIKitInstrumentedTest.() -> () -> Boolean
+    ) =
+        runContextMenuTest(newContextMenuEnabled) {
+            UIPasteboard.generalPasteboard().string = "Paste text"
+            val isFullySelected = setContentAndGetIsFullySelected()
+
+            longPressAndAwaitContextMenu("TextField")
+            tapContextMenuButton("Select All")
+            waitUntil("Text field should be fully selected") {
+                isFullySelected()
+            }
+
+            val visible = listOf("Cut", "Copy", "Paste")
+            val hidden = listOf("Select", "Select All")
+
+            waitUntil("Context menu should update for full selection") {
+                visible.all { findNodeWithLabelOrNull(it) != null } &&
+                    hidden.all { findNodeWithLabelOrNull(it) == null }
+            }
+
+            verifyContextMenuItemsVisible(labels = visible)
+            verifyContextMenuItemsHidden(labels = hidden)
+        }
 
     @Test
-    fun testOldContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() =
-        runReadOnlyCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
+    fun testReadOnlyCollapsedClipboardText() =
+        runComplexTextFieldTest { textFieldKind, _ ->
+            UIPasteboard.generalPasteboard().string = "Paste text"
+            setTextFieldContent(
+                textFieldKind = textFieldKind,
+                initialValue = TextFieldValue("Text", TextRange(4, 4)),
+                readOnly = true
+            )
+
+            longPressAndAwaitContextMenu("TextField")
+            verifyContextMenuItemsVisible(labels = listOf("Select All"))
+            verifyContextMenuItemsHidden(labels = listOf("Cut", "Copy", "Paste", "Select"))
+        }
 
     @Test
-    fun testOldContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() =
-        runReadOnlyCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
+    fun testReadOnlyPartialSelectionClipboardText() =
+        runComplexTextFieldTest { textFieldKind, _ ->
+            UIPasteboard.generalPasteboard().string = "Paste text"
+            setTextFieldContent(
+                textFieldKind = textFieldKind,
+                initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
+                readOnly = true
+            )
 
-    @Test
-    fun testNewContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() =
-        runReadOnlyCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() =
-        runReadOnlyCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() =
-        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testOldContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() =
-        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() =
-        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
-
-    @Test
-    fun testNewContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() =
-        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
+            openToolbar("TextField")
+            verifyContextMenuItemsVisible(labels = listOf("Copy", "Select All"))
+            verifyContextMenuItemsHidden(labels = listOf("Cut", "Paste", "Select"))
+        }
 
     @Test
     fun testTapsCountingWithMultiTouch() = runUIKitInstrumentedTest {
@@ -731,98 +753,6 @@ class TextFieldEditMenuTest {
             .testTag("TextField")
             .focusRequester(focusRequester)
 
-    private fun runEditableCollapsedClipboardTextContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        val visibleActions =
-            if (newContextMenu) {
-                listOf("Paste", "Select All")
-            } else {
-                listOf("Paste", "Select", "Select All")
-            }
-        val hiddenActions =
-            if (newContextMenu) {
-                listOf("Cut", "Copy", "Select")
-            } else {
-                listOf("Cut", "Copy")
-            }
-
-        verifyEditableCollapsedClipboardTextContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = visibleActions,
-            hiddenActions = hiddenActions
-        )
-    }
-
-    private fun runEditableCollapsedClipboardEmptyContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        val visibleActions =
-            if (newContextMenu) {
-                listOf("Select All")
-            } else {
-                listOf("Select", "Select All")
-            }
-        val hiddenActions =
-            if (newContextMenu) {
-                listOf("Cut", "Copy", "Paste", "Select")
-            } else {
-                listOf("Cut", "Copy", "Paste")
-            }
-
-        verifyEditableCollapsedClipboardEmptyContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = visibleActions,
-            hiddenActions = hiddenActions
-        )
-    }
-
-    private fun runEditablePartialSelectionClipboardTextContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        verifyEditablePartialSelectionClipboardTextContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
-            hiddenActions = listOf("Select")
-        )
-    }
-
-    private fun runEditableFullSelectionClipboardTextContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        verifyEditableFullSelectionClipboardTextContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = listOf("Cut", "Copy", "Paste"),
-            hiddenActions = listOf("Select", "Select All")
-        )
-    }
-
-    private fun runReadOnlyCollapsedClipboardTextContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        verifyReadOnlyCollapsedClipboardTextContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
-        )
-    }
-
-    private fun runReadOnlyPartialSelectionClipboardTextContextMenuTest(
-        textFieldKind: EditableTextFieldKind,
-        newContextMenu: Boolean,
-    ) = runContextMenuTest(newContextMenu) {
-        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
-            textFieldKind = textFieldKind,
-            visibleActions = listOf("Copy", "Select All"),
-            hiddenActions = listOf("Cut", "Paste", "Select")
-        )
-    }
-
     private fun UIKitInstrumentedTest.longPressAndAwaitContextMenu(textFieldTag: String) {
         val touch = findNodeWithTag(textFieldTag).touchDown()
         waitUntil {
@@ -830,168 +760,6 @@ class TextFieldEditMenuTest {
         }
         touch.up()
         waitForContextMenu()
-    }
-
-    private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardTextContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        verifyEditableCollapsedContextMenu(
-            textFieldKind = textFieldKind,
-            clipboardText = "Paste text",
-            visibleActions = visibleActions,
-            hiddenActions = hiddenActions
-        )
-    }
-
-    private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardEmptyContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        verifyEditableCollapsedContextMenu(
-            textFieldKind = textFieldKind,
-            clipboardText = null,
-            visibleActions = visibleActions,
-            hiddenActions = hiddenActions
-        )
-    }
-
-    private fun UIKitInstrumentedTest.verifyEditableCollapsedContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        clipboardText: String?,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        UIPasteboard.generalPasteboard().string = clipboardText
-        setTextFieldContent(
-            textFieldKind = textFieldKind,
-            initialValue = TextFieldValue("Text", TextRange(4, 4)),
-            readOnly = false
-        )
-
-        longPressAndAwaitContextMenu("TextField")
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
-    }
-
-    private fun UIKitInstrumentedTest.verifyEditablePartialSelectionClipboardTextContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        UIPasteboard.generalPasteboard().string = "Paste text"
-        setTextFieldContent(
-            textFieldKind = textFieldKind,
-            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
-            readOnly = false
-        )
-
-        openToolbar("TextField")
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
-    }
-
-    private fun UIKitInstrumentedTest.verifyReadOnlyCollapsedClipboardTextContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        UIPasteboard.generalPasteboard().string = "Paste text"
-        setTextFieldContent(
-            textFieldKind = textFieldKind,
-            initialValue = TextFieldValue("Text", TextRange(4, 4)),
-            readOnly = true
-        )
-
-        longPressAndAwaitContextMenu("TextField")
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
-    }
-
-    private fun UIKitInstrumentedTest.verifyReadOnlyPartialSelectionClipboardTextContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        UIPasteboard.generalPasteboard().string = "Paste text"
-        setTextFieldContent(
-            textFieldKind = textFieldKind,
-            initialValue = TextFieldValue(PARTIAL_SELECTION_TEXT),
-            readOnly = true
-        )
-
-        openToolbar("TextField")
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
-    }
-
-    private fun UIKitInstrumentedTest.verifyEditableFullSelectionClipboardTextContextMenu(
-        textFieldKind: EditableTextFieldKind,
-        visibleActions: List<String>,
-        hiddenActions: List<String>,
-    ) {
-        UIPasteboard.generalPasteboard().string = "Paste text"
-        when (textFieldKind) {
-            EditableTextFieldKind.BasicTextField -> {
-                val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4, 4)))
-                setContent {
-                    val focusRequester = remember { FocusRequester() }
-                    Column(modifier = Modifier.safeDrawingPadding()) {
-                        BasicTextField(
-                            value = textFieldValue.value,
-                            onValueChange = { textFieldValue.value = it },
-                            modifier = textFieldModifier(focusRequester)
-                        )
-                    }
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
-                    }
-                }
-
-                longPressAndAwaitContextMenu("TextField")
-                tapContextMenuButton("Select All")
-                waitUntil("Text field should be fully selected") {
-                    textFieldValue.value.selection.start == 0 &&
-                        textFieldValue.value.selection.end == textFieldValue.value.text.length
-                }
-            }
-            EditableTextFieldKind.BasicTextField2 -> {
-                val textFieldState = TextFieldState("Text", TextRange(4, 4))
-                setContent {
-                    val focusRequester = remember { FocusRequester() }
-                    Column(modifier = Modifier.safeDrawingPadding()) {
-                        BasicTextField(
-                            state = textFieldState,
-                            modifier = textFieldModifier(focusRequester)
-                        )
-                    }
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
-                    }
-                }
-
-                longPressAndAwaitContextMenu("TextField")
-                tapContextMenuButton("Select All")
-                waitUntil("Text field should be fully selected") {
-                    textFieldState.selection.start == 0 &&
-                        textFieldState.selection.end == textFieldState.text.length
-                }
-            }
-        }
-
-        waitUntil("Context menu should update for full selection") {
-            visibleActions.all { findNodeWithLabelOrNull(it) != null } &&
-                hiddenActions.all { findNodeWithLabelOrNull(it) == null }
-        }
-
-        verifyContextMenuItemsVisible(visibleActions)
-        verifyContextMenuItemsHidden(hiddenActions)
     }
 
     private fun UIKitInstrumentedTest.setTextFieldContent(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -283,32 +283,40 @@ class TextFieldEditMenuTest {
     }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardText() =
-        runEditableCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = false
-        )
+    fun testEditableCollapsedClipboardText() =
+        runComplexTextFieldTest { textFieldKind, newContextMenu ->
+            UIPasteboard.generalPasteboard().string = "Paste text"
+            setTextFieldContent(
+                textFieldKind = textFieldKind,
+                initialValue = TextFieldValue("Text", TextRange(4, 4)),
+                readOnly = false
+            )
 
-    @Test
-    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardText() =
-        runEditableCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = false
-        )
+            longPressAndAwaitContextMenu("TextField")
+            verifyContextMenuItemsVisible(labels = if (newContextMenu) {
+                listOf("Paste", "Select All")
+            } else {
+                listOf("Paste", "Select", "Select All")
+            })
 
-    @Test
-    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardText() =
-        runEditableCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField,
-            newContextMenu = true
-        )
+            verifyContextMenuItemsHidden(
+                labels = if (newContextMenu) {
+                    listOf("Cut", "Copy", "Select")
+                } else {
+                    listOf("Cut", "Copy")
+                }
+            )
+        }
 
-    @Test
-    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardText() =
-        runEditableCollapsedClipboardTextContextMenuTest(
-            textFieldKind = EditableTextFieldKind.BasicTextField2,
-            newContextMenu = true
-        )
+    private fun runComplexTextFieldTest(test: UIKitInstrumentedTest.(EditableTextFieldKind, newContextMenuEnabled: Boolean) -> Unit) {
+        for (newContextMenuEnabled in arrayOf(false, true)) {
+            for (textFieldKind in EditableTextFieldKind.entries) {
+                runContextMenuTest(newContextMenuEnabled) {
+                    test(textFieldKind, newContextMenuEnabled)
+                }
+            }
+        }
+    }
 
     @Test
     fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() =

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -287,221 +287,173 @@ class TextFieldEditMenuTest {
     }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardText() = runContextMenuTest(false) {
-        verifyEditableCollapsedClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardText() =
+        runEditableCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Paste", "Select", "Select All"),
-            hiddenActions = listOf("Cut", "Copy")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardText() = runContextMenuTest(false) {
-        verifyEditableCollapsedClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardText() =
+        runEditableCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Paste", "Select", "Select All"),
-            hiddenActions = listOf("Cut", "Copy")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardText() = runContextMenuTest(true) {
-        verifyEditableCollapsedClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardText() =
+        runEditableCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Paste", "Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardText() = runContextMenuTest(true) {
-        verifyEditableCollapsedClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardText() =
+        runEditableCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Paste", "Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
-        verifyEditableCollapsedClipboardEmptyContextMenu(
+    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() =
+        runEditableCollapsedClipboardEmptyContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Select", "Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
-        verifyEditableCollapsedClipboardEmptyContextMenu(
+    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardEmpty() =
+        runEditableCollapsedClipboardEmptyContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Select", "Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
-        verifyEditableCollapsedClipboardEmptyContextMenu(
+    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() =
+        runEditableCollapsedClipboardEmptyContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
-        verifyEditableCollapsedClipboardEmptyContextMenu(
+    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardEmpty() =
+        runEditableCollapsedClipboardEmptyContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditablePartialSelectionClipboardText() = runContextMenuTest(false) {
-        verifyEditablePartialSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextFieldEditablePartialSelectionClipboardText() =
+        runEditablePartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
-            hiddenActions = listOf("Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2EditablePartialSelectionClipboardText() = runContextMenuTest(false) {
-        verifyEditablePartialSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextField2EditablePartialSelectionClipboardText() =
+        runEditablePartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
-            hiddenActions = listOf("Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldEditablePartialSelectionClipboardText() = runContextMenuTest(true) {
-        verifyEditablePartialSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextFieldEditablePartialSelectionClipboardText() =
+        runEditablePartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
-            hiddenActions = listOf("Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextField2EditablePartialSelectionClipboardText() = runContextMenuTest(true) {
-        verifyEditablePartialSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextField2EditablePartialSelectionClipboardText() =
+        runEditablePartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
-            hiddenActions = listOf("Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextFieldEditableFullSelectionClipboardText() = runContextMenuTest(false) {
-        verifyEditableFullSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextFieldEditableFullSelectionClipboardText() =
+        runEditableFullSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Cut", "Copy", "Paste"),
-            hiddenActions = listOf("Select", "Select All")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2EditableFullSelectionClipboardText() = runContextMenuTest(false) {
-        verifyEditableFullSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextField2EditableFullSelectionClipboardText() =
+        runEditableFullSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Cut", "Copy", "Paste"),
-            hiddenActions = listOf("Select", "Select All")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldEditableFullSelectionClipboardText() = runContextMenuTest(true) {
-        verifyEditableFullSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextFieldEditableFullSelectionClipboardText() =
+        runEditableFullSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Cut", "Copy", "Paste"),
-            hiddenActions = listOf("Select", "Select All")
+            newContextMenu = true
         )
-    }
 
     @Test
     @Ignore // CMP-10301: Menu is not shown after tap on Select All
-    fun testNewContextMenuBasicTextField2EditableFullSelectionClipboardText() = runContextMenuTest(true) {
-        verifyEditableFullSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextField2EditableFullSelectionClipboardText() =
+        runEditableFullSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Cut", "Copy", "Paste"),
-            hiddenActions = listOf("Select", "Select All")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() = runContextMenuTest(false) {
-        verifyReadOnlyCollapsedClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() =
+        runReadOnlyCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() = runContextMenuTest(false) {
-        verifyReadOnlyCollapsedClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() =
+        runReadOnlyCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() = runContextMenuTest(true) {
-        verifyReadOnlyCollapsedClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextFieldReadOnlyCollapsedClipboardText() =
+        runReadOnlyCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() = runContextMenuTest(true) {
-        verifyReadOnlyCollapsedClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextField2ReadOnlyCollapsedClipboardText() =
+        runReadOnlyCollapsedClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Select All"),
-            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() = runContextMenuTest(false) {
-        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() =
+        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Copy", "Select All"),
-            hiddenActions = listOf("Cut", "Paste", "Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testOldContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() = runContextMenuTest(false) {
-        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+    fun testOldContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() =
+        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Copy", "Select All"),
-            hiddenActions = listOf("Cut", "Paste", "Select")
+            newContextMenu = false
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() = runContextMenuTest(true) {
-        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextFieldReadOnlyPartialSelectionClipboardText() =
+        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField,
-            visibleActions = listOf("Copy", "Select All"),
-            hiddenActions = listOf("Cut", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
-    fun testNewContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() = runContextMenuTest(true) {
-        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+    fun testNewContextMenuBasicTextField2ReadOnlyPartialSelectionClipboardText() =
+        runReadOnlyPartialSelectionClipboardTextContextMenuTest(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
-            visibleActions = listOf("Copy", "Select All"),
-            hiddenActions = listOf("Cut", "Paste", "Select")
+            newContextMenu = true
         )
-    }
 
     @Test
     fun testTapsCountingWithMultiTouch() = runUIKitInstrumentedTest {
@@ -772,6 +724,98 @@ class TextFieldEditMenuTest {
         delay(500)
         findNodeWithTag(textFieldTag).doubleTap()
         waitForContextMenu()
+    }
+
+    private fun runEditableCollapsedClipboardTextContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        val visibleActions =
+            if (newContextMenu) {
+                listOf("Paste", "Select All")
+            } else {
+                listOf("Paste", "Select", "Select All")
+            }
+        val hiddenActions =
+            if (newContextMenu) {
+                listOf("Cut", "Copy", "Select")
+            } else {
+                listOf("Cut", "Copy")
+            }
+
+        verifyEditableCollapsedClipboardTextContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = visibleActions,
+            hiddenActions = hiddenActions
+        )
+    }
+
+    private fun runEditableCollapsedClipboardEmptyContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        val visibleActions =
+            if (newContextMenu) {
+                listOf("Select All")
+            } else {
+                listOf("Select", "Select All")
+            }
+        val hiddenActions =
+            if (newContextMenu) {
+                listOf("Cut", "Copy", "Paste", "Select")
+            } else {
+                listOf("Cut", "Copy", "Paste")
+            }
+
+        verifyEditableCollapsedClipboardEmptyContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = visibleActions,
+            hiddenActions = hiddenActions
+        )
+    }
+
+    private fun runEditablePartialSelectionClipboardTextContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        verifyEditablePartialSelectionClipboardTextContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = listOf("Cut", "Copy", "Paste", "Select All"),
+            hiddenActions = listOf("Select")
+        )
+    }
+
+    private fun runEditableFullSelectionClipboardTextContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        verifyEditableFullSelectionClipboardTextContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = listOf("Cut", "Copy", "Paste"),
+            hiddenActions = listOf("Select", "Select All")
+        )
+    }
+
+    private fun runReadOnlyCollapsedClipboardTextContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        verifyReadOnlyCollapsedClipboardTextContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    private fun runReadOnlyPartialSelectionClipboardTextContextMenuTest(
+        textFieldKind: EditableTextFieldKind,
+        newContextMenu: Boolean,
+    ) = runContextMenuTest(newContextMenu) {
+        verifyReadOnlyPartialSelectionClipboardTextContextMenu(
+            textFieldKind = textFieldKind,
+            visibleActions = listOf("Copy", "Select All"),
+            hiddenActions = listOf("Cut", "Paste", "Select")
+        )
     }
 
     private fun UIKitInstrumentedTest.longPressAndAwaitContextMenu(textFieldTag: String) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.test.waitForContextMenu
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -421,6 +422,7 @@ class TextFieldEditMenuTest {
     }
 
     @Test
+    @Ignore // CMP-10301: Menu is not shown after tap on Select All
     fun testNewContextMenuBasicTextField2EditableFullSelectionClipboardText() = runContextMenuTest(true) {
         verifyEditableFullSelectionClipboardTextContextMenu(
             textFieldKind = EditableTextFieldKind.BasicTextField2,
@@ -928,8 +930,6 @@ class TextFieldEditMenuTest {
                         focusRequester.requestFocus()
                     }
                 }
-
-           //     delay(60000)
 
                 longPressAndAwaitContextMenu("TextField")
                 tapContextMenuButton("Select All")

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -83,7 +83,7 @@ class TextFieldEditMenuTest {
                 BasicTextField(
                     textValue.value,
                     { textValue.value = it },
-                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                 )
             }
             LaunchedEffect(focusRequester) {
@@ -105,7 +105,7 @@ class TextFieldEditMenuTest {
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     textFieldState,
-                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                 )
             }
             LaunchedEffect(focusRequester) {
@@ -124,7 +124,7 @@ class TextFieldEditMenuTest {
         setContent {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                TextField("Hello-LongLongLongLongLong-text", {}, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+                TextField("Hello-LongLongLongLongLong-text", {}, modifier = textFieldModifier(focusRequester))
             }
             LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
@@ -143,7 +143,7 @@ class TextFieldEditMenuTest {
         setContent {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+                BasicTextField(textFieldState, modifier = textFieldModifier(focusRequester))
             }
             LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
@@ -164,7 +164,7 @@ class TextFieldEditMenuTest {
                 BasicTextField(
                     value = textFieldValue.value,
                     onValueChange = { textFieldValue.value = it },
-                    modifier = Modifier.testTag("TextField").focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                 )
             }
             LaunchedEffect(focusRequester) {
@@ -193,7 +193,7 @@ class TextFieldEditMenuTest {
         setContent {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(textFieldState, modifier = Modifier.testTag("TextField").focusRequester(focusRequester))
+                BasicTextField(textFieldState, modifier = textFieldModifier(focusRequester))
             }
             LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
@@ -225,9 +225,7 @@ class TextFieldEditMenuTest {
                 BasicTextField(
                     value = textFieldValue.value,
                     onValueChange = { textFieldValue.value = it },
-                    modifier = Modifier
-                        .testTag("TextField")
-                        .focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                 )
             }
             LaunchedEffect(focusRequester) {
@@ -261,9 +259,7 @@ class TextFieldEditMenuTest {
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     state = textFieldState,
-                    modifier = Modifier
-                        .testTag("TextField")
-                        .focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                 )
             }
             LaunchedEffect(focusRequester) {
@@ -602,9 +598,7 @@ class TextFieldEditMenuTest {
                 BasicTextField(
                     value = textFieldValue.value,
                     onValueChange = { textFieldValue.value = it },
-                    modifier = Modifier
-                        .testTag("TextField")
-                        .focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                         .appendTextContextMenuComponents {
                             item(key = "CustomKey", label = "Custom Action") {
                                 customItemClicked = true
@@ -646,9 +640,7 @@ class TextFieldEditMenuTest {
             Column(modifier = Modifier.safeDrawingPadding()) {
                 BasicTextField(
                     state = textFieldState,
-                    modifier = Modifier
-                        .testTag("TextField")
-                        .focusRequester(focusRequester)
+                    modifier = textFieldModifier(focusRequester)
                         .appendTextContextMenuComponents {
                             item(key = "CustomKey", label = "Custom Action") {
                                 customItemClicked = true
@@ -725,6 +717,11 @@ class TextFieldEditMenuTest {
         findNodeWithTag(textFieldTag).doubleTap()
         waitForContextMenu()
     }
+
+    private fun textFieldModifier(focusRequester: FocusRequester): Modifier =
+        Modifier
+            .testTag("TextField")
+            .focusRequester(focusRequester)
 
     private fun runEditableCollapsedClipboardTextContextMenuTest(
         textFieldKind: EditableTextFieldKind,
@@ -941,9 +938,7 @@ class TextFieldEditMenuTest {
                         BasicTextField(
                             value = textFieldValue.value,
                             onValueChange = { textFieldValue.value = it },
-                            modifier = Modifier
-                                .testTag("TextField")
-                                .focusRequester(focusRequester)
+                            modifier = textFieldModifier(focusRequester)
                         )
                     }
                     LaunchedEffect(focusRequester) {
@@ -965,9 +960,7 @@ class TextFieldEditMenuTest {
                     Column(modifier = Modifier.safeDrawingPadding()) {
                         BasicTextField(
                             state = textFieldState,
-                            modifier = Modifier
-                                .testTag("TextField")
-                                .focusRequester(focusRequester)
+                            modifier = textFieldModifier(focusRequester)
                         )
                     }
                     LaunchedEffect(focusRequester) {
@@ -1009,9 +1002,7 @@ class TextFieldEditMenuTest {
                         BasicTextField(
                             value = textFieldValue.value,
                             onValueChange = { textFieldValue.value = it },
-                            modifier = Modifier
-                                .testTag("TextField")
-                                .focusRequester(focusRequester),
+                            modifier = textFieldModifier(focusRequester),
                             readOnly = readOnly
                         )
                     }
@@ -1021,9 +1012,7 @@ class TextFieldEditMenuTest {
                         }
                         BasicTextField(
                             state = textFieldState,
-                            modifier = Modifier
-                                .testTag("TextField")
-                                .focusRequester(focusRequester),
+                            modifier = textFieldModifier(focusRequester),
                             readOnly = readOnly
                         )
                     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -63,6 +63,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
@@ -284,6 +285,22 @@ class TextFieldEditMenuTest {
         // A long press again brings the context menu back.
         longPressAndAwaitContextMenu("TextField")
         findNodeWithLabel("Paste").assertVisibleInContainer()
+    }
+
+    @Test
+    fun testOldContextMenuEditableCollapsedClipboardText() = runContextMenuTest(false) {
+        verifyEditableCollapsedClipboardTextContextMenu(
+            visibleActions = listOf("Paste", "Select", "Select All"),
+            hiddenActions = listOf("Cut", "Copy")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuEditableCollapsedClipboardText() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardTextContextMenu(
+            visibleActions = listOf("Paste", "Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Select")
+        )
     }
 
     @Test
@@ -566,6 +583,34 @@ class TextFieldEditMenuTest {
         waitForContextMenu()
     }
 
+    private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardTextContextMenu(
+        visibleActions: List<String>,
+        hiddenActions: List<String>,
+    ) {
+        UIPasteboard.generalPasteboard().string = "Paste text"
+        val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4,4)))
+        setContent {
+            val focusRequester = remember { FocusRequester() }
+            Column(modifier = Modifier.safeDrawingPadding()) {
+                BasicTextField(
+                    value = textFieldValue.value,
+                    onValueChange = { textFieldValue.value = it },
+                    modifier = Modifier
+                        .testTag("TextField")
+                        .focusRequester(focusRequester)
+                )
+            }
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        longPressAndAwaitContextMenu("TextField")
+
+        verifyContextMenuItemsVisible(visibleActions)
+        verifyContextMenuItemsHidden(hiddenActions)
+    }
+
     @OptIn(ExperimentalFoundationApi::class)
     private fun runContextMenuTest(
         newContextMenuEnabled: Boolean,
@@ -587,6 +632,15 @@ class TextFieldEditMenuTest {
                 it.assertVisibleInContainer()
                 assertTrue(it.isAccessibilityElement ?: false)
             }
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class) private fun UIKitInstrumentedTest.verifyContextMenuItemsHidden(labels: List<String>) {
+        labels.forEach { label ->
+            assertNull(
+                findNodeWithLabelOrNull(label),
+                "Context menu item \"$label\" should be hidden"
+            )
         }
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -288,32 +288,72 @@ class TextFieldEditMenuTest {
     }
 
     @Test
-    fun testOldContextMenuEditableCollapsedClipboardText() = runContextMenuTest(false) {
+    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardText() = runContextMenuTest(false) {
         verifyEditableCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
             visibleActions = listOf("Paste", "Select", "Select All"),
             hiddenActions = listOf("Cut", "Copy")
         )
     }
 
     @Test
-    fun testNewContextMenuEditableCollapsedClipboardText() = runContextMenuTest(true) {
+    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardText() = runContextMenuTest(false) {
         verifyEditableCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Paste", "Select", "Select All"),
+            hiddenActions = listOf("Cut", "Copy")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardText() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
             visibleActions = listOf("Paste", "Select All"),
             hiddenActions = listOf("Cut", "Copy", "Select")
         )
     }
 
     @Test
-    fun testOldContextMenuEditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
+    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardText() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardTextContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Paste", "Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Select")
+        )
+    }
+
+    @Test
+    fun testOldContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
         verifyEditableCollapsedClipboardEmptyContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
             visibleActions = listOf("Select", "Select All"),
             hiddenActions = listOf("Cut", "Copy", "Paste")
         )
     }
 
     @Test
-    fun testNewContextMenuEditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
+    fun testOldContextMenuBasicTextField2EditableCollapsedClipboardEmpty() = runContextMenuTest(false) {
         verifyEditableCollapsedClipboardEmptyContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
+            visibleActions = listOf("Select", "Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextFieldEditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardEmptyContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField,
+            visibleActions = listOf("Select All"),
+            hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
+        )
+    }
+
+    @Test
+    fun testNewContextMenuBasicTextField2EditableCollapsedClipboardEmpty() = runContextMenuTest(true) {
+        verifyEditableCollapsedClipboardEmptyContextMenu(
+            textFieldKind = EditableTextFieldKind.BasicTextField2,
             visibleActions = listOf("Select All"),
             hiddenActions = listOf("Cut", "Copy", "Paste", "Select")
         )
@@ -600,10 +640,12 @@ class TextFieldEditMenuTest {
     }
 
     private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardTextContextMenu(
+        textFieldKind: EditableTextFieldKind,
         visibleActions: List<String>,
         hiddenActions: List<String>,
     ) {
         verifyEditableCollapsedContextMenu(
+            textFieldKind = textFieldKind,
             clipboardText = "Paste text",
             visibleActions = visibleActions,
             hiddenActions = hiddenActions
@@ -611,10 +653,12 @@ class TextFieldEditMenuTest {
     }
 
     private fun UIKitInstrumentedTest.verifyEditableCollapsedClipboardEmptyContextMenu(
+        textFieldKind: EditableTextFieldKind,
         visibleActions: List<String>,
         hiddenActions: List<String>,
     ) {
         verifyEditableCollapsedContextMenu(
+            textFieldKind = textFieldKind,
             clipboardText = null,
             visibleActions = visibleActions,
             hiddenActions = hiddenActions
@@ -622,22 +666,40 @@ class TextFieldEditMenuTest {
     }
 
     private fun UIKitInstrumentedTest.verifyEditableCollapsedContextMenu(
+        textFieldKind: EditableTextFieldKind,
         clipboardText: String?,
         visibleActions: List<String>,
         hiddenActions: List<String>,
     ) {
         UIPasteboard.generalPasteboard().string = clipboardText
-        val textFieldValue = mutableStateOf(TextFieldValue("Text", TextRange(4,4)))
         setContent {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
-                BasicTextField(
-                    value = textFieldValue.value,
-                    onValueChange = { textFieldValue.value = it },
-                    modifier = Modifier
-                        .testTag("TextField")
-                        .focusRequester(focusRequester)
-                )
+                when (textFieldKind) {
+                    EditableTextFieldKind.BasicTextField -> {
+                        val textFieldValue = remember {
+                            mutableStateOf(TextFieldValue("Text", TextRange(4, 4)))
+                        }
+                        BasicTextField(
+                            value = textFieldValue.value,
+                            onValueChange = { textFieldValue.value = it },
+                            modifier = Modifier
+                                .testTag("TextField")
+                                .focusRequester(focusRequester)
+                        )
+                    }
+                    EditableTextFieldKind.BasicTextField2 -> {
+                        val textFieldState = remember {
+                            TextFieldState("Text", TextRange(4, 4))
+                        }
+                        BasicTextField(
+                            state = textFieldState,
+                            modifier = Modifier
+                                .testTag("TextField")
+                                .focusRequester(focusRequester)
+                        )
+                    }
+                }
             }
             LaunchedEffect(focusRequester) {
                 focusRequester.requestFocus()
@@ -648,6 +710,11 @@ class TextFieldEditMenuTest {
 
         verifyContextMenuItemsVisible(visibleActions)
         verifyContextMenuItemsHidden(hiddenActions)
+    }
+
+    private enum class EditableTextFieldKind {
+        BasicTextField,
+        BasicTextField2
     }
 
     @OptIn(ExperimentalFoundationApi::class)


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

(Optional) Fixes [CMP-10292](https://youtrack.jetbrains.com/issue/CMP-10292) [iOS] Add instrumented tests for old and new edit menus with TextField and TextField2

## Testing
(Optional) Describe how you tested your changes (provide a snippet or/and steps)

## Release Notes

N/A
