### PR TITLE
Don't set alwaysOnTop in WindowComposeSceneLayer

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -38,9 +38,11 @@ import androidx.compose.ui.window.getDialogScrimBlendMode
 import androidx.compose.ui.window.layoutDirectionFor
 import androidx.compose.ui.window.sizeInPx
 import java.awt.Point
+import java.awt.Window
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import javax.swing.JDialog
+import javax.swing.JWindow
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.DelicateSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -64,10 +66,9 @@ internal class WindowComposeSceneLayer(
         it.setContainerSizeFromComponent(windowContainer)
     }
 
-    private val layerWindow = JDialog(parentWindow).also {
-        it.isAlwaysOnTop = true
+    private val layerWindow = JWindow(parentWindow).also {
         it.focusableWindowState = focusable
-        it.isUndecorated = true
+        it.type = Window.Type.POPUP
 
         @OptIn(DelicateSkikoApi::class)
         it.background =


### PR DESCRIPTION
Don't set `alwaysOnTop=true`: this fixes the issue that alt-tabbing away from the window while a popup is open keeps the window on top of other windows.

Also set window type to `Window.Type.POPUP`. Not sure what it does, if anything, but looks like it's suitable.
Also made the window a `JWindow`, rather than a `JDialog`.

These follow the code at https://github.com/openjdk/jdk/blob/16d0f161ef23d3025b467030fda667ecf13c80dd/src/java.desktop/share/classes/javax/swing/Popup.java#L236 (except for `alwaysOnTop=true`)

Fixes https://youtrack.jetbrains.com/issue/CMP-10370

## Testing
Tested manually by showing a popup and switching to a different window.
```
fun main() {
    System.setProperty("compose.layers.type", "WINDOW")
    singleWindowApplication {
        MaterialTheme {
            val contextMenuState = remember { DropdownMenuState() }
            Box(
                modifier = Modifier
                    .fillMaxSize()
                    .contextMenuOpenDetector(contextMenuState),
                contentAlignment = Alignment.Center
            ) {
                DropdownMenu(contextMenuState) {
                    DropdownMenuItem(onClick = {}) {
                        Text("Item 1")
                    }
                    DropdownMenuItem(onClick = {}) {
                        Text("Item 2")
                    }
                }
            }
        }
    }
}
```

## Release Notes
### Fixes - Desktop
- Fixed popups/dialogs staying on top of other windows with `compose.layers.type=WINDOW`.
