### PR TITLE
Support Locale and Verbatim VoiceOver annotation

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -33,7 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *__nullable)accessibilityLabel;
 
+- (NSAttributedString *__nullable)accessibilityAttributedLabel;
+
 - (NSString *__nullable)accessibilityValue;
+
+- (NSAttributedString *__nullable)accessibilityAttributedValue;
 
 - (CGRect)accessibilityFrame;
 

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -49,6 +49,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [super accessibilityLabel];
 }
 
+- (NSAttributedString *__nullable)accessibilityAttributedLabel {
+    return [super accessibilityAttributedLabel];
+}
+
+- (NSAttributedString *__nullable)accessibilityAttributedValue {
+    return [super accessibilityAttributedLabel];
+}
+
 - (NSString *__nullable)accessibilityValue {
     return [super accessibilityValue];
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -24,17 +24,17 @@ import androidx.compose.ui.node.HitTestResult
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.requireLayoutNode
 import androidx.compose.ui.platform.accessibility.AccessibilityScrollEventResult
+import androidx.compose.ui.platform.accessibility.accessibilityAttributedValue
 import androidx.compose.ui.platform.accessibility.accessibilityCustomActions
 import androidx.compose.ui.platform.accessibility.accessibilityTraits
-import androidx.compose.ui.platform.accessibility.accessibilityValue
 import androidx.compose.ui.platform.accessibility.allScrollableParentNodeIds
+import androidx.compose.ui.platform.accessibility.attributedContentDescription
 import androidx.compose.ui.platform.accessibility.canBeAccessibilityElement
 import androidx.compose.ui.platform.accessibility.canScroll
-import androidx.compose.ui.platform.accessibility.contentDescription
 import androidx.compose.ui.platform.accessibility.isRTL
 import androidx.compose.ui.platform.accessibility.isScreenReaderFocusable
 import androidx.compose.ui.platform.accessibility.linkTag
-import androidx.compose.ui.platform.accessibility.linkText
+import androidx.compose.ui.platform.accessibility.linkAttributedString
 import androidx.compose.ui.platform.accessibility.scrollIfPossible
 import androidx.compose.ui.platform.accessibility.scrollToCenterRectIfNeeded
 import androidx.compose.ui.platform.accessibility.sortFlattenChildren
@@ -65,6 +65,9 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.native.ref.WeakReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
@@ -102,9 +105,14 @@ import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
 import platform.CoreGraphics.CGSizeZero
+import platform.Foundation.NSAttributedString
+import platform.Foundation.NSMutableAttributedString
+import platform.Foundation.create
 import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
+import platform.Foundation.appendAttributedString
+import platform.Foundation.length
 import platform.QuartzCore.CACurrentMediaTime
 import platform.UIKit.NSStringFromCGRect
 import platform.UIKit.UIAccessibilityAnnouncementNotification
@@ -164,10 +172,10 @@ private sealed interface AccessibilityNode {
     val isAccessibilityElement: Boolean
     val semanticsNode: SemanticsNode
 
-    val contentDescription: String? get() = null
+    val attributedContentDescription: List<NSAttributedString> get() = emptyList()
     val shouldMergeDescription: Boolean get() = false
     val accessibilityHint: String? get() = null
-    val accessibilityValue: String? get() = null
+    val accessibilityAttributedValue: NSAttributedString? get() = null
     val accessibilityTraits: UIAccessibilityTraits get() = UIAccessibilityTraitNone
     val accessibilityContainerType: UIAccessibilityContainerType
         get() = UIAccessibilityContainerTypeNone
@@ -230,8 +238,8 @@ private sealed interface AccessibilityNode {
                 it.isAccessibilityFocusable = ::isBeyondBoundsOrFocusable
             }
 
-        override val contentDescription: String?
-            get() = semanticsNode.contentDescription
+        override val attributedContentDescription: List<NSAttributedString>
+            get() = semanticsNode.attributedContentDescription
 
         override val shouldMergeDescription: Boolean
             get() = semanticsNode.canBeAccessibilityElement()
@@ -249,8 +257,8 @@ private sealed interface AccessibilityNode {
         override val accessibilityTraits: UIAccessibilityTraits
             get() = cachedConfig.accessibilityTraits()
 
-        override val accessibilityValue: String?
-            get() = cachedConfig.accessibilityValue()
+        override val accessibilityAttributedValue: NSAttributedString?
+            get() = cachedConfig.accessibilityAttributedValue()
 
         override fun accessibilityActivate(): Boolean {
             if (!semanticsNode.isValid) {
@@ -303,7 +311,7 @@ private sealed interface AccessibilityNode {
             }
 
             val frame = semanticsNode.boundsInWindow
-            val approximateScrollAnimationDuration = 350L
+            val approximateScrollAnimationDuration = 350.milliseconds
 
             val result = semanticsNode.scrollIfPossible(direction)
             return if (result != null) {
@@ -428,12 +436,12 @@ private sealed interface AccessibilityNode {
 private class CachedAccessibilityPropertyKey<V>
 
 private object CachedAccessibilityPropertyKeys {
-    val accessibilityLabel = CachedAccessibilityPropertyKey<String?>()
+    val accessibilityAttributedLabel = CachedAccessibilityPropertyKey<NSAttributedString?>()
     val accessibilityIdentifier = CachedAccessibilityPropertyKey<String?>()
     val accessibilityHint = CachedAccessibilityPropertyKey<String?>()
     val accessibilityCustomActions = CachedAccessibilityPropertyKey<List<UIAccessibilityCustomAction>>()
     val accessibilityTraits = CachedAccessibilityPropertyKey<UIAccessibilityTraits>()
-    val accessibilityValue = CachedAccessibilityPropertyKey<String?>()
+    val accessibilityAttributedValue = CachedAccessibilityPropertyKey<NSAttributedString?>()
     val accessibilityElements = CachedAccessibilityPropertyKey<List<Any>>()
 }
 
@@ -633,9 +641,18 @@ private class AccessibilityElement(
         return value as T
     }
 
-    override fun accessibilityLabel(): String? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityLabel) {
-            makeAccessibilityLabel()
+    override fun accessibilityLabel(): String? = accessibilityAttributedLabel()?.string
+
+    override fun accessibilityAttributedLabel(): NSAttributedString? =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityAttributedLabel) {
+            makeAccessibilityAttributedLabel()
+        }
+
+    override fun accessibilityValue(): String? = accessibilityAttributedValue()?.string
+
+    override fun accessibilityAttributedValue(): NSAttributedString? =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityAttributedValue) {
+            node.accessibilityAttributedValue
         }
 
     override fun accessibilityElementDidBecomeFocused() {
@@ -706,11 +723,6 @@ private class AccessibilityElement(
     override fun accessibilityTraits(): UIAccessibilityTraits =
         getOrElse(CachedAccessibilityPropertyKeys.accessibilityTraits) {
             node.accessibilityTraits
-        }
-
-    override fun accessibilityValue(): String? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityValue) {
-            node.accessibilityValue
         }
 
     override fun accessibilityPerformEscape(): Boolean {
@@ -790,7 +802,7 @@ private class AccessibilityElement(
         accessibilityContainer as? UIFocusEnvironmentProtocol
 
     override fun preferredFocusEnvironments(): List<*> =
-        accessibilityElements?.mapNotNull { it as? UIFocusEnvironmentProtocol } ?: emptyList<Any>()
+        accessibilityElements?.filterIsInstance<UIFocusEnvironmentProtocol>() ?: emptyList<Any>()
 
     private var updateFocusScheduled = false
     override fun setNeedsFocusUpdate() {
@@ -850,7 +862,7 @@ private class AccessibilityElement(
             val timerJob = launch {
                 while (true) {
                     frameClock.sendFrame(CACurrentMediaTime().toNanoSeconds())
-                    delay(1)
+                    delay(1.milliseconds)
                 }
             }
             node.scrollBy(delta)
@@ -1274,7 +1286,7 @@ internal class AccessibilityMediator(
                     // Estimated delay between the iOS Accessibility Engine sync intervals.
                     // There is no reason to post change notifications more frequently because the
                     // iOS Accessibility Engine will ignore them.
-                    delay(100)
+                    delay(100.milliseconds)
                 }
             }
         }
@@ -1299,7 +1311,7 @@ internal class AccessibilityMediator(
             // Allow some time for the iOS Accessibility Engine to read the updated accessibility
             // elements tree. If no new reads occur during this time, it is assumed that iOS
             // Accessibility has been disabled and resources can be cleaned up.
-            delay(2000)
+            delay(2.seconds)
 
             cleanUp()
         }
@@ -1334,7 +1346,7 @@ internal class AccessibilityMediator(
 
     fun notifyScrollCompleted(
         scrollResult: AccessibilityScrollEventResult,
-        delay: Long,
+        delay: Duration,
         focusedNode: SemanticsNode,
         focusedRectInWindow: Rect
     ) {
@@ -1408,7 +1420,7 @@ internal class AccessibilityMediator(
         focusedScrollableParentsIdsUpdateJob = coroutineScope.launch {
             // Throttle the recalculation of scrollable parent node IDs to avoid unnecessary
             // reloading of the accessibility tree when the focusMode changes quickly.
-            delay(10)
+            delay(10.milliseconds)
             val scrollableElementsIds = mutableSetOf<Int>()
             val isInHierarchy = iterateAccessibilityElementHierarchy(focusedElement) {
                 if (it.node.semanticsNode.canScroll) {
@@ -2025,16 +2037,22 @@ private class AccessibilityFocusedElementObserver(
     }
 }
 
-private fun AccessibilityElement.makeAccessibilityLabel(): String? {
+private fun AccessibilityElement.makeAccessibilityAttributedLabel(): NSAttributedString? {
     val contentDescription = if (node.shouldMergeDescription) {
         val collector = NodeDescriptionCollector()
         collectContentDescription(collector)
-        collector.getText().takeIf { it.isNotBlank() }
+        collector.getAttributedString()
     } else {
         null
     }
 
-    return contentDescription ?: node.contentDescription ?: node.semanticsNode.linkText()
+    if (contentDescription != null) {
+        return contentDescription
+    }
+
+    return contentDescription
+        ?: NodeDescriptionCollector.collectInPlace(node.attributedContentDescription)
+        ?: node.semanticsNode.linkAttributedString()
 }
 
 /**
@@ -2045,29 +2063,55 @@ private fun AccessibilityElement.makeAccessibilityLabel(): String? {
 private class NodeDescriptionCollector {
     companion object {
         private const val MAX_TEXT_COLLECT_NODES = 5
+        @OptIn(BetaInteropApi::class)
+        private val separator = NSAttributedString.create(string = ", ")
+
+        fun append(nodes: List<NSAttributedString>, intoString: NSMutableAttributedString) {
+            nodes.forEach {
+                if (it.length > 0UL) {
+                    if (intoString.length > 0UL) {
+                        intoString.appendAttributedString(separator)
+                    }
+                    intoString.appendAttributedString(it)
+                }
+            }
+        }
+
+        fun collectInPlace(nodes: List<NSAttributedString>): NSMutableAttributedString? {
+            if (nodes.isEmpty()) {
+                return null
+            }
+            val string = NSMutableAttributedString()
+            append(nodes, string)
+            return string.takeIf { it.length > 0UL }
+        }
     }
-    private val text = StringBuilder()
+    private val string = NSMutableAttributedString()
+
     private var numNodes = 0
+    private var collected = false
 
     fun collect(node: AccessibilityElement): Boolean {
+        assert(!collected) { "NodeDescriptionCollector must not be mutated after collecting" }
         if (numNodes >= MAX_TEXT_COLLECT_NODES) {
             return false
         }
-        node.node.contentDescription
-            ?.takeIf { it.isNotBlank() }
-            ?.let {
+        node.node.attributedContentDescription.let {
+            if (it.isNotEmpty()) {
                 numNodes++
-                if (text.isNotEmpty()) {
-                    text.append(", ")
-                }
-                text.append(it)
+                append(it, string)
             }
+        }
 
         return true
     }
 
-    fun getText(): String {
-        return text.toString()
+    fun getAttributedString(): NSAttributedString? {
+        collected = true
+        if (numNodes == 0) {
+            return null
+        }
+        return string
     }
 }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.ios.kt
@@ -22,11 +22,25 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.VerbatimTtsAnnotation
+import androidx.compose.ui.util.fastForEach
 import kotlin.math.roundToInt
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CValue
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
+import platform.Foundation.NSAttributedString
+import platform.Foundation.NSMakeRange
+import platform.Foundation.NSMutableAttributedString
+import platform.Foundation.NSNumber
+import platform.Foundation.NSRange
+import platform.Foundation.addAttribute
+import platform.Foundation.create
 import platform.UIKit.UIAccessibilityCustomAction
+import platform.UIKit.UIAccessibilitySpeechAttributeLanguage
+import platform.UIKit.UIAccessibilitySpeechAttributeSpellOut
 import platform.UIKit.UIAccessibilityTraitAdjustable
 import platform.UIKit.UIAccessibilityTraitButton
 import platform.UIKit.UIAccessibilityTraitHeader
@@ -128,32 +142,68 @@ internal fun SemanticsConfiguration.accessibilityTraits(): UIAccessibilityTraits
     return result
 }
 
-internal fun SemanticsConfiguration.accessibilityValue(): String? {
+internal fun SemanticsConfiguration.accessibilityAttributedValue(): NSAttributedString? {
     getOrNull(SemanticsProperties.StateDescription)?.takeIf { it.isNotBlank() }?.let {
-        return it
+        return it.toAccessibilityNSAttributedString()
     }
 
     if (contains(SemanticsProperties.EditableText)) {
         getOrNull(SemanticsProperties.EditableText)
             ?.takeIf { it.isNotBlank() }
-            ?.let { return it.text }
+            ?.let { return it.toAccessibilityNSAttributedString() }
 
         getOrNull(SemanticsProperties.Text)
             ?.joinToString("\n")
             ?.takeIf { it.isNotBlank() }
-            ?.let { return it }
+            ?.let { return it.toAccessibilityNSAttributedString() }
     }
 
     return getOrNull(SemanticsProperties.ProgressBarRangeInfo)?.let {
         return if (it.range.endInclusive > it.range.start) {
             val fraction = (it.current - it.range.start) /
                 (it.range.endInclusive - it.range.start)
-            "${(fraction * 100f).roundToInt()}%"
+            "${(fraction * 100f).roundToInt()}%".toAccessibilityNSAttributedString()
         } else {
             null
         }
     }
 }
+
+@OptIn(BetaInteropApi::class)
+internal fun AnnotatedString.toAccessibilityNSAttributedString(): NSAttributedString {
+    val result = NSMutableAttributedString.create(string = text)
+
+    spanStyles.fastForEach { range ->
+        if (range.end > range.start) {
+            range.item.localeList?.forEach { locale ->
+                result.addAttribute(
+                    UIAccessibilitySpeechAttributeLanguage,
+                    locale.toLanguageTag(),
+                    nsRange(range.start, range.end)
+                )
+            }
+        }
+    }
+
+    getTtsAnnotations(0, text.length).fastForEach { range ->
+        if (range.end > range.start && range.item is VerbatimTtsAnnotation) {
+            result.addAttribute(
+                UIAccessibilitySpeechAttributeSpellOut,
+                NSNumber(bool = true),
+                nsRange(range.start, range.end)
+            )
+        }
+    }
+
+    return result
+}
+
+private fun nsRange(start: Int, end: Int): CValue<NSRange> =
+    NSMakeRange(loc = start.toULong(), len = (end - start).toULong())
+
+@OptIn(BetaInteropApi::class)
+internal fun String.toAccessibilityNSAttributedString(): NSAttributedString =
+    NSAttributedString.create(string = this)
 
 internal fun SemanticsConfiguration.accessibilityCustomActions():
     List<UIAccessibilityCustomAction> {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toSize
+import platform.Foundation.NSAttributedString
 import platform.UIKit.UIAccessibilityScrollDirection
 import platform.UIKit.UIAccessibilityScrollDirectionDown
 import platform.UIKit.UIAccessibilityScrollDirectionLeft
@@ -242,10 +243,12 @@ internal fun SemanticsNode.isScreenReaderFocusable(): Boolean {
     return !isTransparent && canBeAccessibilityElement()
 }
 
-internal fun SemanticsNode.linkText(): String? {
+internal fun SemanticsNode.linkAttributedString(): NSAttributedString? {
     val (text, annotation) = this.findCorrespondingLinkAnnotations() ?: return null
 
-    return text.substring(annotation.start, annotation.end).takeIf { it.isNotBlank() }
+    return text.subSequence(annotation.start, annotation.end)
+        .takeIf { it.isNotBlank() }
+        ?.toAccessibilityNSAttributedString()
 }
 
 internal fun SemanticsNode.linkTag(): String? {
@@ -392,15 +395,25 @@ internal val SemanticsNode.allScrollableParentNodeIds: IntSet get() {
     return result
 }
 
-internal val SemanticsNode.contentDescription: String? get() {
+internal val SemanticsNode.attributedContentDescription: List<NSAttributedString> get() {
     val contentDescription = config.getOrNull(SemanticsProperties.ContentDescription)
         ?.joinToString(", ")
         ?.takeIf { it.isNotBlank() }
 
-    return contentDescription ?: if (config.contains(SemanticsProperties.EditableText)) {
-        null
+    if (contentDescription != null) {
+        return listOf(contentDescription.toAccessibilityNSAttributedString())
+    }
+
+    return if (config.contains(SemanticsProperties.EditableText)) {
+        emptyList()
     } else {
-        config.getOrNull(SemanticsProperties.Text)?.joinToString(", ") { it.text }
+        config.getOrNull(SemanticsProperties.Text)?.mapNotNull {
+            if (it.isNotBlank()) {
+                it.toAccessibilityNSAttributedString()
+            } else {
+                null
+            }
+        } ?: emptyList()
     }
 }
 
@@ -417,7 +430,7 @@ internal fun SemanticsNode.sortFlattenChildren(children: List<SemanticsNode>): L
         if (!first.unmergedConfig.contains(SemanticsProperties.TraversalIndex) &&
             !second.unmergedConfig.contains(SemanticsProperties.TraversalIndex) &&
             first.layoutNode.parent != second.layoutNode.parent &&
-            first.layoutNode.findClosestParentNode({ it == second.layoutNode }) != null
+            first.layoutNode.findClosestParentNode { it == second.layoutNode } != null
         ) {
             sortedChildren[index] = second
             sortedChildren[index + 1] = first

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -65,21 +65,32 @@ import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.VerbatimTtsAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.text.withAnnotation
 import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
+import platform.Foundation.NSAttributedString
+import platform.Foundation.NSNumber
 import platform.UIKit.UIAccessibilityContainerTypeNone
 import platform.UIKit.UIAccessibilityContainerTypeSemanticGroup
+import platform.UIKit.UIAccessibilitySpeechAttributeLanguage
+import platform.UIKit.UIAccessibilitySpeechAttributeSpellOut
 import platform.UIKit.UIAccessibilityTraitAdjustable
 import platform.UIKit.UIAccessibilityTraitButton
 import platform.UIKit.UIAccessibilityTraitHeader
@@ -1485,4 +1496,85 @@ class ComponentsAccessibilitySemanticTest {
             }
         }
     }
+
+    @Test
+    fun testVerbatimTtsAnnotationInAttributedLabel() = runUIKitInstrumentedTest {
+        setContent {
+            Text(
+                text = buildAnnotatedString {
+                    append("Code ")
+                    withAnnotation(VerbatimTtsAnnotation("ABC123")) {
+                        append("ABC123")
+                    }
+                },
+                modifier = Modifier.testTag("Verbatim")
+            )
+        }
+
+        val label = assertNotNull(
+            findNodeWithTag("Verbatim").accessibilityLabel,
+            "Expected an attributed accessibility label"
+        )
+        // The verbatim part must be spelled out, the leading static text must not.
+        label.assertSpelledOut("ABC123")
+        assertEquals(
+            null,
+            label.attributeForSubstring(UIAccessibilitySpeechAttributeSpellOut!!, "Code"),
+            "Plain text should not carry the spell-out attribute"
+        )
+    }
+
+    @Test
+    fun testLanguageSpanInAttributedLabel() = runUIKitInstrumentedTest {
+        setContent {
+            Text(
+                text = buildAnnotatedString {
+                    append("Hello ")
+                    withStyle(SpanStyle(localeList = LocaleList("fr-FR"))) {
+                        append("bonjour")
+                    }
+                },
+                modifier = Modifier.testTag("Language")
+            )
+        }
+
+        val label = assertNotNull(
+            findNodeWithTag("Language").accessibilityLabel,
+            "Expected an attributed accessibility label"
+        )
+        // The localized part must carry the language tag, the leading text must not.
+        label.assertLanguage("bonjour", "fr-FR")
+        assertEquals(
+            null,
+            label.attributeForSubstring(UIAccessibilitySpeechAttributeLanguage!!, "Hello"),
+            "Plain text should not carry the language attribute"
+        )
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private fun NSAttributedString.attributeForSubstring(name: String, substring: String): Any? {
+    val location = string.indexOf(substring)
+    assertTrue(location >= 0, "Substring \"$substring\" not found in \"$string\"")
+    return attributesAtIndex(location.toULong(), null)[name]
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSAttributedString.assertSpelledOut(substring: String) {
+    val value = attributeForSubstring(UIAccessibilitySpeechAttributeSpellOut!!, substring)
+    assertEquals(
+        true,
+        (value as? NSNumber)?.boolValue,
+        "Expected spell-out speech attribute on \"$substring\" in \"$string\""
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSAttributedString.assertLanguage(substring: String, languageTag: String) {
+    val value = attributeForSubstring(UIAccessibilitySpeechAttributeLanguage!!, substring)
+    assertEquals(
+        languageTag,
+        value,
+        "Expected language speech attribute on \"$substring\" in \"$string\""
+    )
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -21,17 +21,19 @@ import androidx.compose.ui.platform.accessibility.CMPAccessibilityTraitTextView
 import androidx.compose.ui.test.utils.DpRectZero
 import androidx.compose.ui.test.utils.intersect
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.width
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
+import platform.Foundation.NSAttributedString
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeDataTable
 import platform.UIKit.UIAccessibilityContainerTypeLandmark
@@ -63,6 +65,8 @@ import platform.UIKit.UIAccessibilityTraits
 import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowScene
+import platform.UIKit.accessibilityAttributedLabel
+import platform.UIKit.accessibilityAttributedValue
 import platform.UIKit.accessibilityContainerType
 import platform.UIKit.accessibilityCustomActions
 import platform.UIKit.accessibilityElementAtIndex
@@ -147,7 +151,9 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
             isAccessibilityElement = element.isAccessibilityElement,
             identifier = (element as? UIAccessibilityElement)?.accessibilityIdentifier,
             label = element.accessibilityLabel,
+            accessibilityLabel = element.accessibilityAttributedLabel,
             value = element.accessibilityValue,
+            accessibilityValue = element.accessibilityAttributedValue,
             frame = element.accessibilityFrame.toDpRect(),
             containerType = element.accessibilityContainerType,
             children = children,
@@ -209,7 +215,9 @@ internal data class AccessibilityTestNode(
     var isAccessibilityElement: Boolean? = null,
     var identifier: String? = null,
     var label: String? = null,
+    var accessibilityLabel: NSAttributedString? = null,
     var value: String? = null,
+    var accessibilityValue: NSAttributedString? = null,
     var frame: DpRect? = null,
     var containerType: UIAccessibilityContainerType? = null,
     var children: List<AccessibilityTestNode>? = null,
@@ -235,8 +243,16 @@ internal data class AccessibilityTestNode(
         label?.let {
             assertEquals(it, actualNode?.label)
         }
+        accessibilityLabel?.let {
+            assertNotNull(actualNode?.accessibilityLabel, "Accessibility label should not be null")
+            assertTrue(it.isEqual(actualNode.accessibilityLabel), "Accessibility label should be equal")
+        }
         value?.let {
             assertEquals(it, actualNode?.value)
+        }
+        accessibilityValue?.let {
+            assertNotNull(actualNode?.accessibilityValue, "Accessibility value should not be null")
+            assertTrue(it.isEqual(actualNode.accessibilityValue), "Accessibility value should be equal")
         }
         frame?.let {
             assertEquals(it, actualNode?.frame)


### PR DESCRIPTION
Use `NSAttributedString` to collect accessibility label and accessibility value. Parse VoiceOver-related attributes into the corresponding attributed string parameters.

Fixes https://youtrack.jetbrains.com/issue/CMP-10308/iOS-A11y.-Support-TtsAnnotation-of-AnnotatedString

## Release Notes
### Features - iOS
- Support `VerbatimTtsAnnotation` and `LocaleList` attributes in accessibility VoiceOver.