### PR TITLE
CoreTextField: Trigger relayout when stale fonts are detected in measure step

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -628,6 +628,11 @@ internal fun CoreTextField(
                                         layoutDirection,
                                         prevResult,
                                     )
+
+                                // ensure measure restarts
+                                // when hasStaleResolvedFonts by reading in measure
+                                result.multiParagraph.intrinsics.hasStaleResolvedFonts
+
                                 if (prevResult != result) {
                                     state.layoutResult =
                                         TextLayoutResultProxy(


### PR DESCRIPTION
Original: https://github.com/JetBrains/compose-multiplatform-core/pull/3179

Fixes https://youtrack.jetbrains.com/issue/CMP-10323

## Release Notes
### Fixes - Web
- Fix of tofu symbols during a first draw in TextFields with unknown symbols