### PR TITLE
Fix frame drops when dragging scrollable content

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.draganddrop.UIKitDragAndDropManager
 import androidx.compose.ui.geometry.Offset
@@ -481,6 +482,11 @@ internal class ComposeSceneMediator(
             nativeEvent = event,
             keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero)
         )
+
+        // Fixes the issue when the `sendPointerEvent` does not trigger `setNeedsRedraw` synchronously,
+        // which lead to frame drops during input.
+        // TODO: Remove after CMP-10411
+        Snapshot.sendApplyNotifications()
     }
 
     private fun onHoverEvent(
@@ -508,6 +514,11 @@ internal class ComposeSceneMediator(
             nativeEvent = event,
             keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero)
         )
+
+        // Fixes the issue when the `sendPointerEvent` does not trigger `setNeedsRedraw` synchronously,
+        // which lead to frame drops during input.
+        // TODO: Remove after CMP-10411
+        Snapshot.sendApplyNotifications()
     }
 
     private fun onCancelScroll() {
@@ -582,6 +593,11 @@ internal class ComposeSceneMediator(
             if (eventKind != TouchesEventKind.MOVED) {
                 previousTouchEventKind = eventKind
             }
+
+            // Fixes the issue when the `sendPointerEvent` does not trigger `setNeedsRedraw` synchronously,
+            // which lead to frame drops during input.
+            // TODO: Remove after CMP-10411
+            Snapshot.sendApplyNotifications()
         }
     }
     private var previousButtonMask: Long = 0L


### PR DESCRIPTION
On iOS it's required to receive invalidation synchronously right after input event processing, otherwise the invalidation won't trigger the closest frame to render. `sendApplyNotifications` performs all events that where scheduled during the touch processing.

Fixes https://youtrack.jetbrains.com/issue/CMP-10397/Compose-drops-frame-on-iOS-when-dragging

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix frame drops when dragging scrollable content