### PR TITLE
buildSrc-fork. Fork more files

### DIFF
--- a/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/build.gradle
+++ b/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/build.gradle
@@ -1,0 +1,15 @@
+// Plugin needs to be in a separate sub-project to avoid breaking task up-to-dateness due to
+// https://github.com/gradle/gradle/issues/34848
+plugins {
+    id("java-gradle-plugin")
+    id("groovy")
+}
+
+gradlePlugin {
+    plugins {
+        androidXHostTestFailureHandlerPlugin {
+            id = "AndroidXHostTestFailureHandlerPlugin"
+            implementationClass = "androidx.build.AndroidXHostTestFailureHandlerPluginStub"
+        }
+    }
+}

--- a/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/build.gradle
+++ b/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/build.gradle
@@ -1,5 +1,3 @@
-// Plugin needs to be in a separate sub-project to avoid breaking task up-to-dateness due to
-// https://github.com/gradle/gradle/issues/34848
 plugins {
     id("java-gradle-plugin")
     id("groovy")

--- a/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/src/main/groovy/androidx/build/AndroidXHostTestFailureHandlerPluginStub.groovy
+++ b/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/src/main/groovy/androidx/build/AndroidXHostTestFailureHandlerPluginStub.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2025 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package androidx.build
 
 import org.gradle.api.Plugin

--- a/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/src/main/groovy/androidx/build/AndroidXHostTestFailureHandlerPluginStub.groovy
+++ b/androidx-settings-plugins-fork/hostTestFailureHandlerPlugin/src/main/groovy/androidx/build/AndroidXHostTestFailureHandlerPluginStub.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package org.jetbrains.androidx.build
+package androidx.build
 
-import androidx.build.getSupportRootFolder
 import org.gradle.api.Plugin
-import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
 
-class JetBrainsAndroidXPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        val supportRoot = project.getSupportRootFolder()
-        project.apply(
-            mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc-fork/apply/applyJetBrainsAndroidXImplPlugin.gradle"
-            )
-        )
+/**
+ * A stub of plugin that is applied in the root AOSP settings.gradle,
+ * but not needed in settings-fork.gradle, where plugins not applied
+ */
+@SuppressWarnings("unused")
+abstract class AndroidXHostTestFailureHandlerPluginStub implements Plugin<Settings> {
+    @Override
+    void apply(Settings settings) {
     }
 }

--- a/androidx-settings-plugins-fork/settings.gradle
+++ b/androidx-settings-plugins-fork/settings.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright 2025 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 apply from: "../buildSrc-fork/settingsScripts/out-setup.groovy"
 
 getGradle().beforeProject { project ->

--- a/androidx-settings-plugins-fork/settings.gradle
+++ b/androidx-settings-plugins-fork/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
-package org.jetbrains.androidx.build
+apply from: "../buildSrc-fork/settingsScripts/out-setup.groovy"
 
-import androidx.build.getSupportRootFolder
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-
-class JetBrainsAndroidXPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        val supportRoot = project.getSupportRootFolder()
-        project.apply(
-            mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc-fork/apply/applyJetBrainsAndroidXImplPlugin.gradle"
-            )
-        )
-    }
+getGradle().beforeProject { project ->
+    def checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
+    init.chooseBuildDirectory(checkoutRoot, rootProject.name, project)
 }
+
+include ":hostTestFailureHandlerPlugin"

--- a/build-fork.gradle
+++ b/build-fork.gradle
@@ -29,7 +29,7 @@ buildscript {
     SdkHelperKt.setSupportRootFolder(project, project.projectDir)
 
     // Needed for atomicfu plugin
-    apply(from: "buildSrc/repos.gradle")
+    apply(from: "buildSrc-fork/repos.gradle")
     repos.addMavenRepositories(repositories)
 }
 

--- a/buildSrc-fork/apply/applyAndroidXComposeImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXComposeImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.AndroidXComposeImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXComposeImplPlugin

--- a/buildSrc-fork/apply/applyAndroidXDocsImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXDocsImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.docs.AndroidXDocsImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXDocsImplPlugin

--- a/buildSrc-fork/apply/applyAndroidXImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.AndroidXImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXImplPlugin

--- a/buildSrc-fork/apply/applyAndroidXPlaygroundRootImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXPlaygroundRootImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.AndroidXPlaygroundRootImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXPlaygroundRootImplPlugin

--- a/buildSrc-fork/apply/applyAndroidXRepackageImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXRepackageImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.AndroidXRepackageImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXRepackageImplPlugin

--- a/buildSrc-fork/apply/applyAndroidXRootImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyAndroidXRootImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.AndroidXRootImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: AndroidXRootImplPlugin

--- a/buildSrc-fork/apply/applyJetBrainsAndroidXImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyJetBrainsAndroidXImplPlugin.gradle
@@ -1,0 +1,9 @@
+import org.jetbrains.androidx.build.JetBrainsAndroidXImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: JetBrainsAndroidXImplPlugin

--- a/buildSrc-fork/apply/applyJetBrainsAndroidXRootImplPlugin.gradle
+++ b/buildSrc-fork/apply/applyJetBrainsAndroidXRootImplPlugin.gradle
@@ -1,0 +1,9 @@
+import org.jetbrains.androidx.build.JetBrainsAndroidXRootImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.ext["outDir"]}/buildSrc-fork/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: JetBrainsAndroidXRootImplPlugin

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXComposePlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXComposePlugin.kt
@@ -25,7 +25,7 @@ class AndroidXComposePlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXComposeImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXComposeImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
@@ -33,7 +33,7 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXPlaygroundRootImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXPlaygroundRootImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXPlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXPlugin.kt
@@ -32,7 +32,7 @@ class AndroidXPlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXRepackagePlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXRepackagePlugin.kt
@@ -31,7 +31,7 @@ abstract class AndroidXRepackagePlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXRepackageImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXRepackageImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXRootPlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/AndroidXRootPlugin.kt
@@ -31,7 +31,7 @@ abstract class AndroidXRootPlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXRootImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXRootImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/androidx/build/docs/AndroidXDocsPlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/androidx/build/docs/AndroidXDocsPlugin.kt
@@ -32,7 +32,7 @@ class AndroidXDocsPlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyAndroidXDocsImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyAndroidXDocsImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc-fork/plugins/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootPlugin.kt
+++ b/buildSrc-fork/plugins/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootPlugin.kt
@@ -28,7 +28,7 @@ abstract class JetBrainsAndroidXRootPlugin : Plugin<Project> {
         val supportRoot = project.getSupportRootFolder()
         project.apply(
             mapOf<String, String>(
-                "from" to "$supportRoot/buildSrc/apply/applyJetBrainsAndroidXRootImplPlugin.gradle"
+                "from" to "$supportRoot/buildSrc-fork/apply/applyJetBrainsAndroidXRootImplPlugin.gradle"
             )
         )
     }

--- a/buildSrc/build-fork.gradle
+++ b/buildSrc/build-fork.gradle
@@ -1,6 +1,6 @@
 buildscript {
     project.ext.supportRootFolder = project.projectDir.getParentFile()
-    apply from: "repos.gradle"
+    apply from: "../buildSrc-fork/repos.gradle"
     repos.addMavenRepositories(repositories)
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 }
 
 ext.supportRootFolder = project.projectDir.getParentFile()
-apply from: "repos.gradle"
+apply from: "../buildSrc-fork/repos.gradle"
 apply plugin: "kotlin"
 
 repos.addMavenRepositories(repositories)

--- a/buildSrc/settings-fork.gradle
+++ b/buildSrc/settings-fork.gradle
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-rootProject.buildFileName = "../buildSrc-fork/build.gradle"
+rootProject.name = "buildSrc-fork"
+rootProject.buildFileName = "build-fork.gradle"
 
 dependencyResolutionManagement {
     // the default libs.version.toml is automatically registered by Gradle under `libs` name.

--- a/placeholder-fork/settings.gradle
+++ b/placeholder-fork/settings.gradle
@@ -1,0 +1,6 @@
+apply from: "../buildSrc-fork/settingsScripts/out-setup.groovy"
+getGradle().beforeProject { project ->
+    init.chooseBuildDirectory(
+            new File("${buildscript.sourceFile.parent}/.."), rootProject.name, project
+    )
+}

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -492,7 +492,7 @@ includeProject(":internal-testutils-mockito", "testutils/testutils-mockito")
 includeProject(":internal-testutils-xctest", "testutils/testutils-xctest")
 
 // Workaround for b/203825166
-includeBuild("placeholder")
+includeBuild("placeholder-fork")
 
 includeProject(":mpp")
 

--- a/settings-plugin-management-fork.gradle
+++ b/settings-plugin-management-fork.gradle
@@ -7,6 +7,6 @@ ext.configureForkPluginManagement = { PluginManagementSpec pluginManagement ->
                 url = "https://plugins.gradle.org/m2/"
             }
         }
-        includeBuild("androidx-settings-plugins")
+        includeBuild("androidx-settings-plugins-fork")
     }
 }


### PR DESCRIPTION
Part of https://youtrack.jetbrains.com/issue/CMP-10017/Simplify-merges-short-term.-Make-buildSrc-build.gradle-for-the-fork-mode

There were files that were not forked and mistakenly reused from the original build

## Release Notes
N/A