### PR TITLE
Rely on RenderNode to apply alpha

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -317,12 +317,6 @@ actual class GraphicsLayer internal constructor(
     ) {
         this.size = size
         recordWithTracking { canvas ->
-            // FIXME: Remove it to fix https://youtrack.jetbrains.com/issue/CMP-10436
-            canvas.alphaMultiplier = if (compositingStrategy == CompositingStrategy.ModulateAlpha) {
-                this@GraphicsLayer.alpha
-            } else {
-                1.0f
-            }
             pictureDrawScope.draw(
                 density = density,
                 layoutDirection = layoutDirection,

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
 import kotlin.math.roundToInt
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -52,6 +53,7 @@ import kotlin.test.assertTrue
 import org.jetbrains.skia.IRect
 import org.jetbrains.skia.Surface
 
+// Adopted copy from AndroidGraphicsLayerTest
 @OptIn(InternalComposeUiApi::class)
 class SkiaGraphicsLayerTest {
 
@@ -688,10 +690,6 @@ class SkiaGraphicsLayerTest {
             block = { graphicsContext ->
                 layer =
                     graphicsContext.createGraphicsLayer().apply {
-                        // FIXME: Move it after `record` block to match android
-                        //  https://youtrack.jetbrains.com/issue/CMP-10436
-                        compositingStrategy = CompositingStrategy.ModulateAlpha
-                        alpha = 0.5f
                         record {
                             inset(0f, 0f, size.width / 3, size.height / 3) {
                                 drawRect(color = Color.Red)
@@ -700,8 +698,8 @@ class SkiaGraphicsLayerTest {
                                 drawRect(color = Color.Blue)
                             }
                         }
-//                        alpha = 0.5f
-//                        compositingStrategy = CompositingStrategy.ModulateAlpha
+                        alpha = 0.5f
+                        compositingStrategy = CompositingStrategy.ModulateAlpha
                     }
                 drawRect(bgColor)
                 drawLayer(layer!!)


### PR DESCRIPTION
Requires https://github.com/JetBrains/skiko/pull/1227
Fixes [CMP-10436](https://youtrack.jetbrains.com/issue/CMP-10436) [skiko/iOS] CompositingStrategy.ModulateAlpha bakes alpha into the recorded picture at record time; animating alpha leaves content invisible until next content invalidation

## Release Notes
### Fixes - Multiple Platforms
- Fixes that `GraphicsLayer` with `CompositingStrategy.ModulateAlpha` does not apply `alpha` value without extra invalidation.
