### PR TITLE
Change the native keyCode for `Key.NumPadDot` to `KeyEvent.VK_DECIMAL`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
@@ -429,7 +429,7 @@ actual value class Key(val keyCode: Long) {
         actual val NumPadAdd = Key(KeyEvent.VK_ADD, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '.' key (for decimals or digit grouping). */
-        actual val NumPadDot = Key(KeyEvent.VK_PERIOD, KEY_LOCATION_NUMPAD)
+        actual val NumPadDot = Key(KeyEvent.VK_DECIMAL, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad ',' key (for decimals or digit grouping). */
         actual val NumPadComma = Key(KeyEvent.VK_COMMA, KEY_LOCATION_NUMPAD)


### PR DESCRIPTION
Change the native keyCode for `Key.NumPadDot` to `KeyEvent.VK_DECIMAL`
Verified that the keyCode sent by AWT when pressing this key is `KeyEvent.VK_DECIMAL`.

Fixes https://youtrack.jetbrains.com/issue/CMP-4211

## Testing
Tested manually with
```
fun main() = singleWindowApplication(
    onPreviewKeyEvent = {
        println(it.key)
        println(it.nativeKeyEvent)
        false
    },
{ }
```

## Release Notes
### Fixes - Desktop
- Fixed the native keyCode for `Key.NumPadDot` to the correct `KeyEvent.VK_DECIMAL`
