### PR TITLE
Implement `GraphicsLayer.setOutsets` for non-Android platforms

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.mpp.demo.bug.BugReproducers
 import androidx.compose.mpp.demo.components.Components
 import androidx.compose.mpp.demo.graphics.Blending
 import androidx.compose.mpp.demo.graphics.BrushAndShadows
+import androidx.compose.mpp.demo.graphics.GraphicsLayerOutsets
 import androidx.compose.mpp.demo.graphics.GraphicsLayerSettings
 import androidx.compose.mpp.demo.textfield.android.AndroidTextFieldSamples
 import androidx.compose.mpp.demo.textfield.android.TextBrushDemo
@@ -30,6 +31,7 @@ private val GraphicsComponents = Screen.Selection(
     Screen.Example("Blending") { Blending() },
     Screen.Example("Brush & Shadows") { BrushAndShadows() },
     Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
+    Screen.Example("GraphicsLayer Outsets") { GraphicsLayerOutsets() },
 )
 
 val MainScreen = Screen.Selection(

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/graphics/GraphicsLayerOutsets.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/graphics/GraphicsLayerOutsets.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.graphics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.LayerOutsets
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// Adapted from CompositingStrategyOffscreenLayerOutsets sample (8b9299a94f)
+//
+// Scenario: an outer Box has alpha < 1 (promoted to offscreen buffer, implicit clip to bounds).
+// Its child draws a Rect that extends beyond the outer box via drawBehind.
+// Without outsets the overflow is clipped. With outsets it is visible.
+
+private val LayerBoxSize = 100.dp
+private val OutsetsAmount = 80.dp  // how far the child rect overflows
+
+@Composable
+fun GraphicsLayerOutsets() {
+    var alpha by remember { mutableFloatStateOf(0.5f) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(
+            "alpha < 1 promotes the layer to an offscreen buffer, implicitly clipping it to its " +
+            "bounds. The child draws a red rect (via drawBehind) that starts at the layer's " +
+            "bottom-right corner and extends ${OutsetsAmount} beyond.\n\n" +
+            "LayerOutsets expand the offscreen buffer so that overflow remains visible.",
+            fontSize = 13.sp,
+            color = Color.DarkGray
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        SliderSetting("Alpha", alpha, 0f..1f) { alpha = it }
+
+        Spacer(Modifier.height(24.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Without outsets", fontSize = 12.sp, color = Color.DarkGray)
+                Spacer(Modifier.height(8.dp))
+                OutsetsDemo(alpha = alpha, outsets = LayerOutsets.Zero)
+            }
+
+            Spacer(Modifier.width(16.dp))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("With outsets (${OutsetsAmount})", fontSize = 12.sp, color = Color.DarkGray)
+                Spacer(Modifier.height(8.dp))
+                OutsetsDemo(alpha = alpha, outsets = LayerOutsets(OutsetsAmount))
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            "• Gray area = scene background\n" +
+            "• Blue border = layer layout bounds (${LayerBoxSize} × ${LayerBoxSize})\n" +
+            "• Red rect = child content drawn ${OutsetsAmount} beyond the layer's corner\n" +
+            "• At alpha = 1: both panels look identical (no offscreen buffer, no clipping)\n" +
+            "• At alpha < 1: left panel clips the red rect; right panel keeps it visible",
+            fontSize = 12.sp,
+            color = Color.DarkGray
+        )
+    }
+}
+
+@Composable
+private fun OutsetsDemo(alpha: Float, outsets: LayerOutsets) {
+    val sceneSize = LayerBoxSize + OutsetsAmount + 8.dp
+    // Gray background large enough to show the overflow region
+    Box(
+        modifier = Modifier
+            .size(sceneSize)
+            .background(Color(0xFFBDBDBD))
+    ) {
+        // The layer: alpha < 1 here promotes to an offscreen buffer, clipping to LayerBoxSize
+        Box(
+            modifier = Modifier
+                .size(LayerBoxSize)
+                .graphicsLayer(alpha = alpha, outsets = outsets)
+                .background(Color.White)
+        ) {
+            // Child fills the layer and draws a red rect that extends beyond it via drawBehind
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .drawBehind {
+                        // Rect starts at the bottom-right corner of this child and overflows out
+                        drawRect(
+                            topLeft = Offset(size.width, size.height),
+                            brush = SolidColor(Color.Red),
+                            size = Size(OutsetsAmount.toPx(), OutsetsAmount.toPx())
+                        )
+                    }
+            )
+        }
+
+        // Blue border overlay always visible, marks the original layer bounds
+        Box(
+            modifier = Modifier
+                .size(LayerBoxSize)
+                .border(2.dp, Color.Blue)
+        )
+    }
+}

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.drawscope.draw
 import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.graphics.skiaImageFilter
 import androidx.compose.ui.graphics.materializeSkiaPath
+import androidx.compose.ui.graphics.requirePrecondition
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toSkia
 import androidx.compose.ui.unit.Density
@@ -66,6 +67,12 @@ actual class GraphicsLayer internal constructor(
 
     private var internalOutline: Outline? = null
     private var outlinePath: Path? = null
+
+    private var outsetLeft: Int = 0
+    private var outsetTop: Int = 0
+    private var outsetRight: Int = 0
+    private var outsetBottom: Int = 0
+    private var cachedLayerPaint: SkPaint? = null
 
     private var parentLayerUsages = 0
     private val childDependenciesTracker = ChildLayerDependenciesTracker()
@@ -356,7 +363,21 @@ actual class GraphicsLayer internal constructor(
         if (isReleased) return
         configureOutlineAndClip()
         parentLayer?.addSubLayer(this)
-        renderNode?.drawInto(canvas.skiaCanvas)
+        val paint = cachedLayerPaint
+        if (hasOutsets() && paint != null) {
+            val skCanvas = canvas.skiaCanvas
+            skCanvas.saveLayer(
+                left = topLeft.x - outsetLeft.toFloat(),
+                top = topLeft.y - outsetTop.toFloat(),
+                right = topLeft.x + size.width + outsetRight.toFloat(),
+                bottom = topLeft.y + size.height + outsetBottom.toFloat(),
+                paint = paint,
+            )
+            renderNode?.drawInto(skCanvas)
+            skCanvas.restore()
+        } else {
+            renderNode?.drawInto(canvas.skiaCanvas)
+        }
     }
 
     private fun onAddedToParentLayer() {
@@ -444,7 +465,7 @@ actual class GraphicsLayer internal constructor(
         ImageBitmap(size.width, size.height).apply { draw(Canvas(this), null) }
 
     private fun updateLayerProperties() {
-        renderNode?.layerPaint = if (requiresLayer()) {
+        val paint = if (requiresLayer()) {
             SkPaint().also {
                 it.setAlphaf(alpha)
                 it.imageFilter = renderEffect?.skiaImageFilter
@@ -454,7 +475,13 @@ actual class GraphicsLayer internal constructor(
         } else {
             null
         }
+        cachedLayerPaint = paint
+        // When outsets are present, we manage the offscreen layer manually in draw() using an
+        // expanded saveLayer bounds, so the renderNode must not create its own inner layer.
+        renderNode?.layerPaint = if (hasOutsets()) null else paint
     }
+
+    private fun hasOutsets() = outsetLeft > 0 || outsetTop > 0 || outsetRight > 0 || outsetBottom > 0
 
     private fun requiresLayer(): Boolean {
         val alphaNeedsLayer = alpha < 1f && compositingStrategy != CompositingStrategy.ModulateAlpha
@@ -472,6 +499,15 @@ actual class GraphicsLayer internal constructor(
         @IntRange(from = 0) right: Int,
         @IntRange(from = 0) bottom: Int
     ) {
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-10054/Implement-GraphicsLayer.setOutsets-method
+        requirePrecondition(left >= 0 && top >= 0 && right >= 0 && bottom >= 0) {
+            "Outsets cannot be negative! Left: $left, Top: $top, Right: $right, Bottom: $bottom"
+        }
+        if (left != outsetLeft || top != outsetTop || right != outsetRight || bottom != outsetBottom) {
+            outsetLeft = left
+            outsetTop = top
+            outsetRight = right
+            outsetBottom = bottom
+            updateLayerProperties()
+        }
     }
 }

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
@@ -989,6 +989,70 @@ class SkiaGraphicsLayerTest {
     }
 
     @Test
+    fun testSetOutsets_clipsContentWithoutOutsets() {
+        // Without outsets, alpha-triggered offscreen buffer clips overflow content
+        val halfWidth = TEST_WIDTH / 2
+        val halfHeight = TEST_HEIGHT / 2
+        graphicsLayerTest(
+            block = { graphicsContext ->
+                val layer =
+                    graphicsContext.createGraphicsLayer().apply {
+                        record(size = IntSize(halfWidth, halfHeight)) {
+                            // Draw red filling the full TEST_SIZE, overflowing the layer bounds
+                            drawRect(Color.Red, size = Size(TEST_WIDTH.toFloat(), TEST_HEIGHT.toFloat()))
+                        }
+                        alpha = 0.5f
+                    }
+                drawRect(Color.White)
+                drawLayer(layer)
+            },
+            verify = { pixelMap ->
+                with(pixelMap) {
+                    // Content within layer bounds is composited
+                    assertPixelColor(
+                        Color.Red.copy(alpha = 0.5f).compositeOver(Color.White),
+                        halfWidth / 2,
+                        halfHeight / 2
+                    )
+                    // Overflow content is clipped — white background shows through
+                    assertPixelColor(Color.White, halfWidth + 10, halfHeight + 10)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun testSetOutsets_expandsOffscreenBufferToShowOverflow() {
+        // With outsets matching the overflow, alpha-triggered offscreen buffer captures overflow
+        val halfWidth = TEST_WIDTH / 2
+        val halfHeight = TEST_HEIGHT / 2
+        graphicsLayerTest(
+            block = { graphicsContext ->
+                val layer =
+                    graphicsContext.createGraphicsLayer().apply {
+                        record(size = IntSize(halfWidth, halfHeight)) {
+                            // Draw red filling the full TEST_SIZE, overflowing the layer bounds
+                            drawRect(Color.Red, size = Size(TEST_WIDTH.toFloat(), TEST_HEIGHT.toFloat()))
+                        }
+                        alpha = 0.5f
+                        setOutsets(left = 0, top = 0, right = halfWidth, bottom = halfHeight)
+                    }
+                drawRect(Color.White)
+                drawLayer(layer)
+            },
+            verify = { pixelMap ->
+                with(pixelMap) {
+                    val compositedRed = Color.Red.copy(alpha = 0.5f).compositeOver(Color.White)
+                    // Content within original layer bounds is composited
+                    assertPixelColor(compositedRed, halfWidth / 2, halfHeight / 2)
+                    // Overflow content is now captured by the expanded offscreen buffer
+                    assertPixelColor(compositedRed, halfWidth + 10, halfHeight + 10)
+                }
+            }
+        )
+    }
+
+    @Test
     fun testEndRecordingAlwaysCalled() {
         graphicsLayerTest(
             block = { graphicsContext ->

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/GraphicsLayerOwnerLayer.skiko.kt
@@ -104,6 +104,17 @@ internal class GraphicsLayerOwnerLayer(
         val maybeChangedFields = scope.mutatedFields or mutatedFields
         this.layoutDirection = scope.layoutDirection
         this.density = scope.graphicsDensity
+        if (maybeChangedFields and Fields.Outsets != 0) {
+            with(density) {
+                graphicsLayer.setOutsets(
+                    left = scope.outsets.left.roundToPx(),
+                    top = scope.outsets.top.roundToPx(),
+                    right = scope.outsets.right.roundToPx(),
+                    bottom = scope.outsets.bottom.roundToPx(),
+                )
+                invalidate()
+            }
+        }
         if (maybeChangedFields and Fields.TransformOrigin != 0) {
             this.transformOrigin = scope.transformOrigin
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/LegacyRenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/LegacyRenderNodeLayer.skiko.kt
@@ -116,6 +116,10 @@ internal class LegacyRenderNodeLayer(
     private var ambientShadowColor: Color = DefaultShadowColor
     private var spotShadowColor: Color = DefaultShadowColor
     private var compositingStrategy: CompositingStrategy = CompositingStrategy.Auto
+    private var outsetLeft: Int = 0
+    private var outsetTop: Int = 0
+    private var outsetRight: Int = 0
+    private var outsetBottom: Int = 0
 
     override fun destroy() {
         picture?.close()
@@ -199,6 +203,14 @@ internal class LegacyRenderNodeLayer(
         this.spotShadowColor = scope.spotShadowColor
         this.compositingStrategy = scope.compositingStrategy
         this.outline = scope.outline
+        if (maybeChangedFields and Fields.Outsets != 0) {
+            with(density) {
+                outsetLeft = scope.outsets.left.roundToPx()
+                outsetTop = scope.outsets.top.roundToPx()
+                outsetRight = scope.outsets.right.roundToPx()
+                outsetBottom = scope.outsets.bottom.roundToPx()
+            }
+        }
         if (maybeChangedFields and Fields.MatrixAffectingFields != 0) {
             updateMatrix()
         }
@@ -246,8 +258,17 @@ internal class LegacyRenderNodeLayer(
         layerManager.voteFrameRate(frameRate)
 
         if (picture == null) {
-            val measureDrawBounds = !clip || shadowElevation > 0
-            val bounds = size.toRect()
+            val measureDrawBounds = !clip || shadowElevation > 0 || hasOutsets()
+            val bounds = if (hasOutsets()) {
+                Rect(
+                    -outsetLeft.toFloat(),
+                    -outsetTop.toFloat(),
+                    size.width + outsetRight.toFloat(),
+                    size.height + outsetBottom.toFloat()
+                )
+            } else {
+                size.toRect()
+            }
             val pictureCanvas = pictureRecorder.beginRecording(
                 left = if (measureDrawBounds) PICTURE_MIN_VALUE else bounds.left,
                 top = if (measureDrawBounds) PICTURE_MIN_VALUE else bounds.top,
@@ -355,6 +376,9 @@ internal class LegacyRenderNodeLayer(
     }
 
     override fun updateDisplayList() = Unit
+
+    private fun hasOutsets() =
+        outsetLeft > 0 || outsetTop > 0 || outsetRight > 0 || outsetBottom > 0
 
     @OptIn(InternalComposeUiApi::class)
     fun drawShadow(canvas: Canvas) = with(density) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
@@ -1426,6 +1426,149 @@ class CommonGraphicsLayerTest {
 
         assertPixels()
     }
+
+    @Test
+    fun testLayerOutsetsWithImplicitClipToBounds() = runComposeUiTest {
+        val outerBoxSizePx = 100
+        val innerBoxSizePx = 50
+        val outsetsPx = 20
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val outerBoxSizeDp = outerBoxSizePx.dp
+                val outsetsDp = outsetsPx.dp
+                Box(Modifier.size(outerBoxSizeDp).background(Color.White)) {
+                    Box(
+                        Modifier.graphicsLayer {
+                            alpha = 0.5f
+                            outsets = LayerOutsets(outsetsDp)
+                        }
+                    ) {
+                        val innerBoxSizeDp = innerBoxSizePx.dp
+                        Box(
+                            Modifier.size(innerBoxSizeDp).drawBehind {
+                                drawRect(
+                                    Color.Red,
+                                    size = Size(outerBoxSizePx.toFloat(), outerBoxSizePx.toFloat()),
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        val compositedColor = Color.Red.copy(alpha = 0.5f).compositeOver(Color.White)
+        onRoot().captureToImage().apply {
+            with(toPixelMap()) {
+                assertEqualsWithTolerance(compositedColor, this[0, 0])
+                assertEqualsWithTolerance(
+                    compositedColor,
+                    this[innerBoxSizePx + outsetsPx - 3, innerBoxSizePx + outsetsPx - 3],
+                )
+                assertEqualsWithTolerance(compositedColor, this[0, innerBoxSizePx + outsetsPx - 3])
+                assertEqualsWithTolerance(compositedColor, this[innerBoxSizePx + outsetsPx - 3, 0])
+                assertEqualsWithTolerance(Color.White, this[outerBoxSizePx - 5, outerBoxSizePx - 5])
+            }
+        }
+    }
+
+    @Test
+    fun testLayerOutsetsUpdatesCorrectly() = runComposeUiTest {
+        val outerBoxSizePx = 100
+        val innerBoxSizePx = 50
+        var outsetsPx by mutableStateOf(20)
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val outerBoxSizeDp = outerBoxSizePx.dp
+                val outsetsDp = outsetsPx.dp
+                Box(Modifier.size(outerBoxSizeDp).background(Color.White)) {
+                    Box(
+                        Modifier.graphicsLayer {
+                            alpha = 0.5f
+                            outsets = LayerOutsets(outsetsDp)
+                        }
+                    ) {
+                        val innerBoxSizeDp = innerBoxSizePx.dp
+                        Box(
+                            Modifier.size(innerBoxSizeDp).drawBehind {
+                                drawRect(
+                                    Color.Red,
+                                    size = Size(outerBoxSizePx.toFloat(), outerBoxSizePx.toFloat()),
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        val compositedColor = Color.Red.copy(alpha = 0.5f).compositeOver(Color.White)
+        onRoot().captureToImage().apply {
+            with(toPixelMap()) {
+                assertEqualsWithTolerance(compositedColor, this[0, 0])
+                assertEqualsWithTolerance(
+                    compositedColor,
+                    this[innerBoxSizePx + outsetsPx - 3, innerBoxSizePx + outsetsPx - 3],
+                )
+                assertEqualsWithTolerance(compositedColor, this[0, innerBoxSizePx + outsetsPx - 3])
+                assertEqualsWithTolerance(compositedColor, this[innerBoxSizePx + outsetsPx - 3, 0])
+                assertEqualsWithTolerance(Color.White, this[outerBoxSizePx - 5, outerBoxSizePx - 5])
+            }
+        }
+
+        // Reduce outsets to zero — the overflow must now be clipped.
+        runOnIdle { outsetsPx = 0 }
+        onRoot().captureToImage().apply {
+            with(toPixelMap()) {
+                assertEqualsWithTolerance(compositedColor, this[0, 0])
+                assertEqualsWithTolerance(Color.White, this[innerBoxSizePx, innerBoxSizePx])
+                assertEqualsWithTolerance(compositedColor, this[0, innerBoxSizePx - 3])
+                assertEqualsWithTolerance(Color.White, this[innerBoxSizePx, 0])
+                assertEqualsWithTolerance(Color.White, this[outerBoxSizePx - 5, outerBoxSizePx - 5])
+            }
+        }
+    }
+
+    @Test
+    fun testLayerOutsetsWithPivot() = runComposeUiTest {
+        val outerBoxSizePx = 100
+        val innerBoxSizePx = 50
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val outerBoxSizeDp = outerBoxSizePx.dp
+                Box(Modifier.size(outerBoxSizeDp).background(Color.White)) {
+                    Box(
+                        Modifier.graphicsLayer {
+                            rotationZ = 90f
+                            outsets = LayerOutsets(10.dp, 100.dp, 5.dp, 50.dp)
+                            // Pivot must be calculated on the original layer size (without outsets)
+                            transformOrigin = TransformOrigin(1.0f, 1.0f)
+                        }
+                    ) {
+                        val innerBoxSizeDp = innerBoxSizePx.dp
+                        Box(Modifier.size(innerBoxSizeDp).background(Color.Red))
+                    }
+                }
+            }
+        }
+
+        val pixelMap = onRoot().captureToImage().toPixelMap()
+        for (i in 0 until outerBoxSizePx) {
+            for (j in 0 until outerBoxSizePx) {
+                if (innerBoxSizePx in (j + 1)..i) {
+                    assertEqualsWithTolerance(Color.Red, pixelMap[i, j])
+                } else {
+                    assertEqualsWithTolerance(Color.White, pixelMap[i, j])
+                }
+            }
+        }
+    }
+}
+
+private fun assertEqualsWithTolerance(expected: Color, actual: Color, tolerance: Float = 0.03f) {
+    assertColorsEqual(expected, actual, alphaTolerance = tolerance) {
+        "Expected $expected but was $actual"
+    }
 }
 
 fun Bitmap.assertColor(expectedColor: Color, x: Int, y: Int) {


### PR DESCRIPTION
[CMP-10054](https://youtrack.jetbrains.com/issue/CMP-10054) Implement GraphicsLayer.setOutsets method

<img width="1136" height="962" alt="Screenshot 2026-06-22 at 14 45 47" src="https://github.com/user-attachments/assets/2d52c2f3-68a4-45a0-9e66-df03bc110216" />

## Release Notes
### Features - Multiple Platforms
- Support `LayerOutsets` to `GraphicsLayer` & `Modifier.graphicsLayer` which can be used to increase the visual bounds of the layer beyond its measured size. This can be used to avoid the implicit `clipToBounds` behavior when the layer is promoted to an offscreen buffer.