### PR TITLE
[Cherry-pick] Fix new line detection in `TextInputHelpers` loop logic for iOS (#3197)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -447,8 +447,7 @@ internal class TextInputStringTokenizer(
             }
         } else {
             while (location > 0) {
-                if (string[location].isNewLineCharacter()) {
-                    location++
+                if (string[location - 1].isNewLineCharacter()) {
                     break
                 }
                 location--


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-10151

## Testing
Manual

## Release Notes
### Fixes - iOS
- Fixed a crash that could occur when inserting text via Scribble (Apple Pencil) in TextFields with `usingNativeTextInput` set to `true`