### PR TITLE
Introduce `ComposeDesktopEntryPoint` interface

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -135,6 +135,10 @@ public final class androidx/compose/ui/ComposableSingletons$ImageComposeScene_sk
 	public final fun getLambda$1296475654$ui ()Lkotlin/jvm/functions/Function2;
 }
 
+public abstract interface class androidx/compose/ui/ComposeDesktopEntryPoint {
+	public abstract fun getSemanticsOwners ()Ljava/util/Collection;
+}
+
 public final class androidx/compose/ui/ComposedModifierKt {
 	public static final fun composed (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)Landroidx/compose/ui/Modifier;
 	public static final fun composed (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)Landroidx/compose/ui/Modifier;
@@ -548,7 +552,7 @@ public final class androidx/compose/ui/awt/AwtWindow_desktopKt {
 	public static final fun AwtWindow (ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
-public final class androidx/compose/ui/awt/ComposeDialog : javax/swing/JDialog {
+public final class androidx/compose/ui/awt/ComposeDialog : javax/swing/JDialog, androidx/compose/ui/ComposeDesktopEntryPoint {
 	public static final field $stable I
 	public fun <init> ()V
 	public fun <init> (Ljava/awt/GraphicsConfiguration;)V
@@ -563,6 +567,7 @@ public final class androidx/compose/ui/awt/ComposeDialog : javax/swing/JDialog {
 	public final fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
 	public final fun getRenderApi ()Lorg/jetbrains/skiko/GraphicsApi;
+	public fun getSemanticsOwners ()Ljava/util/Collection;
 	public final fun getUndecoratedResizerThickness-D9Ej5fM ()F
 	public final fun getWindowHandle ()J
 	public final fun isTransparent ()Z
@@ -582,7 +587,7 @@ public final class androidx/compose/ui/awt/ComposeDialog : javax/swing/JDialog {
 	public final fun setUndecoratedResizerThickness-0680j_4 (F)V
 }
 
-public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPane {
+public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPane, androidx/compose/ui/ComposeDesktopEntryPoint {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/awt/ComposePanel$Companion;
 	public fun <init> ()V
@@ -594,6 +599,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public fun getMinimumSize ()Ljava/awt/Dimension;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
 	public final fun getRenderApi ()Lorg/jetbrains/skiko/GraphicsApi;
+	public fun getSemanticsOwners ()Ljava/util/Collection;
 	public fun hasFocus ()Z
 	public fun isFocusOwner ()Z
 	public fun remove (Ljava/awt/Component;)V
@@ -620,7 +626,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 public final class androidx/compose/ui/awt/ComposePanel$Companion {
 }
 
-public final class androidx/compose/ui/awt/ComposeWindow : javax/swing/JFrame {
+public final class androidx/compose/ui/awt/ComposeWindow : javax/swing/JFrame, androidx/compose/ui/ComposeDesktopEntryPoint {
 	public static final field $stable I
 	public fun <init> (Ljava/awt/GraphicsConfiguration;)V
 	public synthetic fun <init> (Ljava/awt/GraphicsConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -633,6 +639,7 @@ public final class androidx/compose/ui/awt/ComposeWindow : javax/swing/JFrame {
 	public final fun getPlacement ()Landroidx/compose/ui/window/WindowPlacement;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
 	public final fun getRenderApi ()Lorg/jetbrains/skiko/GraphicsApi;
+	public fun getSemanticsOwners ()Ljava/util/Collection;
 	public final fun getUndecoratedResizerThickness-D9Ej5fM ()F
 	public final fun getWindowHandle ()J
 	public final fun isMinimized ()Z

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -185,6 +185,7 @@ public final class androidx/compose/ui/ImageComposeScene {
 	public final fun close ()V
 	public final fun getConstraints-msEJaDk ()J
 	public final fun getContentSize-YbymL2g ()J
+	public final fun getSemanticsOwners ()Ljava/util/Collection;
 	public final fun hasInvalidations ()Z
 	public final fun render (J)Lorg/jetbrains/skia/Image;
 	public static synthetic fun render$default (Landroidx/compose/ui/ImageComposeScene;JILjava/lang/Object;)Lorg/jetbrains/skia/Image;

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -2557,6 +2557,8 @@ final class androidx.compose.ui/ImageComposeScene { // androidx.compose.ui/Image
 
     final val contentSize // androidx.compose.ui/ImageComposeScene.contentSize|{}contentSize[0]
         final fun <get-contentSize>(): androidx.compose.ui.unit/IntSize // androidx.compose.ui/ImageComposeScene.contentSize.<get-contentSize>|<get-contentSize>(){}[0]
+    final val semanticsOwners // androidx.compose.ui/ImageComposeScene.semanticsOwners|{}semanticsOwners[0]
+        final fun <get-semanticsOwners>(): kotlin.collections/Collection<androidx.compose.ui.semantics/SemanticsOwner> // androidx.compose.ui/ImageComposeScene.semanticsOwners.<get-semanticsOwners>|<get-semanticsOwners>(){}[0]
 
     final var constraints // androidx.compose.ui/ImageComposeScene.constraints|{}constraints[0]
         final fun <get-constraints>(): androidx.compose.ui.unit/Constraints // androidx.compose.ui/ImageComposeScene.constraints.<get-constraints>|<get-constraints>(){}[0]

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
@@ -16,12 +16,13 @@
 
 package androidx.compose.ui
 
+import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.semantics.SemanticsOwner
 
 /**
  * The interface for classes that are an entry point for using Compose on the desktop.
  */
-@InternalComposeUiApi
+@ComposeToolingApi
 interface ComposeDesktopEntryPoint {
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.ui.semantics.SemanticsOwner
+
+/**
+ * The interface for classes that are an entry point for using Compose on the desktop.
+ */
+@InternalComposeUiApi
+interface ComposeDesktopEntryPoint {
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposeDesktopEntryPoint].
+     *
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
+     */
+    val semanticsOwners: Collection<SemanticsOwner>
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
@@ -53,6 +54,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 /**
  * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
  */
+@OptIn(ComposeToolingApi::class)
 class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
     private val composePanel: ComposeWindowPanel
 
@@ -222,7 +224,7 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
      * composable function) will cause the function to restart when the set of semantics owners
      * changes.
      */
-    @ExperimentalComposeUiApi
+    @ComposeToolingApi
     override val semanticsOwners: Collection<SemanticsOwner>
         get() = composePanel.semanticsOwners
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -17,11 +17,13 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Constraints
@@ -51,7 +53,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 /**
  * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
  */
-class ComposeDialog : JDialog {
+class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
     private val composePanel: ComposeWindowPanel
 
     private fun createComposePanel(
@@ -211,6 +213,18 @@ class ComposeDialog : JDialog {
         set(value) { composePanel.isClearFocusOnMouseDownEnabled = value }
 
     private val undecoratedWindowResizer = UndecoratedWindowResizer(this)
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposeDialog].
+     *
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
+     */
+    @ExperimentalComposeUiApi
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = composePanel.semanticsOwners
 
     override fun add(component: Component) = composePanel.add(component)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -69,7 +70,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private var savedState: SavedState? = null,
     private val renderSettings: RenderSettings = DefaultRenderSettings,
     private val coroutineContext: CoroutineContext = EmptyCoroutineContext
-) : JLayeredPane() {
+) : JLayeredPane(), ComposeDesktopEntryPoint {
     constructor() : this(
         savedState = null,
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
@@ -334,12 +335,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposePanel].
      *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
      * composable function) will cause the function to restart when the set of semantics owners
      * changes.
      */
     @ExperimentalComposeUiApi
-    val semanticsOwners: Collection<SemanticsOwner>
+    override val semanticsOwners: Collection<SemanticsOwner>
         get() = _composeContainer?.semanticsOwners ?: emptyList()
 
     // Needed to preserve binary compatibility

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ComposeUiFlags
@@ -65,6 +66,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * @param renderSettings Configuration class for rendering settings.
  * @param coroutineContext The coroutine context for Compose content rendering and effects.
  */
+@OptIn(ComposeToolingApi::class)
 class ComposePanel @ExperimentalComposeUiApi constructor(
     private val skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     private var savedState: SavedState? = null,
@@ -339,7 +341,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * composable function) will cause the function to restart when the set of semantics owners
      * changes.
      */
-    @ExperimentalComposeUiApi
+    @ComposeToolingApi
     override val semanticsOwners: Collection<SemanticsOwner>
         get() = _composeContainer?.semanticsOwners ?: emptyList()
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -60,7 +61,7 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     savedState: SavedState? = null,
     coroutineContext: CoroutineContext = EmptyCoroutineContext
-) : JFrame(graphicsConfiguration) {
+) : JFrame(graphicsConfiguration), ComposeDesktopEntryPoint {
     /**
      * System window for displaying Compose UI, inheriting [javax.swing.JFrame].
      *
@@ -87,11 +88,12 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposeWindow].
      *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when set of semantics owners changes.
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
      */
     @ExperimentalComposeUiApi
-    val semanticsOwners: Collection<SemanticsOwner>
+    override val semanticsOwners: Collection<SemanticsOwner>
         get() = composePanel.semanticsOwners
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
@@ -56,6 +57,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * @param savedState The saved state to restore the UI state from a previous instance.
  * @param coroutineContext The coroutine context for Compose content rendering and effects.
  */
+@OptIn(ComposeToolingApi::class)
 class ComposeWindow @ExperimentalComposeUiApi constructor(
     graphicsConfiguration: GraphicsConfiguration? = null,
     skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
@@ -92,7 +94,7 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
      * composable function) will cause the function to restart when the set of semantics owners
      * changes.
      */
-    @ExperimentalComposeUiApi
+    @ComposeToolingApi
     override val semanticsOwners: Collection<SemanticsOwner>
         get() = composePanel.semanticsOwners
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -160,6 +161,7 @@ private class ImageComposeSceneSemanticOwnersTestContext : SemanticsOwnersTestCo
 private class ComposeWindowSemanticOwnersTestContext : SemanticsOwnersTestContext {
     private lateinit var testScope: WindowTestScope
 
+    @OptIn(ComposeToolingApi::class)
     override val semanticsOwners: Collection<SemanticsOwner>
         get() = testScope.window.semanticsOwners
 
@@ -184,6 +186,7 @@ private class ComposePanelSemanticOwnersTestContext(
     private lateinit var testScope: WindowTestScope
     private lateinit var composePanel: ComposePanel
 
+    @OptIn(ComposeToolingApi::class)
     override val semanticsOwners: Collection<SemanticsOwner>
         get() = composePanel.semanticsOwners
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -206,10 +206,10 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ImageComposeScene].
      *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when set of semantics owners changes.
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
      */
-    @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>
         get() = _platformContext.semanticsOwners
 


### PR DESCRIPTION
Introduce `ComposeDesktopEntryPoint` interface to make it easier for the compose-hot-reload MCP server to work with them.

Fixes https://youtrack.jetbrains.com/issue/CMP-8854/Remove-experimental-annotation-from-semanticsOwners-providers

## Testing
N/A

## Release Notes
N/A