### PR TITLE
Remove `foundation` dependency on skiko `SystemTheme`

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
@@ -19,12 +19,11 @@ package androidx.compose.foundation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.LocalSystemTheme
-import org.jetbrains.skiko.SystemTheme
+import androidx.compose.ui.isUiSystemInDarkTheme
 
 @OptIn(InternalComposeUiApi::class)
 @Composable
 @ReadOnlyComposable
 internal actual fun _isSystemInDarkTheme(): Boolean {
-    return LocalSystemTheme.current == SystemTheme.DARK
+    return isUiSystemInDarkTheme()
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
@@ -16,7 +16,10 @@
 
 package androidx.compose.ui
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
+import org.jetbrains.skiko.SystemTheme
 import org.jetbrains.skiko.currentSystemTheme
 
 @Deprecated("This class was made public by mistake and will be removed in a future release")
@@ -24,5 +27,11 @@ enum class SystemTheme {
     Dark, Light, Unknown
 }
 
+internal val LocalSystemTheme = staticCompositionLocalOf { currentSystemTheme }
+
 @InternalComposeUiApi
-val LocalSystemTheme = staticCompositionLocalOf { currentSystemTheme }
+@Composable
+@ReadOnlyComposable
+fun isUiSystemInDarkTheme(): Boolean {
+    return LocalSystemTheme.current == SystemTheme.DARK
+}


### PR DESCRIPTION
Add `isUiSystemInDarkTheme` in `ui` and make `LocalSystemTheme` internal to avoid `foundation` dependency on skiko types

## Testing
N/A

## Release Notes
N/A