### PR TITLE
[Cherry-pick] Update back gesture layout direction handling on iOS (#3188)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.ios.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.uikit.utils.CMPScreenEdgePanGestureRecognizer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
@@ -45,7 +46,6 @@ import platform.UIKit.UIGestureRecognizerStateFailed
 import platform.UIKit.UIRectEdgeLeft
 import platform.UIKit.UIRectEdgeRight
 import platform.UIKit.UIScreenEdgePanGestureRecognizer
-import platform.UIKit.UIUserInterfaceLayoutDirection.*
 import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 import platform.darwin.NSObject
@@ -53,6 +53,7 @@ import platform.darwin.NSUIntegerMax
 
 internal class UIKitNavigationEventInput(
     private val density: Density,
+    initialLayoutDirection: LayoutDirection,
     private val endEdgePanGestureBehavior: EndEdgePanGestureBehavior,
     private val getTopLeftOffsetInWindow: () -> IntOffset
 ) : BackNavigationEventInput() {
@@ -67,7 +68,7 @@ internal class UIKitNavigationEventInput(
             field = value
             updateRecognizers()
         }
-    private var isRtlEnabled: Boolean = false
+    var layoutDirection: LayoutDirection = initialLayoutDirection
         set(value) {
             if (field == value) return
             field = value
@@ -96,8 +97,16 @@ internal class UIKitNavigationEventInput(
     }
 
     private fun updateRecognizers() {
-        startEdgePanGestureRecognizer.edges = if (!isRtlEnabled) UIRectEdgeLeft else UIRectEdgeRight
-        endEdgePanGestureRecognizer.edges = if (isRtlEnabled) UIRectEdgeLeft else UIRectEdgeRight
+        when (layoutDirection) {
+            LayoutDirection.Ltr -> {
+                startEdgePanGestureRecognizer.edges = UIRectEdgeLeft
+                endEdgePanGestureRecognizer.edges = UIRectEdgeRight
+            }
+            LayoutDirection.Rtl -> {
+                startEdgePanGestureRecognizer.edges = UIRectEdgeRight
+                endEdgePanGestureRecognizer.edges = UIRectEdgeLeft
+            }
+        }
 
         if (isRecognizersEnabled) {
             startEdgePanGestureRecognizer.enabled = true
@@ -116,8 +125,6 @@ internal class UIKitNavigationEventInput(
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         removeGestureListeners()
         if (window != null) {
-            isRtlEnabled =
-                composeRootView.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft
             var view: UIView = composeRootView
             while (view.superview != window) {
                 view = requireNotNull(view.superview) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -64,7 +64,10 @@ import platform.Foundation.removeObserver
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
 import platform.UIKit.UIApplication
 import platform.UIKit.UIResponder
+import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceLayoutDirection
+import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionLeftToRight
+import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionRightToLeft
 import platform.UIKit.UIUserInterfaceStyle
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
@@ -88,7 +91,12 @@ internal class ComposeContainer(
     private var mediator: ComposeSceneMediator? = null
     private val windowContext = PlatformWindowContext()
     private var layersHolder: ComposeLayersHolder? = null
-    private val layoutDirection get() = getApplicationLayoutDirection()
+    private var layoutDirection = getApplicationLayoutDirection()
+        set(value) {
+            field = value
+            mediator?.layoutDirection = value
+            navigationEventInput.layoutDirection = value
+        }
     private val motionDurationScale = MotionDurationScaleImpl()
     private var activeStateListener: SceneActiveStateListener? = null
     private var sceneJob: Job = Job().also {
@@ -108,6 +116,7 @@ internal class ComposeContainer(
     }
     private val navigationEventInput = UIKitNavigationEventInput(
         density = view.density,
+        initialLayoutDirection = layoutDirection,
         getTopLeftOffsetInWindow = { IntOffset.Zero }, //full screen
         endEdgePanGestureBehavior = configuration.endEdgePanGestureBehavior
     )
@@ -159,6 +168,10 @@ internal class ComposeContainer(
 
     private fun onLayoutSubviews() {
         windowContext.updateWindowContainerSize()
+    }
+
+    private fun onTraitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+        layoutDirection = view.effectiveUserInterfaceLayoutDirection.asLayoutDirection()
     }
 
     private fun onDidMoveToWindow(window: UIWindow?) {
@@ -248,7 +261,8 @@ internal class ComposeContainer(
             view.updateMetalView(
                 metalView = metalView,
                 onDidMoveToWindow = ::onDidMoveToWindow,
-                onLayoutSubviews = ::onLayoutSubviews
+                onLayoutSubviews = ::onLayoutSubviews,
+                onTraitCollectionDidChange = ::onTraitCollectionDidChange,
             )
             view.embedSubview(mediator.overlayView)
 
@@ -417,7 +431,7 @@ private fun UIUserInterfaceStyle.asComposeSystemTheme(): SystemTheme {
 
 private fun getApplicationLayoutDirection() =
     when (UIApplication.sharedApplication().userInterfaceLayoutDirection) {
-        UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionRightToLeft -> LayoutDirection.Rtl
+        UIUserInterfaceLayoutDirectionRightToLeft -> LayoutDirection.Rtl
         else -> LayoutDirection.Ltr
     }
 
@@ -488,5 +502,14 @@ private class SceneGeometryObserver(
         context: CPointer<out CPointed>?
     ) {
         onGeometryChanged()
+    }
+}
+
+private fun UIUserInterfaceLayoutDirection.asLayoutDirection(): LayoutDirection = when (this) {
+    UIUserInterfaceLayoutDirectionLeftToRight -> LayoutDirection.Ltr
+    UIUserInterfaceLayoutDirectionRightToLeft -> LayoutDirection.Rtl
+    else -> {
+        println("ComposeContainer: unexpected UIUserInterfaceLayoutDirection=$this, falling back to Ltr")
+        LayoutDirection.Ltr
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.ios.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.uikit.addLayoutConstraintsToMatch
 import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.dpSize
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.viewinterop.UIKitInteropTransaction

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.ios.kt
@@ -96,9 +96,12 @@ internal class UIKitComposeSceneLayer(
 
     private val navigationEventInput = UIKitNavigationEventInput(
         density = interactionView.density,
+        initialLayoutDirection = initialLayoutDirection,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft },
         endEdgePanGestureBehavior = configuration.endEdgePanGestureBehavior
-    ).also { navigationEventDispatcher.addInput(it) }
+    ).also {
+        navigationEventDispatcher.addInput(it)
+    }
 
     private val mediator = ComposeSceneMediator(
         onFocusBehavior = configuration.onFocusBehavior,
@@ -142,7 +145,12 @@ internal class UIKitComposeSceneLayer(
             // density of the layer cannot be customized
         }
 
-    override var layoutDirection by mediator::layoutDirection
+    override var layoutDirection: LayoutDirection
+        get() = mediator.layoutDirection
+        set(value) {
+            mediator.layoutDirection = value
+            navigationEventInput.layoutDirection = value
+        }
 
     override var boundsInWindow: IntRect by mediator::interactionBounds
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
@@ -53,6 +53,7 @@ internal class ComposeContainerView(
     private var onDidMoveToWindow: (UIWindow?) -> Unit = {}
     private var onWillMoveToWindow: (UIWindow?) -> Unit = {}
     private var onLayoutSubviews: () -> Unit = {}
+    private var onTraitCollectionDidChange: (UITraitCollection?) -> Unit = {}
     private var foregroundStateListener: SceneForegroundStateListener? = null
 
     val redrawer: MetalRedrawer? get() = metalView?.redrawer
@@ -65,6 +66,7 @@ internal class ComposeContainerView(
         super.traitCollectionDidChange(previousTraitCollection)
 
         updateBackgroundColor()
+        onTraitCollectionDidChange(previousTraitCollection)
     }
 
     private fun updateBackgroundColor() {
@@ -83,7 +85,8 @@ internal class ComposeContainerView(
         metalView: MetalViewHolder?,
         onWillMoveToWindow: (UIWindow?) -> Unit = {},
         onDidMoveToWindow: (UIWindow?) -> Unit = {},
-        onLayoutSubviews: () -> Unit = {}
+        onLayoutSubviews: () -> Unit = {},
+        onTraitCollectionDidChange: (UITraitCollection?) -> Unit = {},
     ) {
         this.metalView?.dispose()
         this.metalView?.view?.removeFromSuperview()
@@ -92,6 +95,7 @@ internal class ComposeContainerView(
         this.onDidMoveToWindow = onDidMoveToWindow
         this.onWillMoveToWindow = onWillMoveToWindow
         this.onLayoutSubviews = onLayoutSubviews
+        this.onTraitCollectionDidChange = onTraitCollectionDidChange
 
         metalView?.let {
             addSubview(metalView.view)
@@ -99,6 +103,8 @@ internal class ComposeContainerView(
         updateLayout()
         window?.let(onWillMoveToWindow)
         window?.let(onDidMoveToWindow)
+
+        onTraitCollectionDidChange(traitCollection)
 
         if (metalView == null) {
             foregroundStateListener?.dispose()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -107,6 +107,7 @@ class ComposeSceneMediatorTest {
             ),
             navigationEventInput = UIKitNavigationEventInput(
                 density = Density(1f),
+                initialLayoutDirection = LayoutDirection.Ltr,
                 getTopLeftOffsetInWindow = { IntOffset.Zero },
                 endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Disabled,
             ),

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SwipeBackTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SwipeBackTest.kt
@@ -22,23 +22,22 @@ import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.findNodeWithTag
-import androidx.compose.ui.test.findNodeWithTagOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.hold
-import androidx.compose.ui.test.utils.leftCenter
-import androidx.compose.ui.test.utils.offsetBy
-import androidx.compose.ui.test.utils.rightCenter
 import androidx.compose.ui.test.utils.up
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.NavigationEventTransitionState
 import androidx.navigationevent.NavigationEventTransitionState.InProgress
@@ -47,6 +46,9 @@ import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import platform.UIKit.UITraitEnvironmentLayoutDirectionLeftToRight
+import platform.UIKit.UITraitEnvironmentLayoutDirectionRightToLeft
 
 internal class SwipeBackInHostingViewTest : SwipeBackTest(
     runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = true, it) }
@@ -60,102 +62,562 @@ internal abstract class SwipeBackTest(
     private val runUIKitInstrumentedTest: (UIKitInstrumentedTest.() -> Unit) -> Unit
 ) {
     @Test
-    fun edgeBackSwipeDoesNotDispatchHorizontalDragToCompose() = runUIKitInstrumentedTest {
+    fun testSwipeBackDoesNotDispatchHorizontalDragToComposeLtr() = runUIKitInstrumentedTest {
         var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        swipeFromLeftEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            expected = 0f, actual = dragDistance,
+            message = "left edge swipe back should not dispatch horizontal drag deltas to Compose in LTR"
+        )
+    }
+
+    @Test
+    fun testSwipeBackDoesNotDispatchHorizontalDragToComposeRtl() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        swipeFromRightEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            expected = 0f, actual = dragDistance,
+            message = "right edge swipe back should not dispatch horizontal drag deltas to Compose in RTL"
+        )
+    }
+
+    @Test
+    fun testBackSwipeCompletesLtr() = runUIKitInstrumentedTest {
         var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
         var backCompletedCount = -1
 
-        setContent {
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
             TestContent(
-                onDragDistanceChanged = { dragDistance = it },
                 onTransitionStateChanged = { transitionState = it },
                 onBackCompletedCountChanged = { backCompletedCount = it }
             )
         }
 
-        waitUntil("drag surface should be ready") {
-            findNodeWithTagOrNull(DRAG_SURFACE) != null &&
-                !dragDistance.isNaN() &&
-                backCompletedCount == 0
-        }
-
-        val backSwipe = swipeRightFromEdge().hold()
+        val swipeBack = swipeFromLeftEdge().hold()
 
         waitUntil("back swipe should be in progress") {
             transitionState is InProgress
         }
 
-        assertEquals(
-            expected = 0f,
-            actual = dragDistance,
-            absoluteTolerance = 0.01f,
-            message = "Edge back swipe should not dispatch horizontal drag deltas to Compose"
-        )
-        assertEquals(
-            expected = 0,
-            actual = backCompletedCount,
-            message = "Back gesture should not complete before release"
-        )
+        swipeBack.up()
 
-        backSwipe.up()
-
-        waitUntil("back swipe should complete after release") {
+        waitUntil("left edge back swipe should complete in LTR") {
             backCompletedCount == 1
         }
     }
 
     @Test
-    fun innerSwipeDispatchesHorizontalDragWithoutStartingBack() = runUIKitInstrumentedTest {
-        var dragDistance = Float.NaN
+    fun testSwipeBackCompletesRtl() = runUIKitInstrumentedTest {
         var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
         var backCompletedCount = -1
 
-        setContent {
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
             TestContent(
-                onDragDistanceChanged = { dragDistance = it },
                 onTransitionStateChanged = { transitionState = it },
                 onBackCompletedCountChanged = { backCompletedCount = it }
             )
         }
 
-        waitUntil("drag surface should be ready") {
-            findNodeWithTagOrNull(DRAG_SURFACE) != null &&
-                !dragDistance.isNaN() &&
-                backCompletedCount == 0
+        val swipeBack = swipeFromRightEdge().hold()
+
+        assertTrue(transitionState is InProgress, message = "right edge swipe back should be in progress in RTL")
+
+        swipeBack.up()
+
+        waitForIdle()
+
+        assertEquals(1, backCompletedCount, message = "right edge swipe back should complete in RTL")
+    }
+
+    @Test
+    fun testSwipeFromRightEdgeNotCompletesSwipeBackInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
         }
 
-        findNodeWithTag(DRAG_SURFACE).swipe(
-            fromPosition = { leftCenter().offsetBy(dx = 16.dp) },
-            toPosition = { rightCenter().offsetBy(dx = (-16).dp) }
-        )
+        val swipeBack = swipeFromRightEdge().hold()
 
-        waitUntil("inner swipe should dispatch drag deltas to Compose") {
-            dragDistance > 0f
+        assertFalse(transitionState is InProgress, message = "right edge swipe back should not be in progress in LTR")
+
+        swipeBack.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "right edge swipe back should not complete in LTR")
+    }
+
+    @Test
+    fun testSwipeFromLeftEdgeNotCompletesSwipeBackInRtl() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
         }
-        assertFalse(
-            transitionState is InProgress,
-            "Inner swipe should not start back navigation"
-        )
+
+        val swipeBack = swipeFromLeftEdge().hold()
+
+        assertFalse(transitionState is InProgress, message = "left edge swipe back should not be in progress in RTL")
+
+        swipeBack.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "left edge swipe back should not complete in RTL")
+    }
+
+    @Test
+    fun testSwipeFromRightEdgeDispatchesHorizontalDragToComposeInLtr() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        swipeFromRightEdge().hold()
+
+        waitForIdle()
+
+        assertTrue(dragDistance < 0f, message = "right edge swipe should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeFromLeftEdgeDispatchesHorizontalDragToComposeInRtl() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        swipeFromLeftEdge().hold()
+
+        waitForIdle()
+
+        assertTrue(dragDistance > 0f, message = "left edge swipe should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeLeftDispatchesHorizontalDragInLtr() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        findNodeWithTag(DRAG_SURFACE).swipeLeft().up()
+
+        waitForIdle()
+
+        assertTrue(dragDistance < 0f, message = "swipe left should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeRightDispatchesHorizontalDragInLtr() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        findNodeWithTag(DRAG_SURFACE).swipeRight().up()
+
+        waitForIdle()
+
+        assertTrue(dragDistance > 0f, message = "swipe right should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeLeftDispatchesHorizontalDragInRtl() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        findNodeWithTag(DRAG_SURFACE).swipeLeft().up()
+
+        waitForIdle()
+
+        assertTrue(dragDistance < 0f, message = "swipe left should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeRightDispatchesHorizontalDragInRtl() = runUIKitInstrumentedTest {
+        var dragDistance = Float.NaN
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onDragDistanceChanged = { dragDistance = it }
+            )
+        }
+
+        findNodeWithTag(DRAG_SURFACE).swipeRight().up()
+
+        waitForIdle()
+
+        assertTrue(dragDistance > 0f, message = "swipe right should dispatch horizontal drag deltas to Compose")
+    }
+
+    @Test
+    fun testSwipeRightNotCompletesSwipeBackInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeRight = findNodeWithTag(DRAG_SURFACE).swipeRight().hold()
+
+        assertFalse(transitionState is InProgress, message = "swipe right should not be in progress in LTR")
+
+        swipeRight.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "swipe right should not complete in LTR")
+    }
+
+    @Test
+    fun testSwipeRightNotCompletesSwipeBackInRtl() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeRight = findNodeWithTag(DRAG_SURFACE).swipeRight().hold()
+
+        assertFalse(transitionState is InProgress, message = "swipe right should not be in progress in RTL")
+
+        swipeRight.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "swipe right should not complete in RTL")
+    }
+
+    @Test
+    fun testSwipeLeftNotCompletesSwipeBackInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeRight = findNodeWithTag(DRAG_SURFACE).swipeLeft().hold()
+
+        assertFalse(transitionState is InProgress, message = "swipe left should not be in progress in LTR")
+
+        swipeRight.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "swipe left should not complete in LTR")
+    }
+
+    @Test
+    fun testSwipeLeftNotCompletesSwipeBackInRtl() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeRight = findNodeWithTag(DRAG_SURFACE).swipeLeft().hold()
+
+        assertFalse(transitionState is InProgress, message = "swipe left should not be in progress in RTL")
+
+        swipeRight.up()
+
+        waitForIdle()
+
+        assertEquals(0, backCompletedCount, message = "swipe left should not complete in RTL")
+    }
+
+    @Test
+    fun testSwipeFromLeftEdgeCompletesSwipeBackInRtl() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(
+            configure = { endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Back },
+            layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft
+        ) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeBack = swipeFromLeftEdge().hold()
+
+        assertTrue(transitionState is InProgress, message = "left edge swipe back should be in progress in RTL")
+
+        swipeBack.up()
+
+        waitForIdle()
+
         assertEquals(
-            expected = 0,
-            actual = backCompletedCount,
-            message = "Inner swipe should not complete back navigation"
+            1, backCompletedCount,
+            message = "left edge swipe back should complete in RTL with EndEdgePanGestureBehavior.Back"
+        )
+    }
+
+    @Test
+    fun testSwipeFromRightEdgeCompletesSwipeBackInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(
+            configure = { endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Back },
+            layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight
+        ) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        val swipeBack = swipeFromRightEdge().hold()
+
+        assertTrue(transitionState is InProgress, message = "right edge swipe back should be in progress in LTR")
+
+        swipeBack.up()
+
+        waitForIdle()
+
+        assertEquals(
+            1, backCompletedCount,
+            message = "right edge swipe back should complete in LTR with EndEdgePanGestureBehavior.Back"
+        )
+    }
+
+    @Test
+    fun testSwipeFromRightAndLeftEdgeCompletesSwipeBackInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(
+            configure = { endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Back },
+            layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight
+        ) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        swipeFromRightEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            1, backCompletedCount,
+            message = "right edge swipe back should complete in LTR with EndEdgePanGestureBehavior.Back"
+        )
+
+        assertTrue(transitionState is NavigationEventTransitionState.Idle, message = "swipe back should be idle")
+
+        swipeFromLeftEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+             2, backCompletedCount,
+            message = "left edge swipe back should complete in LTR with EndEdgePanGestureBehavior.Back"
+        )
+    }
+
+    @Test
+    fun testSwipeFromRightAndLeftEdgeCompletesSwipeBackInRtl() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(
+            configure = { endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Back },
+            layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft
+        ) {
+            TestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        swipeFromRightEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            1, backCompletedCount,
+            message = "right edge swipe back should complete in RTL with EndEdgePanGestureBehavior.Back"
+        )
+
+        assertTrue(transitionState is NavigationEventTransitionState.Idle, message = "swipe back should be idle")
+
+        swipeFromLeftEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            2, backCompletedCount,
+            message = "left edge swipe back should complete in RTL with EndEdgePanGestureBehavior.Back"
+        )
+    }
+
+    @Test
+    fun testChangingLtrToRtlChangesSwipeBackEdge() = runUIKitInstrumentedTest {
+        var backCompletedCount = -1
+        var composeLayoutDirection: LayoutDirection? = null
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            val currentLayoutDirection = LocalLayoutDirection.current
+
+            SideEffect {
+                composeLayoutDirection = currentLayoutDirection
+            }
+
+            TestContent(
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        swipeFromLeftEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+             1, backCompletedCount,
+            message = "left edge swipe back should complete in LTR"
+        )
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionRightToLeft)
+
+        waitUntil { composeLayoutDirection == LayoutDirection.Rtl }
+
+        swipeFromRightEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            2, backCompletedCount,
+            message = "right edge swipe back should complete in RTL"
+        )
+    }
+
+    @Test
+    fun testChangingRtlToLtrChangesSwipeBackEdge() = runUIKitInstrumentedTest {
+        var backCompletedCount = -1
+        var composeLayoutDirection: LayoutDirection? = null
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            val currentLayoutDirection = LocalLayoutDirection.current
+
+            SideEffect {
+                composeLayoutDirection = currentLayoutDirection
+            }
+
+            TestContent(
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        swipeFromRightEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            1, backCompletedCount,
+            message = "right edge swipe back should complete in RTL"
+        )
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionLeftToRight)
+
+        waitUntil { composeLayoutDirection == LayoutDirection.Ltr }
+
+        swipeFromLeftEdge().up()
+
+        waitForIdle()
+
+        assertEquals(
+            2, backCompletedCount,
+            message = "left edge swipe back should complete in LTR"
         )
     }
 }
 
 @Composable
 private fun TestContent(
-    onDragDistanceChanged: (Float) -> Unit,
-    onTransitionStateChanged: (NavigationEventTransitionState) -> Unit,
-    onBackCompletedCountChanged: (Int) -> Unit,
+    onDragDistanceChanged: (Float) -> Unit = {},
+    onTransitionStateChanged: (NavigationEventTransitionState) -> Unit = {},
+    onBackCompletedCountChanged: (Int) -> Unit = {},
+    onComposeLayoutDirectionChanged: (LayoutDirection) -> Unit = {}
 ) {
     var dragDistance by remember { mutableFloatStateOf(0f) }
     var backCompletedCount by remember { mutableIntStateOf(0) }
-    val navigationEventState = rememberNavigationEventState<NavigationEventInfo>(
+    val navigationEventState = rememberNavigationEventState(
         currentInfo = NavigationEventInfo.None,
         backInfo = listOf<NavigationEventInfo>(NavigationEventInfo.None)
     )
+
+    val composeLayoutDirection = LocalLayoutDirection.current
+    SideEffect {
+        onComposeLayoutDirectionChanged(composeLayoutDirection)
+    }
 
     onDragDistanceChanged(dragDistance)
     onTransitionStateChanged(navigationEventState.transitionState)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitNavigationSwipeBackTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitNavigationSwipeBackTest.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.findNodeWithTagOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.center
+import androidx.compose.ui.test.utils.offsetBy
 import androidx.compose.ui.test.utils.rightCenter
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.unit.dp
@@ -63,7 +64,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        findNodeWithTag("pager").swipeRight()
+        findNodeWithTag("pager").swipeRight().up()
 
         waitForIdle()
 
@@ -81,7 +82,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        findNodeWithTag("pager").swipeLeft()
+        findNodeWithTag("pager").swipeLeft().up()
 
         waitForIdle()
 
@@ -98,7 +99,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        findNodeWithTag("outsideBox").swipeLeft()
+        findNodeWithTag("outsideBox").swipeLeft().up()
 
         assertEquals(initialPage, currentPage.value)
         assertEquals(2, navigationController.viewControllers.size)
@@ -110,7 +111,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = mutableIntStateOf(1))
         }
 
-        swipeRightFromEdge().up()
+        swipeFromLeftEdge().up()
 
         waitForPopped(viewControllerHostingCompose)
     }
@@ -129,8 +130,8 @@ internal abstract class UIKitNavigationSwipeBackTest(
 
         findNodeWithTag("outsideBox").swipe(
             fromPosition = { center() },
-            toPosition = { rightCenter() },
-        )
+            toPosition = { rightCenter().offsetBy(dx = (-16).dp) },
+        ).up()
 
         waitForIdle()
 
@@ -151,7 +152,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        findNodeWithTag("outsideBox").swipeRight()
+        findNodeWithTag("outsideBox").swipeRight().up()
 
         waitForPopped(viewControllerHostingCompose)
     }
@@ -168,7 +169,7 @@ internal abstract class UIKitNavigationSwipeBackTest(
             TestContent(currentPage = currentPage)
         }
 
-        swipeRightFromEdge().up()
+        swipeFromLeftEdge().up()
 
         waitForPopped(viewControllerHostingCompose)
     }
@@ -187,8 +188,8 @@ internal abstract class UIKitNavigationSwipeBackTest(
 
         findNodeWithTag("outsideBox").swipe(
             fromPosition = { center() },
-            toPosition = { rightCenter() },
-        )
+            toPosition = { rightCenter().offsetBy(dx = (-16).dp) },
+        ).up()
 
         waitForPopped(viewControllerHostingCompose)
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/LayoutDirectionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/LayoutDirectionTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.DpRectZero
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpRect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import platform.UIKit.UITraitEnvironmentLayoutDirectionLeftToRight
+import platform.UIKit.UITraitEnvironmentLayoutDirectionRightToLeft
+
+internal class LayoutDirectionInHostingViewTest : LayoutDirectionTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = true, it) }
+)
+
+internal class LayoutDirectionInHostingViewControllerTest : LayoutDirectionTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = false, it) }
+)
+
+internal abstract class LayoutDirectionTest(
+    private val runUIKitInstrumentedTest: (UIKitInstrumentedTest.() -> Unit) -> Unit
+) {
+    @Test
+    fun testLayoutChangesFromLtrToRtl() = runUIKitInstrumentedTest {
+        val markerSize = DpSize(80.dp, 50.dp)
+        var markerRect = DpRectZero()
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TestContent(
+                alignment = Alignment.TopStart,
+                markerSize = markerSize,
+                onMarkerRectChanged = { markerRect = it }
+            )
+        }
+
+        val expectedLtrRect = DpRect(
+            origin = DpOffset.Zero,
+            size = markerSize
+        )
+        waitUntil("Marker should be laid out for LTR") {
+            markerRect == expectedLtrRect
+        }
+        assertEquals(expectedLtrRect, markerRect)
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionRightToLeft)
+
+        val expectedRtlRect = DpRect(
+            left = screenSize.width - markerSize.width,
+            top = 0.dp,
+            right = screenSize.width,
+            bottom = markerSize.height
+        )
+        waitUntil("Marker should move to the right for RTL") {
+            markerRect == expectedRtlRect
+        }
+        assertEquals(expectedRtlRect, markerRect)
+    }
+
+    @Test
+    fun testLayoutChangesFromRtlToLtr() = runUIKitInstrumentedTest {
+        val markerSize = DpSize(80.dp, 50.dp)
+        var markerRect = DpRectZero()
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TestContent(
+                alignment = Alignment.TopStart,
+                markerSize = markerSize,
+                onMarkerRectChanged = { markerRect = it }
+            )
+        }
+
+        val expectedRtlRect = DpRect(
+            left = screenSize.width - markerSize.width,
+            top = 0.dp,
+            right = screenSize.width,
+            bottom = markerSize.height
+        )
+        waitUntil("Marker should be laid out for RTL") {
+            markerRect == expectedRtlRect
+        }
+        assertEquals(expectedRtlRect, markerRect)
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionLeftToRight)
+
+        val expectedLtrRect = DpRect(
+            origin = DpOffset.Zero,
+            size = markerSize
+        )
+        waitUntil("Marker should move to the left for LTR") {
+            markerRect == expectedLtrRect
+        }
+        assertEquals(expectedLtrRect, markerRect)
+    }
+}
+
+@Composable
+private fun TestContent(
+    alignment: Alignment = Alignment.TopStart,
+    markerSize: DpSize,
+    onMarkerRectChanged: (DpRect) -> Unit
+) {
+    val density = LocalDensity.current
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Box(
+            modifier = Modifier
+                .align(alignment)
+                .size(markerSize)
+                .background(Color.Red)
+                .onGloballyPositioned {
+                    onMarkerRectChanged(it.boundsInWindow().toDpRect(density))
+                }
+        )
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -99,13 +99,18 @@ import platform.UIKit.UIKeyModifierFlags
 import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIPressType
 import platform.UIKit.UITouch
+import platform.UIKit.UITraitCollection
+import platform.UIKit.UITraitEnvironmentLayoutDirection
+import platform.UIKit.UITraitEnvironmentLayoutDirectionLeftToRight
 import platform.UIKit.UIUserInterfaceIdiomPad
 import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowScene
 import platform.UIKit.endEditing
+import platform.UIKit.setOverrideTraitCollection
 import platform.UIKit.systemBackgroundColor
+import platform.UIKit.traitOverrides
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -245,8 +250,12 @@ internal class UIKitInstrumentedTest(
     private var hostingViewController: ComposeHostingViewController? = null
     private var hostingView: ComposeHostingView? = null
 
-    val viewController: UIViewController get() =
-        appDelegate.window?.rootViewController ?: error("Cannot find active UIViewController")
+    val viewController: UIViewController get() {
+        val rootViewController = appDelegate.window?.rootViewController
+        if (rootViewController != null) { return rootViewController }
+        waitUntil { appDelegate.window?.rootViewController != null }
+        return appDelegate.window?.rootViewController ?: error("Cannot find active UIViewController")
+    }
 
     val rootRedrawer: MetalRedrawer? get() =
         hostingView?.rootRedrawer ?: hostingViewController?.rootRedrawer
@@ -262,10 +271,15 @@ internal class UIKitInstrumentedTest(
     fun setContent(
         configure: ComposeContainerConfiguration.() -> Unit = {},
         interfaceOrientation: UIInterfaceOrientation = UIInterfaceOrientationPortrait,
+        layoutDirection: UITraitEnvironmentLayoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight,
         content: @Composable () -> Unit
     ) = setupWindow(
         interfaceOrientation = interfaceOrientation,
-        rootViewController = { createViewControllerHostingCompose(configure, content) }
+        rootViewController = {
+            createViewControllerHostingCompose(configure, content).also {
+                it.setLayoutDirection(layoutDirection)
+            }
+        }
     )
 
     /**
@@ -404,6 +418,9 @@ internal class UIKitInstrumentedTest(
         condition: () -> Boolean
     ) = UIKitInstrumentedTest.waitUntil(conditionDescription, timeoutMillis, condition)
 
+    fun setLayoutDirection(layoutDirection: UITraitEnvironmentLayoutDirection) =
+        viewController.setLayoutDirection(layoutDirection)
+
     // Touches:
 
     /**
@@ -421,22 +438,24 @@ internal class UIKitInstrumentedTest(
 
     private val EdgeSwipeDuration = 500.milliseconds
 
-    fun swipeRightFromEdge(
+    fun swipeFromLeftEdge(
         duration: Duration = EdgeSwipeDuration,
     ): UITouch {
-        val swipeToLocation = screenBounds.rightCenter().offsetBy(dx = (-16).dp)
+        val fromPosition = screenBounds.leftCenter()
+        val toPosition = screenBounds.rightCenter().offsetBy(dx = (-16).dp)
 
-        return touchDown(screenBounds.leftCenter(), fromEdge = true)
-            .dragTo(swipeToLocation, duration = duration)
+        return touchDown(fromPosition, fromEdge = true)
+            .dragTo(toPosition, duration = duration)
     }
 
-    fun swipeLeftFromEdge(
+    fun swipeFromRightEdge(
         duration: Duration = EdgeSwipeDuration,
     ): UITouch {
-        val swipeToLocation = screenBounds.leftCenter().offsetBy(dx = 16.dp)
+        val fromPosition = screenBounds.rightCenter().offsetBy(dx = (-1).dp)
+        val toPosition = screenBounds.leftCenter().offsetBy(dx = 16.dp)
 
-        return touchDown(screenBounds.rightCenter(), fromEdge = true)
-            .dragTo(swipeToLocation, duration = duration)
+        return touchDown(fromPosition, fromEdge = true)
+            .dragTo(toPosition, duration = duration)
     }
 
     /**
@@ -661,19 +680,18 @@ internal class UIKitInstrumentedTest(
         toPosition: DpRect.() -> DpOffset = { center() },
         fromEdge: Boolean = false,
         duration: Duration = SwipeDuration
-    ) {
+    ): UITouch {
         val frame = frame ?: error("Internal error. Frame is missing.")
-        touchDown(frame.fromPosition(), fromEdge = fromEdge)
+        return touchDown(frame.fromPosition(), fromEdge = fromEdge)
             .dragTo(frame.toPosition(), duration)
-            .up()
     }
 
-    fun AccessibilityTestNode.swipeRight(fromEdge: Boolean = false, duration: Duration = SwipeDuration) {
-        swipe(fromPosition = { leftCenter().offsetBy(dx = 16.dp) }, toPosition = { rightCenter().offsetBy(dx = (-16).dp) }, fromEdge = fromEdge, duration = duration)
+    fun AccessibilityTestNode.swipeRight(fromEdge: Boolean = false, duration: Duration = SwipeDuration): UITouch {
+        return swipe(fromPosition = { leftCenter().offsetBy(dx = 16.dp) }, toPosition = { rightCenter().offsetBy(dx = (-16).dp) }, fromEdge = fromEdge, duration = duration)
     }
 
-    fun AccessibilityTestNode.swipeLeft(fromEdge: Boolean = false, duration: Duration = SwipeDuration) {
-        swipe(fromPosition = { rightCenter().offsetBy(dx = (-16).dp) }, toPosition = { leftCenter().offsetBy(dx = 16.dp) }, fromEdge = fromEdge, duration = duration)
+    fun AccessibilityTestNode.swipeLeft(fromEdge: Boolean = false, duration: Duration = SwipeDuration): UITouch {
+        return swipe(fromPosition = { rightCenter().offsetBy(dx = (-16).dp) }, toPosition = { leftCenter().offsetBy(dx = 16.dp) }, fromEdge = fromEdge, duration = duration)
     }
 }
 
@@ -850,4 +868,17 @@ internal fun UIKitInstrumentedTest.waitForContextMenu() {
         } != null
     }
     delay(500) // wait for toolbar animation
+}
+
+private fun UIViewController.setLayoutDirection(
+    layoutDirection: UITraitEnvironmentLayoutDirection
+) {
+    if (available(OS.Ios to OSVersion(major = 17))) {
+        traitOverrides.setLayoutDirection(layoutDirection)
+    } else {
+        setOverrideTraitCollection(
+            collection = UITraitCollection.traitCollectionWithLayoutDirection(layoutDirection),
+            forChildViewController = this
+        )
+    }
 }


### PR DESCRIPTION
Updates iOS back gesture handling so the active back-swipe edge follows the current layout direction.

Fixes 
[CMP-9916](https://youtrack.jetbrains.com/issue/CMP-9916) RTL iOS Back Swipe Gesture Regression in Compose Multiplatform 1.10


## Testing
- adds `LayoutDirectionTest` test suite
- adds coverage for layout direction changes and swipe-back behavior in both LTR and RTL, including runtime layout direction switches

## Release Notes
### Fixes - iOS
- Fix iOS swipe-back behavior in RTL layouts
