### PR TITLE
Convert UIKit keyboard animation curve to UIViewAnimationOptions

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/KeyboardVisibilityListener.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/KeyboardVisibilityListener.ios.kt
@@ -144,6 +144,9 @@ private class NativeKeyboardVisibilityListener : NSObject() {
     private val NSNotification.animationOptions: UIViewAnimationOptions
         get() {
             val value = userInfo?.get(UIKeyboardAnimationCurveUserInfoKey) as? NSNumber
-            return value?.unsignedIntegerValue() ?: UIViewAnimationOptionCurveEaseInOut
+            // Convert the animation curve constant to animation options.
+            // See https://developer.apple.com/documentation/uikit/uiresponder/keyboardanimationcurveuserinfokey
+            return value?.unsignedIntegerValue()?.let { it shl 16 }
+                ?: UIViewAnimationOptionCurveEaseInOut
         }
 }


### PR DESCRIPTION
Convert the UIKit keyboard animation curve from `UIKeyboardAnimationCurveUserInfoKey`
to `UIViewAnimationOptions` before passing it to `UIView.animateWithDuration`.

`UIKeyboardAnimationCurveUserInfoKey` contains a `UIViewAnimationCurve` raw value,
while `UIViewAnimationOptions` stores animation curve values in the curve option
bit field. Without shifting the value, non-default curves may be interpreted as
unrelated low-order animation options.

Fixes: https://youtrack.jetbrains.com/issue/CMP-10448/Incorrect-keyboard-animation-curve

## Source

SDK Header:

```h
typedef NS_OPTIONS(NSUInteger, UIViewAnimationOptions) {
    ...
    UIViewAnimationOptionCurveEaseInOut            = 0 << 16, // default
    UIViewAnimationOptionCurveEaseIn               = 1 << 16,
    UIViewAnimationOptionCurveEaseOut              = 2 << 16,
    UIViewAnimationOptionCurveLinear               = 3 << 16,  
    ...  
} API_AVAILABLE(ios(4.0)) API_UNAVAILABLE(watchos);
```

Apple Documentation:
https://developer.apple.com/documentation/uikit/uiresponder/keyboardanimationcurveuserinfokey 

## Testing

Not run; this is a small UIKit interop conversion fix and preserves the existing
fallback behavior for missing animation curve info.

## Release Notes

### Fixes - iOS
- Fixed UIKit keyboard animation curve handling by converting `UIKeyboardAnimationCurveUserInfoKey` values to `UIViewAnimationOptions`.

## Google CLA

Sign the Google Contributor's License Agreement at https://cla.developers.google.com to let us upstream your code to Google's AOSP repository