### PR TITLE
Retry loading fallback fonts in case of network errors

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/FallbackFontDownloader.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/FallbackFontDownloader.web.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.text.UnresolvedSymbolsRegistry
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.platform.WebUnresolvedSymbolsRegistry
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -47,14 +49,22 @@ internal class WebFallbackFontDownloader(
 
     init {
         scope.launch {
+            var errorCount = 0
             while (isActive) {
                 val batch = awaitBatch()
                 try {
                     val newFonts = downloader.downloadFallbackFont(batch)
+                    errorCount = 0
                     drainChannel()
                     onFontsLoaded(newFonts)
-                } catch (e: Exception) {
-                    println("Failed to download fallback font: $e")
+                } catch (e: Throwable) {
+                    val pause = 5.seconds * errorCount
+                    errorCount++
+                    scope.launch {
+                        println("FallbackFontDownloader error: $e, next try in $pause seconds")
+                        delay(pause)
+                        submit(batch)
+                    }
                 }
             }
         }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NotoFontDownloader.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NotoFontDownloader.web.kt
@@ -42,7 +42,7 @@ internal class NotoFontDownloader : FallbackFontDownloader {
                 null
             }
         }
-        if (fonts.all { it == null }) {
+        if (fonts.isNotEmpty() && fonts.all { it == null }) {
             // we need to throw an error because we want to retry it later
             error("Failed to download fallback fonts for codepoints: $codepoints")
         }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NotoFontDownloader.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NotoFontDownloader.web.kt
@@ -32,10 +32,22 @@ internal class NotoFontDownloader : FallbackFontDownloader {
 
     override suspend fun downloadFallbackFont(codepoints: Set<Int>): List<FontFamily> {
         val fontsToDownload = getFontsToDownload(codepoints)
-        return fontsToDownload.map { font ->
-            val bytes = loadBytesFromPath(FONT_FALLBACK_BASE_URL + font.font.url)
-            FontFamily(Font(font.font.name, bytes))
+        val fonts = fontsToDownload.map { font ->
+            val fontUrl = FONT_FALLBACK_BASE_URL + font.font.url
+            try {
+                val bytes = loadBytesFromPath(fontUrl)
+                FontFamily(Font(font.font.name, bytes))
+            } catch (e: Throwable) {
+                println("Failed to download fallback font [$fontUrl]: $e")
+                null
+            }
         }
+        if (fonts.all { it == null }) {
+            // we need to throw an error because we want to retry it later
+            error("Failed to download fallback fonts for codepoints: $codepoints")
+        }
+
+        return fonts.filterNotNull()
     }
 
     internal fun getFontsToDownload(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebFallbackFontDownloaderTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebFallbackFontDownloaderTest.kt
@@ -123,27 +123,122 @@ class WebFallbackFontDownloaderTest : OnCanvasTests {
     }
 
     @Test
-    fun exceptionInDownloader_doesNotCrashWorker() = runTest {
+    fun failedDownload_isRetriedWithSameCodepoints() = runTest {
+        val font = FontFamily.Default
+        val calls = mutableListOf<Set<Int>>()
+        val flaky = object : FallbackFontDownloader {
+            override suspend fun downloadFallbackFont(codepoints: Set<Int>): List<FontFamily> {
+                calls += codepoints.toSet()
+                if (calls.size == 1) throw RuntimeException("transient network error")
+                return listOf(font)
+            }
+        }
+        val loaded = mutableListOf<List<FontFamily>>()
+        val downloader = WebFallbackFontDownloader(
+            downloader = flaky,
+            scope = backgroundScope,
+            onFontsLoaded = { loaded += it }
+        )
+
+        downloader.submit(setOf(0x4E2D, 0x6C34))
+        advanceTimeBy(1000)
+
+        assertEquals(2, calls.size, "Failed batch must be retried instead of being dropped")
+        assertEquals(
+            setOf(0x4E2D, 0x6C34),
+            calls[1],
+            "Retry must carry the same codepoints as the failed batch"
+        )
+        assertEquals(
+            listOf(font),
+            loaded.single(),
+            "A successful retry must deliver the downloaded fonts"
+        )
+    }
+
+    @Test
+    fun consecutiveFailures_useGrowingBackoff() = runTest {
         var callCount = 0
-        val throwingOnFirst = object : FallbackFontDownloader {
+        val alwaysFails = object : FallbackFontDownloader {
             override suspend fun downloadFallbackFont(codepoints: Set<Int>): List<FontFamily> {
                 callCount++
-                if (callCount == 1) throw RuntimeException("download failed")
+                throw RuntimeException("permanent failure")
+            }
+        }
+        val downloader = WebFallbackFontDownloader(
+            downloader = alwaysFails,
+            scope = backgroundScope,
+            onFontsLoaded = {}
+        )
+
+        downloader.submit(setOf(1))
+
+        // First failure backs off by 0s, so the first retry happens (and fails) almost immediately.
+        advanceTimeBy(500)
+        assertEquals(2, callCount, "First failure must retry immediately (0s backoff)")
+
+        // Second failure backs off by 5s — no further attempt before that elapses.
+        advanceTimeBy(4000)
+        assertEquals(2, callCount, "Third attempt must wait for the 5s backoff")
+
+        // Cross the 5s boundary — the third attempt fires.
+        advanceTimeBy(2000)
+        assertEquals(3, callCount, "Third attempt must run once the 5s backoff elapsed")
+    }
+
+    @Test
+    fun successResetsBackoff() = runTest {
+        var callCount = 0
+        // Fails on odd calls, succeeds on even ones, so every submit is "fail then retry-succeeds".
+        val flaky = object : FallbackFontDownloader {
+            override suspend fun downloadFallbackFont(codepoints: Set<Int>): List<FontFamily> {
+                callCount++
+                if (callCount % 2 == 1) throw RuntimeException("transient")
                 return emptyList()
             }
         }
         val downloader = WebFallbackFontDownloader(
-            downloader = throwingOnFirst,
+            downloader = flaky,
             scope = backgroundScope,
             onFontsLoaded = {}
         )
+
         downloader.submit(setOf(1))
-        advanceTimeBy(200)
-        assertEquals(1, callCount)
+        advanceTimeBy(1000)
+        assertEquals(2, callCount, "First batch fails then succeeds on the immediate retry")
+
+        // The previous success must reset the backoff to 0, so this failure also retries immediately.
+        // If the backoff were not reset, the retry would be delayed by 5s and callCount would stay 3.
+        downloader.submit(setOf(2))
+        advanceTimeBy(1000)
+        assertEquals(4, callCount, "After a success, the next failure must retry immediately again")
+    }
+
+    @Test
+    fun workerSurvivesFailures_andKeepsProcessingNewBatches() = runTest {
+        val calls = mutableListOf<Set<Int>>()
+        val downloader = WebFallbackFontDownloader(
+            downloader = object : FallbackFontDownloader {
+                override suspend fun downloadFallbackFont(codepoints: Set<Int>): List<FontFamily> {
+                    calls += codepoints.toSet()
+                    if (codepoints == setOf(1)) throw RuntimeException("always fails for 1")
+                    return emptyList()
+                }
+            },
+            scope = backgroundScope,
+            onFontsLoaded = {}
+        )
+
+        downloader.submit(setOf(1))
+        advanceTimeBy(300)
 
         downloader.submit(setOf(2))
-        advanceTimeBy(200)
-        assertEquals(2, callCount, "Worker must survive exception and process next submit")
+        advanceTimeBy(300)
+
+        assertTrue(
+            calls.any { it == setOf(2) },
+            "A continuously failing batch must not block the worker from processing new batches"
+        )
     }
 
     @Test


### PR DESCRIPTION
**Issue:** If an error occurred while loading a fallback font for an unresolved symbol (e.g., a network failure), the batch of codepoints was silently lost. Due to deduplication in the UnresolvedSymbolsRegistry and caching of the Skia paragraph in the ParagraphLayouter, the character was considered “already processed” and was never reported again—it remained unrenderable (tofu) forever, even after network recovery.
**Solution:** In WebFallbackFontDownloader, a failed batch is no longer lost: it is resubmitted for re-download via a non-blocking coroutine with a linear backoff (5s * errorCount), which is reset upon any successful download. A successful retry follows the standard flow (onFontsLoaded → onNewFontInstalled()), invalidates the paragraph cache, and redraws the text. The ParagraphLayouter remains unchanged.

Fixes https://youtrack.jetbrains.com/issue/CMP-10324

## Testing
Added tests cases

## Release Notes
### Fixes - Web
- Web: retry loading fallback fonts in case of network errors
