### PR TITLE
Increase swipe duration in tests

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -599,12 +599,14 @@ internal class UIKitInstrumentedTest(
         val startLocation = locationInView(null).toDpOffset()
 
         val startTime = TimeSource.Monotonic.markNow()
-        while (TimeSource.Monotonic.markNow() <= startTime + duration) {
-            val progress = ((TimeSource.Monotonic.markNow() - startTime) / duration).coerceIn(0.0, 1.0)
+        var currentTime = startTime
+        while (currentTime <= startTime + duration) {
+            val progress = ((currentTime - startTime) / duration).coerceIn(0.0, 1.0)
             val touchLocation = lerp(startLocation, location, progress.toFloat())
 
             this.moveToLocationOnWindow(touchLocation)
             NSRunLoop.currentRunLoop().runUntilDate(NSDate.dateWithTimeIntervalSinceNow(1.0 / 60))
+            currentTime = TimeSource.Monotonic.markNow()
         }
         this.moveToLocationOnWindow(location)
         return this

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -649,7 +649,7 @@ internal class UIKitInstrumentedTest(
         return dragTo(DpOffset(x ?: location.x, y ?: location.y), duration)
     }
 
-    private val SwipeDuration = 200.milliseconds
+    private val SwipeDuration = 0.5.seconds
 
     fun AccessibilityTestNode.swipe(
         fromPosition: DpRect.() -> DpOffset = { center() },


### PR DESCRIPTION
I have run the flaky `UIKitNavigationSwipeBackInHostingViewTest` and `UIKitNavigationSwipeBackInHostingViewControllerTest` test suites 200x each for every configuration before and after the change and increasing swipe duration to the default 500 ms helped. 

I have not added any special speed / velocity configuration in case this current state is sufficient. But in case we need to speed up tests we can introduce calculations based on size of the device, so that drag speed is adjusted to the distance covered.

## Release Notes
N/A
