### PR TITLE
Implement `ComposeDesktopEntryPoint.captureContentToImage`

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -136,6 +136,7 @@ public final class androidx/compose/ui/ComposableSingletons$ImageComposeScene_sk
 }
 
 public abstract interface class androidx/compose/ui/ComposeDesktopEntryPoint {
+	public abstract fun captureContentToImage ()Ljava/awt/image/BufferedImage;
 	public abstract fun getSemanticsOwners ()Ljava/util/Collection;
 }
 
@@ -564,6 +565,7 @@ public final class androidx/compose/ui/awt/ComposeDialog : javax/swing/JDialog, 
 	public fun addMouseListener (Ljava/awt/event/MouseListener;)V
 	public fun addMouseMotionListener (Ljava/awt/event/MouseMotionListener;)V
 	public fun addMouseWheelListener (Ljava/awt/event/MouseWheelListener;)V
+	public fun captureContentToImage ()Ljava/awt/image/BufferedImage;
 	public fun dispose ()V
 	public final fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
@@ -595,6 +597,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public fun add (Ljava/awt/Component;)Ljava/awt/Component;
 	public fun addFocusListener (Ljava/awt/event/FocusListener;)V
 	public fun addNotify ()V
+	public fun captureContentToImage ()Ljava/awt/image/BufferedImage;
 	public fun getFocusTraversalKeysEnabled ()Z
 	public fun getMaximumSize ()Ljava/awt/Dimension;
 	public fun getMinimumSize ()Ljava/awt/Dimension;
@@ -635,6 +638,7 @@ public final class androidx/compose/ui/awt/ComposeWindow : javax/swing/JFrame, a
 	public fun addMouseListener (Ljava/awt/event/MouseListener;)V
 	public fun addMouseMotionListener (Ljava/awt/event/MouseMotionListener;)V
 	public fun addMouseWheelListener (Ljava/awt/event/MouseWheelListener;)V
+	public fun captureContentToImage ()Ljava/awt/image/BufferedImage;
 	public fun dispose ()V
 	public final fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public final fun getPlacement ()Landroidx/compose/ui/window/WindowPlacement;

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeDesktopEntryPoint.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui
 
 import androidx.compose.runtime.tooling.ComposeToolingApi
 import androidx.compose.ui.semantics.SemanticsOwner
+import java.awt.image.BufferedImage
 
 /**
  * The interface for classes that are an entry point for using Compose on the desktop.
@@ -33,4 +34,13 @@ interface ComposeDesktopEntryPoint {
      * changes.
      */
     val semanticsOwners: Collection<SemanticsOwner>
+
+    /**
+     * Captures the content of this entry point into an image.
+     *
+     * Returns `null` if the entry point is not in a state where it has visual content yet.
+     *
+     * May be called only on the event dispatch thread.
+     */
+    fun captureContentToImage(): BufferedImage?
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -44,6 +44,7 @@ import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
+import java.awt.image.BufferedImage
 import java.util.*
 import javax.swing.JDialog
 import kotlin.coroutines.CoroutineContext
@@ -215,18 +216,6 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
         set(value) { composePanel.isClearFocusOnMouseDownEnabled = value }
 
     private val undecoratedWindowResizer = UndecoratedWindowResizer(this)
-
-    /**
-     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
-     * [ComposeDialog].
-     *
-     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when the set of semantics owners
-     * changes.
-     */
-    @ComposeToolingApi
-    override val semanticsOwners: Collection<SemanticsOwner>
-        get() = composePanel.semanticsOwners
 
     override fun add(component: Component) = composePanel.add(component)
 
@@ -454,5 +443,29 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
 
     internal fun measureContent(constraints: Constraints): IntSize {
         return composePanel.measureContent(constraints)
+    }
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposeDialog].
+     *
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
+     */
+    @ComposeToolingApi
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = composePanel.semanticsOwners
+
+    /**
+     * Captures the content of this dialog into an image.
+     *
+     * Returns `null` if the dialog has not been made visible yet.
+     *
+     * May be called only on the event dispatching thread.
+     */
+    @ComposeToolingApi
+    override fun captureContentToImage(): BufferedImage? {
+        return composePanel.captureContentToImage()
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -46,6 +46,7 @@ import java.awt.FocusTraversalPolicy
 import java.awt.Window
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
+import java.awt.image.BufferedImage
 import java.util.*
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities
@@ -333,18 +334,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             _composeContainer?.windowContainer = value
         }
 
-    /**
-     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
-     * [ComposePanel].
-     *
-     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when the set of semantics owners
-     * changes.
-     */
-    @ComposeToolingApi
-    override val semanticsOwners: Collection<SemanticsOwner>
-        get() = _composeContainer?.semanticsOwners ?: emptyList()
-
     // Needed to preserve binary compatibility
     @Suppress("RedundantOverride")
     override fun add(component: Component): Component = super.add(component)
@@ -520,4 +509,27 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             field = value
             _composeContainer?.showLayoutBounds = value
         }
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposePanel].
+     *
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
+     */
+    @ComposeToolingApi
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = _composeContainer?.semanticsOwners ?: emptyList()
+
+    /**
+     * Captures the content of this panel into an image.
+     *
+     * Returns `null` if the panel has not been made visible yet.
+     *
+     * May be called only on the event dispatching thread.
+     */
+    override fun captureContentToImage(): BufferedImage? {
+        return _composeContainer?.captureContentToImage()
+    }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -529,6 +529,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      *
      * May be called only on the event dispatching thread.
      */
+    @ComposeToolingApi
     override fun captureContentToImage(): BufferedImage? {
         return _composeContainer?.captureContentToImage()
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -41,6 +42,7 @@ import java.awt.GraphicsConfiguration
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
+import java.awt.image.BufferedImage
 import java.util.*
 import javax.swing.JFrame
 import kotlin.coroutines.CoroutineContext
@@ -85,18 +87,6 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
 
     internal val windowContext by composePanel::windowContext
     internal var rootForTestListener by composePanel::rootForTestListener
-
-    /**
-     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
-     * [ComposeWindow].
-     *
-     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when the set of semantics owners
-     * changes.
-     */
-    @ComposeToolingApi
-    override val semanticsOwners: Collection<SemanticsOwner>
-        get() = composePanel.semanticsOwners
 
     /**
      * Controls whether mouse-down on an unfocusable element clears focus.
@@ -377,5 +367,29 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
 
     internal fun measureContent(constraints: Constraints): IntSize {
         return composePanel.measureContent(constraints)
+    }
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposeWindow].
+     *
+     * This is backed by Snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when the set of semantics owners
+     * changes.
+     */
+    @ComposeToolingApi
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = composePanel.semanticsOwners
+
+    /**
+     * Captures the content of this window into an image.
+     *
+     * Returns `null` if the window has not been made visible yet.
+     *
+     * May be called only on the event dispatching thread.
+     */
+    @ComposeToolingApi
+    override fun captureContentToImage(): BufferedImage? {
+        return composePanel.captureContentToImage()
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.ComposeDesktopEntryPoint
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.semantics.SemanticsOwner

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -212,4 +212,6 @@ internal class ComposeWindowPanel(
     fun actualizeSize(size: Dimension, insets: Insets): Dimension {
         return composeContainer.actualizeSize(size, insets)
     }
+
+    fun captureContentToImage() = composeContainer.captureContentToImage()
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.awt.UNSPECIFIED_DIMENSION_VALUE
+import androidx.compose.ui.unit.union
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastRoundToInt
@@ -58,6 +59,7 @@ import java.awt.event.MouseEvent as AwtMouseEvent
 import java.awt.event.WindowEvent
 import java.awt.event.WindowFocusListener
 import java.awt.event.WindowListener
+import java.awt.image.BufferedImage
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities
 import kotlin.coroutines.AbstractCoroutineContextElement
@@ -65,7 +67,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.ceil
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Job
 import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.MainUIDispatcher
@@ -619,6 +620,42 @@ internal class ComposeContainer(
 
         override fun shouldSendMouseEvent(event: AwtMouseEvent): Boolean = noBlockingInputLayers
         override fun shouldSendKeyEvent(event: AwtKeyEvent): Boolean = noBlockingInputLayers
+    }
+
+    /**
+     * Captures the content of this container into an image.
+     *
+     * Returns `null` if the window has not been made visible yet.
+     *
+     * This may be called only on the event dispatch thread.
+     */
+    fun captureContentToImage(): BufferedImage? {
+        val mainLayerBounds = mediator.boundsOnScreenPx() ?: return null
+        val layersAndBounds = layers.map {
+            it to it.boundsOnScreenPx()
+        }
+
+        var resultBounds = mainLayerBounds
+        for ((_, bounds) in layersAndBounds) {
+            if (bounds != null) {
+                resultBounds = resultBounds.union(bounds)
+            }
+        }
+
+        val x = resultBounds.left
+        val y = resultBounds.top
+        val width = resultBounds.width
+        val height = resultBounds.height
+
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        mediator.drawContentInto(image, mainLayerBounds.left - x, mainLayerBounds.top - y)
+        for ((layer, bounds) in layersAndBounds) {
+            if (bounds == null) continue
+            // The offset is from mainLayerBounds because layers draw themselves relative to it
+            layer.drawContentInto(image, mainLayerBounds.left - x, mainLayerBounds.top - y)
+        }
+
+        return image
     }
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -950,46 +950,16 @@ internal class ComposeSceneMediator(
      *
      * May be called only on the event dispatching thread.
      */
-    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int): Boolean {
+    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int) {
         require(isEventDispatchThread())
 
         val size = contentComponent.sizeInPx.roundToIntSize()
-
-        val g = target.createGraphics()
-        g.translate(offsetX, offsetY)
-
-        // Draw the background
-        g.color = contentComponent.background ?: java.awt.Color(0, 0, 0, 0)
-        g.fillRect(0, 0, size.width, size.height)
-
-        fun drawInterop() {
-            val density = contentComponent.density.density.toDouble()
-            val gTemp = g.create() as Graphics2D
-            gTemp.scale(density, density)
-            interopContainer.root.paint(gTemp)
-            gTemp.dispose()
+        target.drawScene(offsetX, offsetY, size, contentComponent.density) {
+            fillBackground(contentComponent.background)
+            if (!shouldPlaceInteropAbove) drawInterop(interopContainer.root)
+            drawCompose { canvas -> canvas.withSceneOffset { scene.draw(asComposeCanvas()) } }
+            if (shouldPlaceInteropAbove) drawInterop(interopContainer.root)
         }
-
-        // Draw interop below
-        if (!shouldPlaceInteropAbove) {
-            drawInterop()
-        }
-
-        // Draw Compose to a Surface and then draw that to the target
-        val surface = Surface.makeRasterN32Premul(size.width, size.height)
-        val canvas = surface.canvas
-        canvas.withSceneOffset { scene.draw(canvas.asComposeCanvas()) }
-        g.drawImage(surface.makeImageSnapshot().toComposeImageBitmap().toAwtImage(), 0, 0, null)
-        surface.close()
-
-        // Draw interop above
-        if (shouldPlaceInteropAbove) {
-            drawInterop()
-        }
-
-        g.dispose()
-
-        return true
     }
 }
 
@@ -1104,3 +1074,50 @@ private val MouseEvent.isMacOsCtrlClick
             ((modifiersEx and InputEvent.BUTTON1_DOWN_MASK) != 0) &&
             ((modifiersEx and InputEvent.CTRL_DOWN_MASK) != 0)
         )
+
+
+private class SceneImageDrawScope(
+    private val g: Graphics2D,
+    private val size: IntSize,
+    private val density: Density,
+) {
+    fun fillBackground(color: java.awt.Color?) {
+        g.color = color ?: java.awt.Color(0, 0, 0, 0)
+        g.fillRect(0, 0, size.width, size.height)
+    }
+
+    fun drawInterop(root: Component) {
+        val gInterop = g.create() as Graphics2D
+        try {
+            gInterop.scale(density.density.toDouble(), density.density.toDouble())
+            root.paint(gInterop)
+        } finally {
+            gInterop.dispose()
+        }
+    }
+
+    /** Draws the Compose content via Skia and paints it into the region. */
+    fun drawCompose(draw: (SkCanvas) -> Unit) {
+        Surface.makeRasterN32Premul(size.width, size.height).use { surface ->
+            draw(surface.canvas)
+            g.drawImage(surface.makeImageSnapshot().toComposeImageBitmap().toAwtImage(), 0, 0, null)
+        }
+    }
+}
+
+
+private inline fun BufferedImage.drawScene(
+    offsetX: Int,
+    offsetY: Int,
+    size: IntSize,
+    density: Density,
+    block: SceneImageDrawScope.() -> Unit,
+) {
+    val g = createGraphics()
+    try {
+        g.translate(offsetX, offsetY)
+        SceneImageDrawScope(g, size, density).block()
+    } finally {
+        g.dispose()
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -953,21 +953,36 @@ internal class ComposeSceneMediator(
     fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int): Boolean {
         require(isEventDispatchThread())
 
+        val size = contentComponent.sizeInPx.roundToIntSize()
+
         val g = target.createGraphics()
         g.translate(offsetX, offsetY)
 
+        // Draw the background
+        g.color = contentComponent.background ?: java.awt.Color(0, 0, 0, 0)
+        g.fillRect(0, 0, size.width, size.height)
+
+        fun drawInterop() {
+            val density = contentComponent.density.density.toDouble()
+            g.scale(density, density)
+            interopContainer.root.paint(g)
+        }
+
+        // Draw interop below
+        if (!shouldPlaceInteropAbove) {
+            drawInterop()
+        }
+
         // Draw Compose to a Surface and then draw that to the target
-        val size = contentComponent.sizeInPx.roundToIntSize()
         val surface = Surface.makeRasterN32Premul(size.width, size.height)
         val canvas = surface.canvas
-        canvas.clear(contentComponent.background?.rgb ?: 0)
         canvas.withSceneOffset { scene.draw(canvas.asComposeCanvas()) }
         g.drawImage(surface.makeImageSnapshot().toComposeImageBitmap().toAwtImage(), 0, 0, null)
 
-        // Draw interop
-        val density = contentComponent.density.density.toDouble()
-        g.scale(density, density)
-        interopContainer.root.paint(g)
+        // Draw interop above
+        if (shouldPlaceInteropAbove) {
+            drawInterop()
+        }
 
         g.dispose()
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -80,10 +80,10 @@ import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
 import androidx.compose.ui.window.toDpOffset
-import java.awt.AlphaComposite
 import java.awt.Component
 import java.awt.Cursor
 import java.awt.Dimension
+import java.awt.Graphics2D
 import java.awt.Point
 import java.awt.Toolkit
 import java.awt.event.ContainerEvent
@@ -964,8 +964,10 @@ internal class ComposeSceneMediator(
 
         fun drawInterop() {
             val density = contentComponent.density.density.toDouble()
-            g.scale(density, density)
-            interopContainer.root.paint(g)
+            val gTemp = g.create() as Graphics2D
+            gTemp.scale(density, density)
+            interopContainer.root.paint(gTemp)
+            gTemp.dispose()
         }
 
         // Draw interop below
@@ -978,6 +980,7 @@ internal class ComposeSceneMediator(
         val canvas = surface.canvas
         canvas.withSceneOffset { scene.draw(canvas.asComposeCanvas()) }
         g.drawImage(surface.makeImageSnapshot().toComposeImageBitmap().toAwtImage(), 0, 0, null)
+        surface.close()
 
         // Draw interop above
         if (shouldPlaceInteropAbove) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.ui.input.key.internal
@@ -64,9 +66,12 @@ import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.util.fastCoerceAtLeast
 import androidx.compose.ui.util.fastRoundToInt
@@ -75,6 +80,7 @@ import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
 import androidx.compose.ui.window.toDpOffset
+import java.awt.AlphaComposite
 import java.awt.Component
 import java.awt.Cursor
 import java.awt.Dimension
@@ -96,10 +102,13 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.im.InputMethodRequests
+import java.awt.image.BufferedImage
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
+import javax.swing.SwingUtilities.isEventDispatchThread
 import kotlin.coroutines.CoroutineContext
 import org.jetbrains.skia.Canvas as SkCanvas
+import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
@@ -917,6 +926,52 @@ internal class ComposeSceneMediator(
         fun requestFocusTemporary(): Boolean {
             return super.requestFocus(true)
         }
+    }
+
+    /**
+     * Returns the bounds of the scene on the screen in pixels; null if it has not been made
+     * visible yet.
+     */
+    fun boundsOnScreenPx(): IntRect? {
+        if (!container.isDisplayable) return null
+
+        val sceneBounds = (sceneBoundsInPx ?: Rect(offset = Offset.Zero, size = container.sizeInPx))
+        val containerScreenCoords = Point(0, 0)
+            .also {
+                SwingUtilities.convertPointToScreen(it, contentComponent)
+            }
+            .toDpOffset()
+            .toOffset(container.density)
+        return sceneBounds.translate(containerScreenCoords.x, containerScreenCoords.y).roundToIntRect()
+    }
+
+    /**
+     * Draws the scene into [target] at the given offset.
+     *
+     * May be called only on the event dispatching thread.
+     */
+    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int): Boolean {
+        require(isEventDispatchThread())
+
+        val g = target.createGraphics()
+        g.translate(offsetX, offsetY)
+
+        // Draw Compose to a Surface and then draw that to the target
+        val size = contentComponent.sizeInPx.roundToIntSize()
+        val surface = Surface.makeRasterN32Premul(size.width, size.height)
+        val canvas = surface.canvas
+        canvas.clear(contentComponent.background?.rgb ?: 0)
+        canvas.withSceneOffset { scene.draw(canvas.asComposeCanvas()) }
+        g.drawImage(surface.makeImageSnapshot().toComposeImageBitmap().toAwtImage(), 0, 0, null)
+
+        // Draw interop
+        val density = contentComponent.density.density.toDouble()
+        g.scale(density, density)
+        interopContainer.root.paint(g)
+
+        g.dispose()
+
+        return true
     }
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.awt.AwtEventFilter
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.toAwtRectangle
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.skiko.RecordDrawRectRenderDecorator
@@ -33,9 +34,11 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.util.fastForEachReversed
+import java.awt.Point
 import java.awt.Rectangle
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
+import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
 import kotlin.math.max
 import org.jetbrains.skia.Canvas
@@ -231,9 +234,17 @@ internal abstract class DesktopComposeSceneLayer(
         return boundsInWindow.toAwtRectangle(density).contains(point)
     }
 
+    fun boundsOnScreenPx(): IntRect? {
+        val layerBounds = mediator?.boundsOnScreenPx() ?: return null
+        return drawBounds.translate(layerBounds.topLeft)
+    }
+
+    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int) =
+        mediator?.drawContentInto(target, offsetX + drawBounds.left, offsetY + drawBounds.top) ?: false
+
     /**
      * Detect and trigger [DesktopComposeSceneLayer.onMouseEventOutside] if event happened below
-     * a layer that blocks pointer input outside of its bounds.
+     * a layer that blocks pointer input outside its bounds.
      */
     private inner class DetectEventOutsideLayer : AwtEventListener {
         override fun onMouseEvent(event: MouseEvent): Boolean {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -239,8 +239,9 @@ internal abstract class DesktopComposeSceneLayer(
         return drawBounds.translate(layerBounds.topLeft)
     }
 
-    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int) =
-        mediator?.drawContentInto(target, offsetX + drawBounds.left, offsetY + drawBounds.top) ?: false
+    fun drawContentInto(target: BufferedImage, offsetX: Int, offsetY: Int) {
+        mediator?.drawContentInto(target, offsetX + drawBounds.left, offsetY + drawBounds.top)
+    }
 
     /**
      * Detect and trigger [DesktopComposeSceneLayer.onMouseEventOutside] if event happened below

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Geometry.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Geometry.skiko.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 /**
@@ -150,3 +152,12 @@ internal fun DpOffset.requireReal(): DpOffset {
     y.requireReal("y")
     return this
 }
+
+@Stable
+internal fun IntRect.union(other: IntRect): IntRect =
+    IntRect(
+        left = min(left, other.left),
+        top = min(top, other.top),
+        right = max(right, other.right),
+        bottom = max(bottom, other.bottom)
+    )


### PR DESCRIPTION
To be used by the MCP server.

It captures the content of both the window itself and any layers inside (even if they're window layers), including interop (`SwingPanel`).

Fixes https://youtrack.jetbrains.com/issue/CMP-10389/Allow-MCP-server-to-take-screenshots-of-windows

## Testing
Tested manually with
```
@OptIn(ExperimentalComposeUiApi::class, ComposeToolingApi::class, ExperimentalMaterialApi::class)
fun main() {
    System.setProperty("compose.layers.type", "WINDOW")
    singleWindowApplication {
        fun saveScreenshot() {
            window.captureContentToImage().let {
                ImageIO.write(it, "png", File("/Users/sasha/Desktop/compose_screenshot.png"))
            }
        }

        val contextMenuState = remember { DropdownMenuState() }
        Box(
            modifier = Modifier
                .fillMaxSize()
                .contextMenuOpenDetector(contextMenuState),
            contentAlignment = Alignment.Center
        ) {
            Column {
                Text("Hello World", Modifier.padding(16.dp))
                Button(
                    onClick = { saveScreenshot() }
                ) {
                    Text("Take screenshot")
                }

                SwingPanel(
                    factory = {
                        JPanel().also {
                            it.background = java.awt.Color.BLUE
                            it.preferredSize = Dimension(100, 100)
                            it.isOpaque = true
                        }
                    }
                )
            }

            DropdownMenu(contextMenuState) {
                DropdownMenuItem(onClick = {}) {
                    Text("Item 1")
                }
                DropdownMenuItem(onClick = {}) {
                    Text("Item 2")
                }
                DropdownMenuItem(onClick = { saveScreenshot() }) {
                    Text("Take screenshot")
                }
                DropdownMenuItem(onClick = {}) {
                    SwingPanel(
                        factory = { JLabel("Swing Item") }
                    )
                }
            }
        }
    }
}
```

To test a popup outside the window bounds, you also need to disable the position checks in `PopupPositionProviderAtPosition` and add `clippingEnabled = false` to the popup properties in `OpenDropdownMenu`.

(In the attached screenshot, the Swing Item is not visible, but it's a separate problem - it's actually not visible to the user).

<img width="1764" height="1359" alt="compose_screenshot" src="https://github.com/user-attachments/assets/cfd81647-35f8-4518-a713-0a6566e0f2ae" />

## Release Notes
N/A