### PR TITLE
Check accessibleChild for `null` in `defaultAccessibilityFocusTarget`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessibility.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessibility.kt
@@ -166,7 +166,9 @@ internal class ComposeSceneAccessibility(
             val childCount = context.accessibleChildrenCount
             for (index in 0 until childCount) {
                 val child = context.getAccessibleChild(index)
-                queue.addFirst(child)
+                if (child != null) {
+                    queue.addFirst(child)
+                }
             }
         }
 


### PR DESCRIPTION
Check accessibleChild for `null` in `defaultAccessibilityFocusTarget` before adding it to the queue.

Unfortunately without a reproducer I can't fix the underlying reason for the child being `null`. It's coming from either `ComposeAccessibleComponent.getAccessibleChild`, or some non-CMP Swing component.

But the impact of sometimes returning `null` from `defaultAccessibilityFocusTarget` when we shouldn't isn't that significant to warrant a big investigation.

Fixes https://youtrack.jetbrains.com/issue/CMP-10363

## Testing
N/A

## Release Notes
### Fixes - Desktop
- Fixed a crash when encountering a `null` accessible child in the Swing hierarchy while looking for a component to switch a11y focus to, after the currently focused a11y component has been removed.
