### PR TITLE
Set isClearFocusOnMouseDownEnabled to false by default

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
@@ -34,12 +34,15 @@ import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeUiFlags
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.platform.testTag
@@ -271,27 +274,36 @@ class ClickableFocusTest {
         override fun equals(other: Any?) = super.equals(other)
     }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Test
-    fun mouseClickOutsideClearsFocus() = runComposeUiTest {
-        val focusRequester = FocusRequester()
-        setContent {
-            Column(Modifier.size(300.dp, 400.dp)) {
-                BasicTextField(
-                    state = rememberTextFieldState(),
-                    modifier = Modifier
-                        .testTag("textField")
-                        .focusRequester(focusRequester)
-                )
-                LaunchedEffect(Unit) {
-                    focusRequester.requestFocus()
+    fun mouseClickOutsideClearsFocusWithClearFocusOnMouseDownEnabled() {
+        val prevClearFocusOnMouseDownEnabled = ComposeUiFlags.isClearFocusOnMouseDownEnabled
+        ComposeUiFlags.isClearFocusOnMouseDownEnabled = true
+        try {
+            runComposeUiTest {
+                val focusRequester = FocusRequester()
+                setContent {
+                    Column(Modifier.size(300.dp, 400.dp)) {
+                        BasicTextField(
+                            state = rememberTextFieldState(),
+                            modifier = Modifier
+                                .testTag("textField")
+                                .focusRequester(focusRequester)
+                        )
+                        LaunchedEffect(Unit) {
+                            focusRequester.requestFocus()
+                        }
+                        Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
+                    }
                 }
-                Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
-            }
-        }
 
-        onNodeWithTag("textField").assertIsFocused()
-        onNodeWithTag("box").performMouseInput { click() }
-        onNodeWithTag("textField").assertIsNotFocused()
-        onNode(isFocused()).assertDoesNotExist()
+                onNodeWithTag("textField").assertIsFocused()
+                onNodeWithTag("box").performMouseInput { click() }
+                onNodeWithTag("textField").assertIsNotFocused()
+                onNode(isFocused()).assertDoesNotExist()
+            }
+        } finally {
+            ComposeUiFlags.isClearFocusOnMouseDownEnabled = prevClearFocusOnMouseDownEnabled
+        }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -25,7 +25,7 @@ internal object SkikoComposeUiFlags {
 
     @Suppress("MutableBareField")
     @JvmField
-    var isClearFocusOnMouseDownEnabled: Boolean = true
+    var isClearFocusOnMouseDownEnabled: Boolean = false
 
     @Suppress("MutableBareField")
     @JvmField

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextFieldFocusTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextFieldFocusTest.kt
@@ -18,13 +18,13 @@ package androidx.compose.ui.input
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.TextField
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.background
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
@@ -42,15 +43,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
-import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.KeyboardEvent
-import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.pointerevents.PointerEvent
 import org.w3c.dom.pointerevents.PointerEventInit
 
@@ -161,32 +157,40 @@ class TextFieldFocusTest : OnCanvasTests {
     )
 
     @Test
-    fun mouseClickOutsideClearsFocusByDefault() = runApplicationTest {
-        val focusRequester = FocusRequester()
-        var focusState: FocusState? = null
+    fun mouseClickOutsideClearsFocusWithClearFocusOnMouseDownEnabled() {
+        val prevClearFocusOnMouseDownEnabled = ComposeUiFlags.isClearFocusOnMouseDownEnabled
+        ComposeUiFlags.isClearFocusOnMouseDownEnabled = true
+        try {
+            runApplicationTest {
+                val focusRequester = FocusRequester()
+                var focusState: FocusState? = null
 
-        createComposeWindow {
-            Column(Modifier.size(300.dp, 400.dp)) {
-                Box(Modifier.testTag("box").size(100.dp).background(Color.Gray))
-                BasicTextField(
-                    state = rememberTextFieldState(),
-                    modifier = Modifier
-                        .testTag("textField")
-                        .focusRequester(focusRequester)
-                        .onFocusChanged {
-                            focusState = it
+                createComposeWindow {
+                    Column(Modifier.size(300.dp, 400.dp)) {
+                        Box(Modifier.testTag("box").size(100.dp).background(Color.Gray))
+                        BasicTextField(
+                            state = rememberTextFieldState(),
+                            modifier = Modifier
+                                .testTag("textField")
+                                .focusRequester(focusRequester)
+                                .onFocusChanged {
+                                    focusState = it
+                                }
+                        )
+                        LaunchedEffect(Unit) {
+                            focusRequester.requestFocus()
                         }
-                )
-                LaunchedEffect(Unit) {
-                    focusRequester.requestFocus()
+                    }
                 }
-            }
-        }
-        assertTrue(focusState!!.isFocused, "Expected to be focused after requestFocus")
+                assertTrue(focusState!!.isFocused, "Expected to be focused after requestFocus")
 
-        dispatchEvents(mouseDownPointerEvent(50, 50))
-        awaitIdle()
-        assertFalse(focusState!!.isFocused, "Expected to lose focus after clicking outside")
+                dispatchEvents(mouseDownPointerEvent(50, 50))
+                awaitIdle()
+                assertFalse(focusState!!.isFocused, "Expected to lose focus after clicking outside")
+            }
+        } finally {
+            ComposeUiFlags.isClearFocusOnMouseDownEnabled = prevClearFocusOnMouseDownEnabled
+        }
     }
 
     @Test


### PR DESCRIPTION
Set `ComposeUiFlags.isClearFocusOnMouseDownEnabled` to `false` by default in order to preserve existing behavior.

Cherry-picked from https://github.com/JetBrains/compose-multiplatform-core/pull/3020

Fixes https://youtrack.jetbrains.com/issue/CMP-10390

## Testing
N/A

## Release Notes
### Features - Multiple Platforms
- _(prerelease fix)_ The `isClearFocusOnMouseDownEnabled` flag is now `false` by default.
