### PR TITLE
[web] Introduce separate test for composite input which invokes both autosuggestion and virtual keyboard

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
@@ -209,6 +209,48 @@ internal interface SafariCompositeInput : СompositeInputTestSpec {
             keyEvent(compositionInput, type = "keyup")
         )
     }
+
+    @Test
+    fun compositeWithSuggestionAndKeyboard() = runApplicationTest {
+        val textFieldValue = createApplicationWithHolder()
+
+        // Phase 1: input "我" via single-step composition
+        eventsSequence(
+            compositionStart(),
+            beforeInput("insertCompositionText", "我", isComposing = true),
+            beforeInput("deleteCompositionText", null, isComposing = true),
+            beforeInput("insertFromComposition", "我", isComposing = true),
+            compositionEnd("我"),
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("我")
+
+        // Phase 2: input "在" via single-step composition
+        eventsSequence(
+            compositionStart(),
+            beforeInput("insertCompositionText", "在", isComposing = true),
+            beforeInput("deleteCompositionText", null, isComposing = true),
+            beforeInput("insertFromComposition", "在", isComposing = true),
+            compositionEnd("在"),
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("我在")
+
+        // Phase 3: input "法国" via multi-step composition ("f" -> "f g" -> "法国")
+        eventsSequence(
+            compositionStart(),
+            keyEvent("f", keyCode = 229),
+            beforeInput("insertCompositionText", "f", isComposing = true),
+            keyEvent("g", keyCode = 229, isComposing = true),
+            beforeInput("insertCompositionText", "f g", isComposing = true),
+            beforeInput("insertCompositionText", "法国", isComposing = true),
+            beforeInput("deleteCompositionText", null, isComposing = true),
+            beforeInput("insertFromComposition", "法国", isComposing = true),
+            compositionEnd("法国"),
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("我在法国")
+    }
 }
 
 internal interface IosCompositeInput : СompositeInputTestSpec {


### PR DESCRIPTION
This is a separate test that mimics an iOS Safari behaviour of composite input that combines the autosuggestion and virtual keyboard input. The reasons for having this test are following:

1) We don't have test that covers this exact situation
2) In the branch with contenteditable DOM Backing Input this was most frequently failing scenario after each iteration of development. The idea to have it in master before the branch will be PR-ed 

based on iOS behaviour

## Testing
`./gradlew testWeb`

## Release Notes
N/A