### PR TITLE
Decouple `TextToolbarStatus` from iOS context menu visibility

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -19,8 +19,6 @@
 
 @interface CMPEditMenuView : UIView
 
-@property (readonly) BOOL isEditMenuShown;
-
 - (void)showEditMenuAtRect:(CGRect)targetRect
                       copy:(void (^)(void))copyBlock
                        cut:(void (^)(void))cutBlock

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -141,8 +141,11 @@ internal class UIKitTextInputService(
 
     val textToolbar: TextToolbar by lazy(LazyThreadSafetyMode.NONE) {
         object : TextToolbar {
-            override val status: TextToolbarStatus
-                get() = (currentInputConnection as? ComposeTextInputConnection)?.toolbarStatus ?: TextToolbarStatus.Hidden
+            // Reflects whether the hosting CMPEditMenuView is alive, not the menu's literal visibility,
+            // so hide() always runs and the view can't linger in an orphaned state. Android's TextToolbar
+            // status is intent-based in a similar way (see AndroidTextToolbar.android.kt)
+            override var status: TextToolbarStatus = TextToolbarStatus.Hidden
+                private set
 
             override fun showMenu(
                 rect: Rect,
@@ -151,42 +154,19 @@ internal class UIKitTextInputService(
                 onCutRequested: (() -> Unit)?,
                 onSelectAllRequested: (() -> Unit)?
             ) {
+                status = TextToolbarStatus.Shown
                 if (currentInputConnection == null) {
                     // Entry point for showing the context menu in SelectionContainer scenarios, where
                     // there is no active text input session. iOS requires a UIView that can become first
                     // responder in order to host the context menu, so we create a dedicated connection
-                    // backed by a hidden view for this purpose.
-                    // Note: start() is intentionally not called here — it establishes a text editing
-                    // session (requiring a PlatformTextInputMethodRequest) which is not applicable for
-                    // SelectionContainer.
+                    // without the text input session backed by a hidden view for this purpose.
                     currentInputConnection = SelectionContainerConnection(
                         view = view,
                         coroutineScope = coroutineScope,
                         viewConfiguration = viewConfiguration,
                         focusManager = focusManager
                     )
-                    currentInputConnection?.start(
-                        object : PlatformTextInputMethodRequest {
-                            override val value: () -> TextFieldValue get() = { TextFieldValue() }
-                            override val state: TextEditorState = object : TextEditorState {
-                                override val selection: TextRange get() = TextRange(0, 0)
-                                override val composition: TextRange? get() = null
-                                override val length: Int get() = 0
-                                override fun get(index: Int): Char = ' '
-                                override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = ""
-                                override val text: String get() = ""
-                            }
-                            override val imeOptions: ImeOptions get() = ImeOptions.Default
-                            override val onEditCommand: (List<EditCommand>) -> Unit get() = { _ -> }
-                            override val onImeAction: ((ImeAction) -> Unit)? get() = null
-                            override val textLayoutResult: () -> TextLayoutResult? get() = { null }
-                            override val focusedRectInRoot: () -> Rect? get() = { null }
-                            override val textFieldRectInRoot: () -> Rect? get() = { null }
-                            override val textClippingRectInRoot: () -> Rect? get() = { null }
-                            override val unclippedTextOffsetInRoot: () -> Offset? get() = { null }
-                            override val editText: (block: TextEditingScope.() -> Unit) -> Unit get() = { _ -> }
-                        }
-                    )
+                    currentInputConnection?.start(emptyTextInputRequest())
                 }
                 (currentInputConnection as? ComposeTextInputConnection)?.showToolbarMenu(
                     rect = rect,
@@ -198,11 +178,11 @@ internal class UIKitTextInputService(
             }
 
             override fun hide() {
+                status = TextToolbarStatus.Hidden
                 (currentInputConnection as? ComposeTextInputConnection)?.hideToolbar()
 
                 if (currentInputConnection is SelectionContainerConnection) {
-                    // stop() removes the view from the hierarchy and resigns first responder,
-                    // without requiring a prior start() call.
+                    // stop() removes the view from the hierarchy and resigns first responder.
                     currentInputConnection?.stop()
                     currentInputConnection = null
                 }
@@ -255,3 +235,30 @@ internal class UIKitTextInputService(
         focusManager = { null }
     }
 }
+
+/**
+ * A stub [PlatformTextInputMethodRequest] with no real editing state. Used to start a
+ * [SelectionContainerConnection] purely to attach its hosting view for the context menu —
+ * there is no text editing session behind it.
+ */
+private fun emptyTextInputRequest(): PlatformTextInputMethodRequest =
+    object : PlatformTextInputMethodRequest {
+        override val value: () -> TextFieldValue get() = { TextFieldValue() }
+        override val state: TextEditorState = object : TextEditorState {
+            override val selection: TextRange get() = TextRange(0, 0)
+            override val composition: TextRange? get() = null
+            override val length: Int get() = 0
+            override fun get(index: Int): Char = ' '
+            override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = ""
+            override val text: String get() = ""
+        }
+        override val imeOptions: ImeOptions get() = ImeOptions.Default
+        override val onEditCommand: (List<EditCommand>) -> Unit get() = { _ -> }
+        override val onImeAction: ((ImeAction) -> Unit)? get() = null
+        override val textLayoutResult: () -> TextLayoutResult? get() = { null }
+        override val focusedRectInRoot: () -> Rect? get() = { null }
+        override val textFieldRectInRoot: () -> Rect? get() = { null }
+        override val textClippingRectInRoot: () -> Rect? get() = { null }
+        override val unclippedTextOffsetInRoot: () -> Offset? get() = { null }
+        override val editText: (block: TextEditingScope.() -> Unit) -> Unit get() = { _ -> }
+    }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -142,8 +142,7 @@ internal class UIKitTextInputService(
     val textToolbar: TextToolbar by lazy(LazyThreadSafetyMode.NONE) {
         object : TextToolbar {
             // Reflects whether the hosting CMPEditMenuView is alive, not the menu's literal visibility,
-            // so hide() always runs and the view can't linger in an orphaned state. Android's TextToolbar
-            // status is intent-based in a similar way (see AndroidTextToolbar.android.kt)
+            // so hide() always runs and the view can't linger in an orphaned state.
             override var status: TextToolbarStatus = TextToolbarStatus.Hidden
                 private set
 
@@ -156,6 +155,7 @@ internal class UIKitTextInputService(
             ) {
                 status = TextToolbarStatus.Shown
                 if (currentInputConnection == null) {
+                    // TODO: https://youtrack.jetbrains.com/issue/CMP-10352
                     // Entry point for showing the context menu in SelectionContainer scenarios, where
                     // there is no active text input session. iOS requires a UIView that can become first
                     // responder in order to host the context menu, so we create a dedicated connection

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -166,7 +166,7 @@ internal class UIKitTextInputService(
                         viewConfiguration = viewConfiguration,
                         focusManager = focusManager
                     )
-                    currentInputConnection?.start(emptyTextInputRequest())
+                    currentInputConnection?.start(noopTextInputRequest())
                 }
                 (currentInputConnection as? ComposeTextInputConnection)?.showToolbarMenu(
                     rect = rect,
@@ -241,7 +241,7 @@ internal class UIKitTextInputService(
  * [SelectionContainerConnection] purely to attach its hosting view for the context menu —
  * there is no text editing session behind it.
  */
-private fun emptyTextInputRequest(): PlatformTextInputMethodRequest =
+private fun noopTextInputRequest(): PlatformTextInputMethodRequest =
     object : PlatformTextInputMethodRequest {
         override val value: () -> TextFieldValue get() = { TextFieldValue() }
         override val state: TextEditorState = object : TextEditorState {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -142,7 +142,7 @@ internal class UIKitTextInputService(
     val textToolbar: TextToolbar by lazy(LazyThreadSafetyMode.NONE) {
         object : TextToolbar {
             // Reflects whether the hosting CMPEditMenuView is alive, not the menu's literal visibility,
-            // so hide() always runs and the view can't linger in an orphaned state.
+            // TODO: https://youtrack.jetbrains.com/issue/CMP-10352
             override var status: TextToolbarStatus = TextToolbarStatus.Hidden
                 private set
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.text.input
 
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.platform.TextToolbarStatus
 import androidx.compose.ui.platform.UIKitNativeTextInputContextMenuCustomAction
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.scene.ComposeSceneFocusManager
@@ -128,13 +127,6 @@ internal open class ComposeTextInputConnection(
             selectAll = selectAll
         )
     }
-
-    val toolbarStatus: TextToolbarStatus
-        get() = if (textInputView.isTextMenuShown()) {
-            TextToolbarStatus.Shown
-        } else {
-            TextToolbarStatus.Hidden
-        }
 
     fun showToolbarMenu(
         rect: Rect,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -476,8 +476,6 @@ internal class ComposeTextInputView(
 
     fun hideTextMenu() = this.hideEditMenu()
 
-    fun isTextMenuShown() = isEditMenuShown
-
     private val _tokenizer = TextInputStringTokenizer(textInput = this) {
         input?.let { it.textInRange(TextRange(0, it.endOfDocument())) }
     }


### PR DESCRIPTION
Decouple `TextToolbarStatus` from the native context menu on iOS visibility to fix leaks and incorrect behavior.
Clean ups in the UIKitTextInputService.ios.kt

Since the `TextToolbar.status` was tied with `isEditingMenuShow` flag, during back navigation there might be cases when TextToolbar.status reports as Hidden while the menu repositioning is happening on the CMPEditMenuView side.
That's why `SelectionManager` doesn't call `TextToolbar.hide()` (as it should during the back-navigating teardown), and the menu reappears once again, leaking the `ComposeTextInputView` in the view hierarchy.


Fixes: [CMP-9316 [ios]. context menu doesn't hide after backNavigation](https://youtrack.jetbrains.com/issue/CMP-9316)

## Testing
Should be tested by QA, the case in the attached task

## Release Notes
### Fixes - iOS
- Fix the context menu lingering on screen after navigating back from a `SelectionContainer`
