### PR TITLE
[Cherry pick] Prevent `NavigationDrawer` drags during swipe-back (#3165)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
@@ -86,15 +86,10 @@ internal class UIKitNavigationEventInput(
         action = NSSelectorFromString(UiKitScreenEdgePanGestureHandler::handleEdgePan.name + ":")
     )
 
-    private val activeGestureStates = listOf(
-        UIGestureRecognizerStateBegan,
-        UIGestureRecognizerStateChanged
-    )
-
-    val isBackGestureActive: Boolean
+    val isBackGestureTrackingTouches: Boolean
         get() =
-            startEdgePanGestureRecognizer.state in activeGestureStates ||
-                endEdgePanGestureRecognizer.state in activeGestureStates
+            startEdgePanGestureRecognizer.isTrackingTouches ||
+                endEdgePanGestureRecognizer.isTrackingTouches
 
     init {
         updateRecognizers()
@@ -312,3 +307,13 @@ internal class UIKitBackGestureRecognizer(
         return true
     }
 }
+
+private val UIGestureRecognizer.isTrackingTouches: Boolean
+    get() =
+        numberOfTouches > 0uL && !isInTerminalState
+
+private val UIGestureRecognizer.isInTerminalState: Boolean
+    get() =
+        state == UIGestureRecognizerStateFailed ||
+            state == UIGestureRecognizerStateCancelled ||
+            state == UIGestureRecognizerStateEnded

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -312,7 +312,7 @@ internal class ComposeSceneMediator(
         onCancelScroll = ::onCancelScroll,
         onHoverEvent = ::onHoverEvent,
         onKeyboardPresses = ::onKeyboardPresses,
-        ignoreTouchChanges = navigationEventInput::isBackGestureActive,
+        ignoreTouchChanges = navigationEventInput::isBackGestureTrackingTouches,
         onRemoveSubview = {
             CoroutineScope(coroutineContext).launch {
                 finishUnattachedKeysPresses()
@@ -333,7 +333,7 @@ internal class ComposeSceneMediator(
         isPointInsideInteractionBounds = ::isPointInsideInteractionBounds,
         onTouchesEvent = ::onTouchesEvent,
         onCancelAllTouches = ::onCancelAllTouches,
-        ignoreTouchChanges = navigationEventInput::isBackGestureActive
+        ignoreTouchChanges = navigationEventInput::isBackGestureTrackingTouches
     )
 
     val backgroundView: UIView get() = _backgroundView

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SwipeBackTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SwipeBackTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.findNodeWithTag
+import androidx.compose.ui.test.findNodeWithTagOrNull
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.hold
+import androidx.compose.ui.test.utils.leftCenter
+import androidx.compose.ui.test.utils.offsetBy
+import androidx.compose.ui.test.utils.rightCenter
+import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.unit.dp
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.NavigationEventTransitionState
+import androidx.navigationevent.NavigationEventTransitionState.InProgress
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+internal class SwipeBackInHostingViewTest : SwipeBackTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = true, it) }
+)
+
+internal class SwipeBackInHostingViewControllerTest : SwipeBackTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = false, it) }
+)
+
+internal abstract class SwipeBackTest(
+    private val runUIKitInstrumentedTest: (UIKitInstrumentedTest.() -> Unit) -> Unit
+) {
+    @Test
+    fun edgeBackSwipeDoesNotDispatchHorizontalDragToCompose() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it },
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        waitUntil("drag surface should be ready") {
+            findNodeWithTagOrNull(DRAG_SURFACE) != null &&
+                !dragDistance.isNaN() &&
+                backCompletedCount == 0
+        }
+
+        val backSwipe = swipeRightFromEdge().hold()
+
+        waitUntil("back swipe should be in progress") {
+            transitionState is InProgress
+        }
+
+        assertEquals(
+            expected = 0f,
+            actual = dragDistance,
+            absoluteTolerance = 0.01f,
+            message = "Edge back swipe should not dispatch horizontal drag deltas to Compose"
+        )
+        assertEquals(
+            expected = 0,
+            actual = backCompletedCount,
+            message = "Back gesture should not complete before release"
+        )
+
+        backSwipe.up()
+
+        waitUntil("back swipe should complete after release") {
+            backCompletedCount == 1
+        }
+    }
+
+    @Test
+    fun innerSwipeDispatchesHorizontalDragWithoutStartingBack() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it },
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        waitUntil("drag surface should be ready") {
+            findNodeWithTagOrNull(DRAG_SURFACE) != null &&
+                !dragDistance.isNaN() &&
+                backCompletedCount == 0
+        }
+
+        findNodeWithTag(DRAG_SURFACE).swipe(
+            fromPosition = { leftCenter().offsetBy(dx = 16.dp) },
+            toPosition = { rightCenter().offsetBy(dx = (-16).dp) }
+        )
+
+        waitUntil("inner swipe should dispatch drag deltas to Compose") {
+            dragDistance > 0f
+        }
+        assertFalse(
+            transitionState is InProgress,
+            "Inner swipe should not start back navigation"
+        )
+        assertEquals(
+            expected = 0,
+            actual = backCompletedCount,
+            message = "Inner swipe should not complete back navigation"
+        )
+    }
+}
+
+@Composable
+private fun TestContent(
+    onDragDistanceChanged: (Float) -> Unit,
+    onTransitionStateChanged: (NavigationEventTransitionState) -> Unit,
+    onBackCompletedCountChanged: (Int) -> Unit,
+) {
+    var dragDistance by remember { mutableFloatStateOf(0f) }
+    var backCompletedCount by remember { mutableIntStateOf(0) }
+    val navigationEventState = rememberNavigationEventState<NavigationEventInfo>(
+        currentInfo = NavigationEventInfo.None,
+        backInfo = listOf<NavigationEventInfo>(NavigationEventInfo.None)
+    )
+
+    onDragDistanceChanged(dragDistance)
+    onTransitionStateChanged(navigationEventState.transitionState)
+    onBackCompletedCountChanged(backCompletedCount)
+
+    NavigationBackHandler(
+        state = navigationEventState,
+        onBackCompleted = {
+            backCompletedCount += 1
+        }
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(DRAG_SURFACE)
+            .draggable(
+                state = rememberDraggableState { delta ->
+                    dragDistance += delta
+                },
+                orientation = Orientation.Horizontal,
+            )
+    )
+}
+
+private const val DRAG_SURFACE = "dragSurface"

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitNavigationSwipeBackTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitNavigationSwipeBackTest.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.test.findNodeWithTagOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.center
 import androidx.compose.ui.test.utils.rightCenter
+import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -109,7 +110,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = mutableIntStateOf(1))
         }
 
-        swipeRightFromEdge()
+        swipeRightFromEdge().up()
 
         waitForPopped(viewControllerHostingCompose)
     }
@@ -167,7 +168,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        swipeRightFromEdge()
+        swipeRightFromEdge().up()
 
         waitForPopped(viewControllerHostingCompose)
     }
@@ -257,7 +258,6 @@ private fun TestContent(
                 .weight(1f)
                 .testTag("pager")
         ) { page ->
-            currentPage.value = page
             Box(modifier = Modifier
                 .fillMaxSize()
                 .background(pagerColors[page])

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -412,28 +412,31 @@ internal class UIKitInstrumentedTest(
      * @param position The position on the window.
      * @param window will be used to handle touches; otherwise,
      * the window hosting the view will be used.
+     * @param fromEdge If true, the touch will be simulated from the edge of the screen.
      * @return A UITouch object representing the touch interaction.
      */
     fun touchDown(position: DpOffset, window: UIWindow? = null, fromEdge: Boolean = false): UITouch {
         return getTargetWindow(position, window).touchDown(position, fromEdge)
     }
 
-    private val EdgeSwipeDuration = 200.milliseconds
+    private val EdgeSwipeDuration = 500.milliseconds
 
-    fun swipeRightFromEdge() {
+    fun swipeRightFromEdge(
+        duration: Duration = EdgeSwipeDuration,
+    ): UITouch {
         val swipeToLocation = screenBounds.rightCenter().offsetBy(dx = (-16).dp)
 
-        touchDown(screenBounds.leftCenter(), fromEdge = true)
-            .dragTo(swipeToLocation, duration = EdgeSwipeDuration)
-            .up()
+        return touchDown(screenBounds.leftCenter(), fromEdge = true)
+            .dragTo(swipeToLocation, duration = duration)
     }
 
-    fun swipeLeftFromEdge() {
+    fun swipeLeftFromEdge(
+        duration: Duration = EdgeSwipeDuration,
+    ): UITouch {
         val swipeToLocation = screenBounds.leftCenter().offsetBy(dx = 16.dp)
 
-        touchDown(screenBounds.rightCenter(), fromEdge = true)
-            .dragTo(swipeToLocation, duration = EdgeSwipeDuration)
-            .up()
+        return touchDown(screenBounds.rightCenter(), fromEdge = true)
+            .dragTo(swipeToLocation, duration = duration)
     }
 
     /**
@@ -666,11 +669,11 @@ internal class UIKitInstrumentedTest(
     }
 
     fun AccessibilityTestNode.swipeRight(fromEdge: Boolean = false, duration: Duration = SwipeDuration) {
-        swipe(fromPosition = { center() }, toPosition = { rightCenter() }, fromEdge = fromEdge, duration = duration)
+        swipe(fromPosition = { leftCenter().offsetBy(dx = 16.dp) }, toPosition = { rightCenter().offsetBy(dx = (-16).dp) }, fromEdge = fromEdge, duration = duration)
     }
 
     fun AccessibilityTestNode.swipeLeft(fromEdge: Boolean = false, duration: Duration = SwipeDuration) {
-        swipe(fromPosition = { center() }, toPosition = { leftCenter() }, fromEdge = fromEdge, duration = duration)
+        swipe(fromPosition = { rightCenter().offsetBy(dx = (-16).dp) }, toPosition = { leftCenter().offsetBy(dx = 16.dp) }, fromEdge = fromEdge, duration = duration)
     }
 }
 


### PR DESCRIPTION
Treat the UIKit back gesture as active as soon as UIKit starts tracking edge touches, so that horizontal drag input is not consumed by Compose during swipe-back.

- Fixes [CMP-10103](https://youtrack.jetbrains.com/issue/CMP-10103) Navigating back with a navigating drawer
- Fixes flaky tests by fixing a bug in `UIKitNavigationSwipeBackTest`

## Testing
Adds `SwipeBackTest` test suite.

## Release Notes
### Fixes - iOS
- Fix UIKit back gesture briefly dispatched drag input to Compose content, causing UI like navigation drawers to appear during back navigation