### PR TITLE
Add iOS instrumented tests run configuration script

### DIFF
--- a/.run/ios/iosInstrumentedTests.run.xml
+++ b/.run/ios/iosInstrumentedTests.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iOS Instrumented Tests" type="ShConfigurationType" factoryName="Shell Script" folderName="ios">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/compose/ui/ui/src/uikitInstrumentedTest/launcher" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -30,7 +30,8 @@ Run tests for iOS:
 ./gradlew :mpp:testIos'
 ```
 
-Run iOS instrumented tests.
+Run iOS instrumented tests on CI:
+
 Note: To ensure the test runs on an iOS simulator with a detached hardware keyboard,
 we must shut down all simulators and update the ConnectHardwareKeyboard flag.
 ```bash
@@ -42,6 +43,20 @@ cd compose/ui/ui/src/uikitInstrumentedTest/launcher
 
 xcodebuild test -scheme Launcher -project Launcher.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16'
 ```
+
+Run iOS instrumented tests:
+
+1. Choose which tests to run in [Configuration.kt](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt) or leave `setupXCTestSuite(...)` empty to run the full instrumented suite.
+2. Update the configuration values in `ios-instrumented-tests.sh` when you need a different simulator, OS version, number of iterations,...
+3. Run the instrumented tests:
+   - from the IDE run configuration `iOS Instrumented Tests`
+   - or from the repository root:
+```bash
+./compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
+```
+
+Run iOS instrumented tests.
+
 
 ### API checks
 

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -30,7 +30,7 @@ Run tests for iOS:
 ./gradlew :mpp:testIos'
 ```
 
-Run iOS instrumented tests on CI:
+Run iOS instrumented tests using CLI:
 
 Note: To ensure the test runs on an iOS simulator with a detached hardware keyboard,
 we must shut down all simulators and update the ConnectHardwareKeyboard flag.
@@ -44,19 +44,16 @@ cd compose/ui/ui/src/uikitInstrumentedTest/launcher
 xcodebuild test -scheme Launcher -project Launcher.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16'
 ```
 
-Run iOS instrumented tests:
+Run configured iOS instrumented tests from IDE or using CLI:
 
 1. Choose which tests to run in [Configuration.kt](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt) or leave `setupXCTestSuite(...)` empty to run the full instrumented suite.
 2. Update the configuration values in `ios-instrumented-tests.sh` when you need a different simulator, OS version, number of iterations,...
 3. Run the instrumented tests:
    - from the IDE run configuration `iOS Instrumented Tests`
-   - or from the repository root:
+   - or using CLI from the repository root:
 ```bash
 ./compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
 ```
-
-Run iOS instrumented tests.
-
 
 ### API checks
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/.gitignore
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/.gitignore
@@ -1,0 +1,3 @@
+# Xcode-derived outputs for local instrumented test launcher runs.
+build/
+tmp/

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/.gitignore
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/.gitignore
@@ -1,3 +1,0 @@
-# Xcode-derived outputs for local instrumented test launcher runs.
-build/
-tmp/

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
@@ -8,7 +8,6 @@ platform="iOS Simulator"
 os_version="26.5"
 device_name="iPhone 17"
 iterations="1"
-derived_data_path="./tmp/ios-instrumented-tests"
 open_result="false"
 # `run_until_failure` is applied only when iterations > 1.
 run_until_failure="false"
@@ -36,8 +35,9 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$script_dir"
 
-mkdir -p "$derived_data_path"
-results_dir="${derived_data_path%/}/results"
+results_root="${TMPDIR%/}/ios-instrumented-tests-results"
+mkdir -p "$results_root"
+results_dir="$(mktemp -d "${results_root%/}/run-${USER:-user}-XXXXXX")"
 mkdir -p "$results_dir"
 
 timestamp="$(date '+%Y-%m-%d-%H-%M-%S')"
@@ -47,7 +47,7 @@ destination="platform=${platform},OS=${os_version},name=${device_name}"
 echo "Running iOS instrumented tests with:"
 echo "  destination: ${destination}"
 echo "  iterations: ${iterations}"
-echo "  derivedDataPath: ${derived_data_path}"
+echo "  derivedDataPath: Xcode default"
 echo "  resultBundlePath: ${result_bundle_path}"
 
 # The keyboard preference is picked up when a simulator boots, so shut them all down
@@ -60,7 +60,6 @@ xcodebuild \
   -project Launcher.xcodeproj \
   -scheme Launcher \
   -destination "$destination" \
-  -derivedDataPath "$derived_data_path" \
   build-for-testing
 
 test_args=(
@@ -88,7 +87,6 @@ xcodebuild \
   -project Launcher.xcodeproj \
   -scheme Launcher \
   -destination "$destination" \
-  -derivedDataPath "$derived_data_path" \
   test-without-building \
   "${test_args[@]}"
 test_exit_code=$?

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
@@ -8,7 +8,6 @@ platform="iOS Simulator"
 os_version="26.5"
 device_name="iPhone 17"
 iterations="1"
-open_result="false"
 # `run_until_failure` is applied only when iterations > 1.
 run_until_failure="false"
 
@@ -22,11 +21,6 @@ if [[ ! "$iterations" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
-if [[ "$open_result" != "true" && "$open_result" != "false" ]]; then
-  echo "open_result must be true or false, got: $open_result" >&2
-  exit 1
-fi
-
 if [[ "$run_until_failure" != "true" && "$run_until_failure" != "false" ]]; then
   echo "run_until_failure must be true or false, got: $run_until_failure" >&2
   exit 1
@@ -35,20 +29,12 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$script_dir"
 
-results_root="${TMPDIR%/}/ios-instrumented-tests-results"
-mkdir -p "$results_root"
-results_dir="$(mktemp -d "${results_root%/}/run-${USER:-user}-XXXXXX")"
-mkdir -p "$results_dir"
-
-timestamp="$(date '+%Y-%m-%d-%H-%M-%S')"
-result_bundle_path="${results_dir}/${timestamp}.xcresult"
 destination="platform=${platform},OS=${os_version},name=${device_name}"
 
 echo "Running iOS instrumented tests with:"
 echo "  destination: ${destination}"
 echo "  iterations: ${iterations}"
 echo "  derivedDataPath: Xcode default"
-echo "  resultBundlePath: ${result_bundle_path}"
 
 # The keyboard preference is picked up when a simulator boots, so shut them all down
 # before forcing the detached-keyboard setup required by these instrumented tests.
@@ -64,7 +50,6 @@ xcodebuild \
 
 test_args=(
   -collect-test-diagnostics on-failure
-  -resultBundlePath "$result_bundle_path"
 )
 
 if [[ "$iterations" -gt 1 ]]; then
@@ -91,12 +76,5 @@ xcodebuild \
   "${test_args[@]}"
 test_exit_code=$?
 set -e
-
-if [[ -d "$result_bundle_path" ]]; then
-  echo "xcresult bundle: $result_bundle_path"
-  if [[ "$open_result" == "true" ]]; then
-    open "$result_bundle_path"
-  fi
-fi
 
 exit "$test_exit_code"

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Edit these values directly when you want to change the target simulator or run count.
+platform="iOS Simulator"
+os_version="26.5"
+device_name="iPhone 17"
+iterations="1"
+derived_data_path="./tmp/ios-instrumented-tests"
+open_result="false"
+run_until_failure="false"
+
+if [[ -z "$platform" || -z "$os_version" || -z "$device_name" ]]; then
+  echo "Platform, OS, and device name must be non-empty." >&2
+  exit 1
+fi
+
+if [[ ! "$iterations" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Iterations must be a positive integer, got: $iterations" >&2
+  exit 1
+fi
+
+if [[ "$open_result" != "true" && "$open_result" != "false" ]]; then
+  echo "open_result must be true or false, got: $open_result" >&2
+  exit 1
+fi
+
+if [[ "$run_until_failure" != "true" && "$run_until_failure" != "false" ]]; then
+  echo "run_until_failure must be true or false, got: $run_until_failure" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+mkdir -p "$derived_data_path"
+results_dir="${derived_data_path%/}/results"
+mkdir -p "$results_dir"
+
+timestamp="$(date '+%Y-%m-%d-%H-%M-%S')"
+result_bundle_path="${results_dir}/${timestamp}.xcresult"
+destination="platform=${platform},OS=${os_version},name=${device_name}"
+
+echo "Running iOS instrumented tests with:"
+echo "  destination: ${destination}"
+echo "  iterations: ${iterations}"
+echo "  derivedDataPath: ${derived_data_path}"
+echo "  resultBundlePath: ${result_bundle_path}"
+
+xcodebuild \
+  -project Launcher.xcodeproj \
+  -scheme Launcher \
+  -destination "$destination" \
+  -derivedDataPath "$derived_data_path" \
+  build-for-testing
+
+test_args=(
+  -collect-test-diagnostics on-failure
+  -resultBundlePath "$result_bundle_path"
+)
+
+if [[ "$iterations" -gt 1 ]]; then
+  test_args=(
+    -test-iterations "$iterations"
+    -test-repetition-relaunch-enabled YES
+    "${test_args[@]}"
+  )
+
+  if [[ "$run_until_failure" == "true" ]]; then
+    test_args=(
+      -run-tests-until-failure
+      "${test_args[@]}"
+    )
+  fi
+fi
+
+set +e
+xcodebuild \
+  -project Launcher.xcodeproj \
+  -scheme Launcher \
+  -destination "$destination" \
+  -derivedDataPath "$derived_data_path" \
+  test-without-building \
+  "${test_args[@]}"
+test_exit_code=$?
+set -e
+
+if [[ -d "$result_bundle_path" ]]; then
+  echo "xcresult bundle: $result_bundle_path"
+  if [[ "$open_result" == "true" ]]; then
+    open "$result_bundle_path"
+  fi
+fi
+
+exit "$test_exit_code"

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/ios-instrumented-tests.sh
@@ -3,12 +3,14 @@
 set -euo pipefail
 
 # Edit these values directly when you want to change the target simulator or run count.
+# Use `xcrun xctrace list devices` to find the simulator names and OS versions available locally.
 platform="iOS Simulator"
 os_version="26.5"
 device_name="iPhone 17"
 iterations="1"
 derived_data_path="./tmp/ios-instrumented-tests"
 open_result="false"
+# `run_until_failure` is applied only when iterations > 1.
 run_until_failure="false"
 
 if [[ -z "$platform" || -z "$os_version" || -z "$device_name" ]]; then
@@ -48,6 +50,12 @@ echo "  iterations: ${iterations}"
 echo "  derivedDataPath: ${derived_data_path}"
 echo "  resultBundlePath: ${result_bundle_path}"
 
+# The keyboard preference is picked up when a simulator boots, so shut them all down
+# before forcing the detached-keyboard setup required by these instrumented tests.
+xcrun simctl shutdown all
+defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+
+# Build once, then reuse the build products for the actual test execution.
 xcodebuild \
   -project Launcher.xcodeproj \
   -scheme Launcher \


### PR DESCRIPTION
Adds iOS instrumented tests run configuration script.

We can
- run iOS instrumented tests from IDE
- conveniently configure test parameters such as the number of iterations, OS version, device name 

## Release Notes
N/A
