### PR TITLE
Fix printing `GlobalSnapshotManager` concurrent registrations warning

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -137,6 +137,9 @@ internal class ComposeContainer(
     @VisibleForTesting
     val architectureComponentsOwner = DefaultArchitectureComponentsOwner(savedState)
 
+    val coroutineContext: CoroutineContext =
+        coroutineContext + MainUIDispatcher + DesktopCoroutineExceptionHandler()
+
     private val mediator = ComposeSceneMediator(
         container = container,
         isWindowLevel = isWindowLevel,
@@ -149,7 +152,7 @@ internal class ComposeContainer(
             BlockingInputLayerEventFilter()
         ),
         architectureComponentsOwner = architectureComponentsOwner,
-        coroutineContext = coroutineContext + MainUIDispatcher + DesktopCoroutineExceptionHandler(),
+        coroutineContext = this.coroutineContext,
         skiaLayerComponentFactory = ::createSkiaLayerComponent,
         composeSceneFactory = ::createComposeScene,
     )
@@ -492,7 +495,6 @@ internal class ComposeContainer(
                 skiaLayerAnalytics = skiaLayerAnalytics,
                 renderSettings = renderSettings,
                 transparent = true, // TODO: Consider allowing opaque window layers
-                compositionContext = mediator.frameRecomposer.compositionContext,
                 density = density,
                 layoutDirection = layoutDirection,
                 focusable = focusable,
@@ -500,7 +502,6 @@ internal class ComposeContainer(
             LayerType.OnComponent -> SwingComposeSceneLayer(
                 composeContainer = this,
                 skiaLayerAnalytics = skiaLayerAnalytics,
-                compositionContext = mediator.frameRecomposer.compositionContext,
                 density = density,
                 layoutDirection = layoutDirection,
                 focusable = focusable,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.scene
 
-import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.awt.toAwtRectangle
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
@@ -40,7 +39,6 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 internal class SwingComposeSceneLayer(
     composeContainer: ComposeContainer,
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
-    compositionContext: CompositionContext,
     density: Density,
     layoutDirection: LayoutDirection,
     focusable: Boolean,
@@ -114,7 +112,7 @@ internal class SwingComposeSceneLayer(
             eventListener = eventListener,
             measureDrawLayerBounds = true,
             architectureComponentsOwner = composeContainer.architectureComponentsOwner,
-            coroutineContext = compositionContext.effectCoroutineContext,
+            coroutineContext = composeContainer.coroutineContext,
             skiaLayerComponentFactory = ::createSkiaLayerComponent,
             composeSceneFactory = ::createComposeScene,
         ).also {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.scene
 
-import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.awt.JLayeredPaneWithTransparencyHack
 import androidx.compose.ui.awt.RenderSettings
 import androidx.compose.ui.awt.hasMacOsShadow
@@ -53,7 +52,6 @@ internal class WindowComposeSceneLayer(
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
     private val renderSettings: RenderSettings,
     private val transparent: Boolean,
-    compositionContext: CompositionContext,
     density: Density,
     layoutDirection: LayoutDirection,
     focusable: Boolean,
@@ -133,7 +131,7 @@ internal class WindowComposeSceneLayer(
             eventListener = eventListener,
             measureDrawLayerBounds = true,
             architectureComponentsOwner = composeContainer.architectureComponentsOwner,
-            coroutineContext = compositionContext.effectCoroutineContext,
+            coroutineContext = composeContainer.coroutineContext,
             skiaLayerComponentFactory = ::createSkiaLayerComponent,
             composeSceneFactory = ::createComposeScene,
         ).also {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -324,6 +324,8 @@ internal class ComposeContainer(
                     onFocusConditionsChanged = ::onFocusConditionsChanged,
                     focusedViewsList = if (focusable) focusedViewsList.childFocusedViewsList() else null,
                     consumePointerInputOutside = consumePointerInputOutside,
+                    // FIXME: Do not use [compositionContext.effectCoroutineContext] for
+                    //  [FrameRecomposer] creation.
                     parentCoroutineContext = frameRecomposer.compositionContext.effectCoroutineContext,
                     ownerProvider = architectureComponentsOwner,
                     interfaceOrientationState = interfaceOrientationState,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.skiko.kt
@@ -88,6 +88,17 @@ internal object GlobalSnapshotManager {
         if (!dispatcher.isDispatchNeeded(dispatcher)) {
             return null
         }
+        // FlushCoroutineDispatcher is an internal class, and all cases where it's passed here are
+        // about using [Recomposer.effectCoroutineContext] and means that we're already registered
+        // Snapshot forwarding in this tread in parent composition.
+        // This check is temporary to prevent multiple registrations. The proper solution is to
+        // avoid creating a separate [Recomposer] for all child compositions if they are in
+        // the same window. In case if they are not, it shouldn't use the parent's
+        // [Recomposer.effectCoroutineContext].
+        // TODO: Remove this check once all platform properly adapt shared [Recomposer].
+        if (dispatcher is FlushCoroutineDispatcher) {
+            return null
+        }
         val registration = synchronized(lock) {
             registrations.getOrPut(dispatcher) { Registration(dispatcher) }
                 .also { it.refCount++ }


### PR DESCRIPTION
[CMP-10372](https://youtrack.jetbrains.com/issue/CMP-10372) "concurrent registrations of apply dispatchers" warning with "compose.layers.type=WINDOW"

## Release Notes
### Fixes - Multiple Platforms
- _(prerelease fix)_ Fix printing `GlobalSnapshotManager` concurrent registrations warning during creation of `Popup`/`Dialog` on iOS and Desktop with custom `compose.layers.type`