### PR TITLE
[web] style backing field inputs in shadow css definitions

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -208,43 +208,7 @@ private fun ImeOptions.createDomElement(): HTMLElement {
 
     htmlElement.setAttribute("inputmode", inputMode)
     htmlElement.setAttribute("enterkeyhint", enterKeyHint)
-
-
-    htmlElement.style.apply {
-        setProperty("position", "absolute")
-        setProperty("user-select", "none")
-        setProperty("forced-color-adjust", "none")
-        setProperty("white-space", "pre")
-        setProperty("align-content", "center")
-        setProperty(
-            "top",
-            "calc(min(var(--compose-internal-web-backing-input-top) * 1px, 100vh - var(--compose-internal-web-backing-input-height) * 1px))"
-        )
-        setProperty(
-            "left",
-            "calc(min(var(--compose-internal-web-backing-input-left) * 1px, 100vw - var(--compose-internal-web-backing-input-width) * 1px))"
-        )
-        setProperty("width", "calc(var(--compose-internal-web-backing-input-width) * 1px")
-        setProperty("height", "calc(var(--compose-internal-web-backing-input-height) * 1px")
-        setProperty("padding", "0")
-        setProperty("color", "transparent")
-        setProperty("background", "transparent")
-        setProperty("caret-color", "transparent")
-        setProperty("outline", "none")
-        setProperty("border", "none")
-        setProperty("resize", "none")
-        setProperty("text-shadow", "none")
-        setProperty("z-index", "-1")
-        // TODO: do we need pointer-events: none
-        //setProperty("pointer-events", "none")
-
-        // I keep "opacity" commented to make it explicit that we can't use this property.
-        // Reason: Safari iOS keyboard overlaps the text input. See CMP-8611
-        // setProperty("opacity", "0")
-
-        // To prevent auto-zoom in some mobile browsers, we set a larger font-size
-        setProperty("font-size", "20px")
-    }
+    htmlElement.classList.add("compose-backing-field")
 
     return htmlElement
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -105,6 +105,8 @@ fun ComposeViewport(
     //shadow
     val shadowRoot = shadowContainer.attachShadow(ShadowRootInit(ShadowRootMode.OPEN))
     val shadowRootStyle = document.createElement("style")
+
+    // don't style backing .compose-backing-field with opacity, see https://youtrack.jetbrains.com/projects/CMP/issues/CMP-8611
     shadowRootStyle.textContent = """
         :host {
             -webkit-touch-callout: none; 
@@ -120,6 +122,29 @@ fun ComposeViewport(
                width: 100%;
                height: 100%;
         }
+        
+       .compose-backing-field {
+            height: calc(var(--compose-internal-web-backing-input-height) * 1px);
+            width: calc(var(--compose-internal-web-backing-input-width) * 1px);
+            left: calc(min(var(--compose-internal-web-backing-input-left) * 1px, 100vw - var(--compose-internal-web-backing-input-width) * 1px));
+            top: calc(min(var(--compose-internal-web-backing-input-top) * 1px, 100vh - var(--compose-internal-web-backing-input-height) * 1px));
+       
+            align-content: center;
+            background: transparent;
+            border: none;
+            caret-color: transparent;
+            color: transparent;
+            font-size: 20px;
+            forced-color-adjust: none;
+            outline: none;
+            padding: 0;
+            position: absolute;
+            resize: none;
+            text-shadow: none;
+            user-select: none;
+            white-space: pre;
+            z-index: -1;
+       }
     """.trimIndent()
     shadowRoot.appendChild(shadowRootStyle)
 


### PR DESCRIPTION
This is justified since we don't have any properties we need to compulet per-creation

## Testing
`./gradlew testWeb`

## Release Notes
N/A