### PR TITLE
Window Insets support for Compose for Web

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -188,6 +188,12 @@ private fun readCssVarLeft(): Float =
 // language=js
 private fun hasVirtualKeyboard(): Boolean = js("('virtualKeyboard' in navigator)")
 
+/**
+ * Enables VirtualKeyboard overlay mode so the browser does not resize the layout viewport when
+ * the virtual keyboard appears, allowing us to read and apply IME insets ourselves.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/VirtualKeyboard/overlaysContent
+ */
 // language=js
 private fun enableVirtualKeyboardOverlay(): Unit =
     js("(navigator.virtualKeyboard.overlaysContent = true)")
@@ -202,6 +208,12 @@ private fun readVirtualKeyboardHeight(): Float =
 
 // --- IME: VisualViewport API fallback (Safari, Firefox) ---
 
+/**
+ * Returns the browser's VisualViewport, which represents the visible portion of the viewport
+ * after browser UI and the virtual keyboard have reduced it.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport
+ */
 // language=js
 private fun getVisualViewport(): EventTarget? = js("(window.visualViewport || null)")
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package androidx.compose.ui.platform
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.events.EventTargetListener
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
+
+/**
+ * Reads system window insets (safe area) from the browser via CSS custom properties and
+ * exposes them as Compose state.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class WebWindowInsetsManager(
+    private val density: Density,
+    globalEvents: EventTargetListener
+) {
+
+    val safeAreaInsets = mutableStateOf(PlatformInsets.Zero)
+
+    init {
+        installSafeAreaCssProperties()
+        readAndUpdate()
+        globalEvents.addDisposableEvent("resize") {
+            readAndUpdate()
+        }
+    }
+
+    private fun readAndUpdate() {
+        val top = readCssVarTop()
+        val right = readCssVarRight()
+        val bottom = readCssVarBottom()
+        val left = readCssVarLeft()
+        safeAreaInsets.value = with(density) {
+            PlatformInsets(
+                left = left.dp.roundToPx(),
+                top = top.dp.roundToPx(),
+                right = right.dp.roundToPx(),
+                bottom = bottom.dp.roundToPx()
+            )
+        }
+    }
+}
+
+/**
+ * Installs CSS custom properties on `document.documentElement` that mirror the browser's
+ * `env(safe-area-inset-*)` environment variables.
+ *
+ * Setting them on the root element (rather than on a canvas or shadow root) works around a WebKit
+ * bug where `env()` values return 0 inside canvas-based shadow roots on some iOS versions.
+ */
+// language=js
+private fun installSafeAreaCssProperties(): Unit = js(
+    """(function() {
+        let s = document.documentElement.style;
+        s.setProperty('--cmp-safe-top',    'env(safe-area-inset-top,    0px)');
+        s.setProperty('--cmp-safe-right',  'env(safe-area-inset-right,  0px)');
+        s.setProperty('--cmp-safe-bottom', 'env(safe-area-inset-bottom, 0px)');
+        s.setProperty('--cmp-safe-left',   'env(safe-area-inset-left,   0px)');
+    })()"""
+)
+
+// language=js
+private fun readCssVarTop(): Float =
+    js("(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cmp-safe-top')) || 0)")
+
+// language=js
+private fun readCssVarRight(): Float =
+    js("(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cmp-safe-right')) || 0)")
+
+// language=js
+private fun readCssVarBottom(): Float =
+    js("(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cmp-safe-bottom')) || 0)")
+
+// language=js
+private fun readCssVarLeft(): Float =
+    js("(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cmp-safe-left')) || 0)")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -19,7 +19,6 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -27,6 +26,28 @@ import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.js
 import kotlinx.browser.window
 import org.w3c.dom.events.EventTarget
+
+private class WebWindowInsets(
+    private val safeArea: () -> PlatformInsets,
+    private val keyboard: () -> PlatformInsets,
+) : PlatformWindowInsets {
+    override val statusBars: PlatformInsets
+        get() = PlatformInsets(getTop = { safeArea().top })
+    override val navigationBars: PlatformInsets
+        get() = PlatformInsets(getBottom = { safeArea().bottom })
+    override val systemBars: PlatformInsets
+        get() = safeArea()
+    override val displayCutout: PlatformInsets
+        get() = safeArea()
+    override val ime: PlatformInsets
+        get() = keyboard()
+    override val systemGestures: PlatformInsets
+        get() = safeArea()
+    override val mandatorySystemGestures: PlatformInsets
+        get() = PlatformInsets(getTop = { safeArea().top }, getBottom = { safeArea().bottom })
+    override val tappableElement: PlatformInsets
+        get() = PlatformInsets(getTop = { safeArea().top })
+}
 
 /**
  * Reads system window insets (safe area and IME) from the browser and exposes them as Compose
@@ -41,13 +62,17 @@ import org.w3c.dom.events.EventTarget
  *   between `window.innerHeight` and `visualViewport.height`.
  *
  */
-@OptIn(InternalComposeUiApi::class)
 internal class WebWindowInsetsManager(
     private val density: Density
 ) {
 
-    val safeAreaInsets = mutableStateOf(PlatformInsets.Zero)
-    val imeInsets = mutableStateOf(PlatformInsets.Zero)
+    private val safeAreaInsets = mutableStateOf(PlatformInsets.Zero)
+    private val imeInsets = mutableStateOf(PlatformInsets.Zero)
+
+    val windowInsets: PlatformWindowInsets = WebWindowInsets(
+        safeArea = { safeAreaInsets.value },
+        keyboard = { imeInsets.value },
+    )
 
     private val hasVirtualKeyboardApi: Boolean = hasVirtualKeyboard()
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -25,49 +25,99 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.js
+import kotlinx.browser.window
+import org.w3c.dom.events.EventTarget
 
 /**
- * Reads system window insets (safe area) from the browser via CSS custom properties and
- * exposes them as Compose state.
+ * Reads system window insets (safe area and IME) from the browser and exposes them as Compose
+ * state.
+ *
+ * Safe area insets are read from CSS `env(safe-area-inset-*)` environment variables via CSS custom
+ * properties, and re-read on each window resize event.
+ *
+ * IME (virtual keyboard) insets are tracked using:
+ * - **VirtualKeyboard API** when available — the most precise source.
+ * - **VisualViewport API** as a fallback for Safari and Firefox — derived from the difference
+ *   between `window.innerHeight` and `visualViewport.height`.
+ *
  */
 @OptIn(InternalComposeUiApi::class)
 internal class WebWindowInsetsManager(
-    private val density: Density,
-    globalEvents: EventTargetListener
+    private val density: Density
 ) {
 
     val safeAreaInsets = mutableStateOf(PlatformInsets.Zero)
+    val imeInsets = mutableStateOf(PlatformInsets.Zero)
+
+    private val hasVirtualKeyboardApi: Boolean = hasVirtualKeyboard()
+
+    private val safeAreaListener: EventTargetListener
+    private val imeEventsListener: EventTargetListener?
 
     init {
         installSafeAreaCssProperties()
-        readAndUpdate()
-        globalEvents.addDisposableEvent("resize") {
-            readAndUpdate()
+        safeAreaListener = initSafeAreaTracking()
+        imeEventsListener = initImeTracking()
+    }
+
+    fun dispose() {
+        safeAreaListener.dispose()
+        imeEventsListener?.dispose()
+    }
+
+
+    private fun initSafeAreaTracking(): EventTargetListener {
+        readAndUpdateSafeArea()
+        return EventTargetListener(window).apply {
+            addDisposableEvent("resize") { readAndUpdateSafeArea() }
         }
     }
 
-    private fun readAndUpdate() {
-        val top = readCssVarTop()
-        val right = readCssVarRight()
-        val bottom = readCssVarBottom()
-        val left = readCssVarLeft()
+    private fun initImeTracking(): EventTargetListener? {
+        readAndUpdateIme()
+        return if (hasVirtualKeyboardApi) {
+            enableVirtualKeyboardOverlay()
+            val vk = getVirtualKeyboard() ?: return null
+            EventTargetListener(vk).apply {
+                addDisposableEvent("geometrychange") { readAndUpdateIme() }
+            }
+        } else {
+            val vv = getVisualViewport() ?: return null
+            EventTargetListener(vv).apply {
+                addDisposableEvent("resize") { readAndUpdateIme() }
+                addDisposableEvent("scroll") { readAndUpdateIme() }
+            }
+        }
+    }
+
+    private fun readAndUpdateSafeArea() {
         safeAreaInsets.value = with(density) {
             PlatformInsets(
-                left = left.dp.roundToPx(),
-                top = top.dp.roundToPx(),
-                right = right.dp.roundToPx(),
-                bottom = bottom.dp.roundToPx()
+                left = readCssVarLeft().dp.roundToPx(),
+                top = readCssVarTop().dp.roundToPx(),
+                right = readCssVarRight().dp.roundToPx(),
+                bottom = readCssVarBottom().dp.roundToPx()
             )
+        }
+    }
+
+    private fun readAndUpdateIme() {
+        val bottomCssPx = if (hasVirtualKeyboardApi) {
+            readVirtualKeyboardHeight()
+        } else {
+            readVisualViewportImeHeight()
+        }
+        imeInsets.value = with(density) {
+            PlatformInsets(bottom = bottomCssPx.dp.roundToPx())
         }
     }
 }
 
 /**
- * Installs CSS custom properties on `document.documentElement` that mirror the browser's
- * `env(safe-area-inset-*)` environment variables.
+ * Installs CSS custom properties on `document.documentElement` that mirror `env(safe-area-inset-*)`.
  *
- * Setting them on the root element (rather than on a canvas or shadow root) works around a WebKit
- * bug where `env()` values return 0 inside canvas-based shadow roots on some iOS versions.
+ * Setting them on the root element (rather than inside a canvas shadow root) works around a WebKit
+ * bug where `env()` values return 0 in canvas-based shadow roots on some iOS versions.
  */
 // language=js
 private fun installSafeAreaCssProperties(): Unit = js(
@@ -95,3 +145,34 @@ private fun readCssVarBottom(): Float =
 // language=js
 private fun readCssVarLeft(): Float =
     js("(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cmp-safe-left')) || 0)")
+
+// language=js
+private fun hasVirtualKeyboard(): Boolean = js("('virtualKeyboard' in navigator)")
+
+// language=js
+private fun enableVirtualKeyboardOverlay(): Unit =
+    js("(navigator.virtualKeyboard.overlaysContent = true)")
+
+// language=js
+private fun getVirtualKeyboard(): EventTarget? = js("navigator.virtualKeyboard")
+
+/** Returns the current keyboard height in CSS pixels (0 when keyboard is hidden). */
+// language=js
+private fun readVirtualKeyboardHeight(): Float =
+    js("(navigator.virtualKeyboard.boundingRect.height || 0)")
+
+// --- IME: VisualViewport API fallback (Safari, Firefox) ---
+
+// language=js
+private fun getVisualViewport(): EventTarget? = js("(window.visualViewport || null)")
+
+/**
+ * Estimates the IME height in CSS pixels from the visual viewport geometry.
+ * Returns 0 when the keyboard is not visible.
+ */
+// language=js
+private fun readVisualViewportImeHeight(): Float = js("""(function() {
+    let vv = window.visualViewport;
+    if (!vv) return 0;
+    return Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+})()""")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.unit.dp
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.js
 import kotlinx.browser.window
+import org.w3c.dom.DOMRect
+import org.w3c.dom.Element
 import org.w3c.dom.events.EventTarget
 
 private class WebWindowInsets(
@@ -61,10 +63,21 @@ private class WebWindowInsets(
  * - **VisualViewport API** as a fallback for Safari and Firefox — derived from the difference
  *   between `window.innerHeight` and `visualViewport.height`.
  *
+ * All insets are clipped to the portion of the system UI zones that the [composeScene] actually
+ * overlaps. For example, if the canvas is positioned below the status bar, the top inset will be
+ * zero; if it extends into the navigation bar area, the bottom inset will reflect the overlap.
+ *
  */
 internal class WebWindowInsetsManager(
-    private val density: Density
+    private val density: Density,
+    canvas: Element
 ) {
+    private var canvasRect: DOMRect = canvas.getBoundingClientRect()
+        set(value) {
+            field = value
+            readAndUpdateSafeArea()
+            readAndUpdateIme()
+        }
 
     private val safeAreaInsets = mutableStateOf(PlatformInsets.Zero)
     private val imeInsets = mutableStateOf(PlatformInsets.Zero)
@@ -76,30 +89,22 @@ internal class WebWindowInsetsManager(
 
     private val hasVirtualKeyboardApi: Boolean = hasVirtualKeyboard()
 
-    private val safeAreaListener: EventTargetListener
     private val imeEventsListener: EventTargetListener?
 
     init {
         installSafeAreaCssProperties()
-        safeAreaListener = initSafeAreaTracking()
         imeEventsListener = initImeTracking()
     }
 
     fun dispose() {
-        safeAreaListener.dispose()
         imeEventsListener?.dispose()
     }
 
-
-    private fun initSafeAreaTracking(): EventTargetListener {
-        readAndUpdateSafeArea()
-        return EventTargetListener(window).apply {
-            addDisposableEvent("resize") { readAndUpdateSafeArea() }
-        }
+    fun onCanvasResized(canvas: Element) {
+        canvasRect = canvas.getBoundingClientRect()
     }
 
     private fun initImeTracking(): EventTargetListener? {
-        readAndUpdateIme()
         return if (hasVirtualKeyboardApi) {
             enableVirtualKeyboardOverlay()
             val vk = getVirtualKeyboard() ?: return null
@@ -110,30 +115,39 @@ internal class WebWindowInsetsManager(
             val vv = getVisualViewport() ?: return null
             EventTargetListener(vv).apply {
                 addDisposableEvent("resize") { readAndUpdateIme() }
-                addDisposableEvent("scroll") { readAndUpdateIme() }
             }
         }
     }
 
     private fun readAndUpdateSafeArea() {
+        val vw = window.innerWidth.toFloat()
+        val vh = window.innerHeight.toFloat()
+        val adjustedLeft = maxOf(0f, readCssVarLeft() - canvasRect.left.toFloat())
+        val adjustedTop = maxOf(0f, readCssVarTop() - canvasRect.top.toFloat())
+        val adjustedRight = maxOf(0f, readCssVarRight() - (vw - canvasRect.right.toFloat()))
+        val adjustedBottom = maxOf(0f, readCssVarBottom() - (vh - canvasRect.bottom.toFloat()))
+
         safeAreaInsets.value = with(density) {
             PlatformInsets(
-                left = readCssVarLeft().dp.roundToPx(),
-                top = readCssVarTop().dp.roundToPx(),
-                right = readCssVarRight().dp.roundToPx(),
-                bottom = readCssVarBottom().dp.roundToPx()
+                left = adjustedLeft.dp.roundToPx(),
+                top = adjustedTop.dp.roundToPx(),
+                right = adjustedRight.dp.roundToPx(),
+                bottom = adjustedBottom.dp.roundToPx()
             )
         }
     }
 
     private fun readAndUpdateIme() {
-        val bottomCssPx = if (hasVirtualKeyboardApi) {
+        val rawHeight = if (hasVirtualKeyboardApi) {
             readVirtualKeyboardHeight()
         } else {
             readVisualViewportImeHeight()
         }
+        val vh = window.innerHeight.toFloat()
+        val adjustedBottom = maxOf(0f, rawHeight - (vh - canvasRect.bottom.toFloat()))
+
         imeInsets.value = with(density) {
-            PlatformInsets(bottom = bottomCssPx.dp.roundToPx())
+            PlatformInsets(bottom = adjustedBottom.dp.roundToPx())
         }
     }
 }
@@ -148,10 +162,10 @@ internal class WebWindowInsetsManager(
 private fun installSafeAreaCssProperties(): Unit = js(
     """(function() {
         let s = document.documentElement.style;
-        s.setProperty('--cmp-safe-top',    'env(safe-area-inset-top,    0px)');
-        s.setProperty('--cmp-safe-right',  'env(safe-area-inset-right,  0px)');
+        s.setProperty('--cmp-safe-top', 'env(safe-area-inset-top, 0px)');
+        s.setProperty('--cmp-safe-right', 'env(safe-area-inset-right, 0px)');
         s.setProperty('--cmp-safe-bottom', 'env(safe-area-inset-bottom, 0px)');
-        s.setProperty('--cmp-safe-left',   'env(safe-area-inset-left,   0px)');
+        s.setProperty('--cmp-safe-left', 'env(safe-area-inset-left, 0px)');
     })()"""
 )
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
@@ -44,4 +44,27 @@ class ComposeViewportConfiguration internal constructor() {
      */
     @ExperimentalComposeUiApi
     var isClearFocusOnMouseDownEnabled: Boolean = ComposeUiFlags.isClearFocusOnMouseDownEnabled
+
+    /**
+     * Controls whether the Compose scene handles system window insets (status bar, navigation bar,
+     * IME keyboard) and exposes them via [androidx.compose.foundation.layout.WindowInsets] APIs
+     * such as `WindowInsets.safeDrawing`, `WindowInsets.ime`, etc.
+     *
+     * When set to `true`, the scene reads safe area insets from the browser using CSS
+     * `env(safe-area-inset-*)` environment variables, and tracks IME (virtual keyboard) geometry.
+     *
+     * **Prerequisite**: the page must opt in to edge-to-edge rendering by including
+     * `viewport-fit=cover` in the viewport meta tag:
+     * ```html
+     * <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+     * ```
+     * Without `viewport-fit=cover`, the browser applies safe area padding automatically and all
+     * `env(safe-area-inset-*)` variables return `0px`, so insets will always be zero.
+     *
+     * By default, this is `false` and the scene reports zero insets.
+     *
+     * Note: This API is experimental and subject to change in the future.
+     */
+    @ExperimentalComposeUiApi
+    var enableBrowserWindowInsets: Boolean = false
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
@@ -63,6 +63,12 @@ class ComposeViewportConfiguration internal constructor() {
      *
      * By default, this is `false` and the scene reports zero insets.
      *
+     * **Scrollable containers:** insets are re-read on `window resize` and keyboard geometry events,
+     * but not on page scroll. If the [composeScene] is inside a scrollable page, its viewport position
+     * changes as the user scrolls, so the insets may become invalid. In that case
+     * it is recommended to disable inset handling entirely (`enableBrowserWindowInsets = false`) and
+     * manage padding manually.
+     *
      * Note: This API is experimental and subject to change in the future.
      */
     @ExperimentalComposeUiApi

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.input.pointer.composeButtons
 import androidx.compose.ui.internal.focusExt
 import androidx.compose.ui.navigationevent.BackNavigationEventInput
 import androidx.compose.ui.platform.DefaultArchitectureComponentsOwner
+import androidx.compose.ui.platform.EmptyPlatformWindowInsets
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
@@ -240,6 +241,7 @@ internal class ComposeWindow(
         object : PlatformContext by PlatformContext.Empty() {
             override val windowInfo get() = _windowInfo
             override val architectureComponentsOwner get() = archComponentsOwner
+            override val windowInsets get() = insetsManager?.windowInsets ?: EmptyPlatformWindowInsets
 
             override val dragAndDropManager: PlatformDragAndDropManager = object :
                 WebDragAndDropManager(rootNode, canvasEvents, state.globalEvents, density) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -482,7 +482,7 @@ internal class ComposeWindow(
     init {
         if (configuration.enableBrowserWindowInsets) {
             checkViewportFitCover()
-            insetsManager = WebWindowInsetsManager(density)
+            insetsManager = WebWindowInsetsManager(density, canvas)
         }
 
         initEvents(canvas)
@@ -558,6 +558,8 @@ internal class ComposeWindow(
         skiaLayer.attachTo(canvas)
         scene.size = sizeInPx
         skiaLayer.needRender()
+
+        insetsManager?.onCanvasResized(canvas)
     }
 
     // TODO: need to call .dispose() on window close.

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.platform.WebHapticFeedback
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.WebTextToolbar
 import androidx.compose.ui.platform.WebWakeLockManager
+import androidx.compose.ui.platform.WebWindowInsetsManager
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.platform.accessibility.ComposeWebSemanticsListener
 import androidx.compose.ui.platform.installFallbackFontDownloader
@@ -213,6 +214,8 @@ internal class ComposeWindow(
     private val navigationEventInput = BackNavigationEventInput()
 
     private val canvasEvents = EventTargetListener(canvas)
+
+    private var insetsManager: WebWindowInsetsManager? = null
 
     private var keyboardModeState: KeyboardModeState = KeyboardModeState.Hardware
 
@@ -477,6 +480,7 @@ internal class ComposeWindow(
     init {
         if (configuration.enableBrowserWindowInsets) {
             checkViewportFitCover()
+            insetsManager = WebWindowInsetsManager(density, state.globalEvents)
         }
 
         initEvents(canvas)

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalWasmJsInterop::class)
+@file:OptIn(ExperimentalWasmJsInterop::class, ExperimentalWasmJsInterop::class)
 
 package androidx.compose.ui.window
 
@@ -88,6 +88,8 @@ import androidx.compose.ui.viewinterop.TrackInteropPlacementContainer
 import androidx.compose.ui.viewinterop.WebInteropContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.enableSavedStateHandles
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
 import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
@@ -473,6 +475,10 @@ internal class ComposeWindow(
     }
 
     init {
+        if (configuration.enableBrowserWindowInsets) {
+            checkViewportFitCover()
+        }
+
         initEvents(canvas)
         state.init()
 
@@ -874,6 +880,22 @@ private fun clipTargetElement(canvas: HTMLCanvasElement): HTMLTextAreaElement {
 
     return clipTarget
 }
+
+// language=js
+private fun checkViewportFitCover(): Unit = js(
+    """(function() {
+        let meta = document.querySelector('meta[name=viewport]');
+        let content = meta ? (meta.getAttribute('content') || '') : '';
+        if (!content.includes('viewport-fit=cover')) {
+            console.warn(
+                "[ComposeWeb] enableBrowserWindowInsets is set to true, but " +
+                "'viewport-fit=cover' is not found in the viewport meta tag. " +
+                "Safe area insets will be zero. Add viewport-fit=cover to your viewport meta tag: " +
+                "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, viewport-fit=cover\">"
+            );
+        }
+    })()"""
+)
 
 // strings checks are faster on a JS side
 // language=js

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -480,7 +480,7 @@ internal class ComposeWindow(
     init {
         if (configuration.enableBrowserWindowInsets) {
             checkViewportFitCover()
-            insetsManager = WebWindowInsetsManager(density, state.globalEvents)
+            insetsManager = WebWindowInsetsManager(density)
         }
 
         initEvents(canvas)
@@ -570,6 +570,7 @@ internal class ComposeWindow(
         frameRecomposer.close()
         skiaLayer.detach()
 
+        insetsManager?.dispose()
         systemThemeObserver.dispose()
         state.dispose()
         // modern browsers supposed to garbage collect all events on the element disposed

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalWasmJsInterop::class, ExperimentalWasmJsInterop::class)
+@file:OptIn(ExperimentalWasmJsInterop::class)
 
 package androidx.compose.ui.window
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/WebWindowInsetsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/WebWindowInsetsTest.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.platform.LocalPlatformWindowInsets
+import androidx.compose.ui.platform.PlatformWindowInsets
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.browser.window
+import org.w3c.dom.events.Event
+
+@OptIn(
+    ExperimentalWasmJsInterop::class,
+    InternalComposeUiApi::class,
+    ExperimentalComposeUiApi::class
+)
+class WebWindowInsetsTest : OnCanvasTests {
+
+    @AfterTest
+    fun cleanup() {
+        cleanupMocks()
+    }
+
+    private fun mockBrowserEnvironment(
+        top: Int = 0,
+        right: Int = 0,
+        bottom: Int = 0,
+        left: Int = 0,
+        viewportFitCover: Boolean = true,
+        canvasTop: Int = 0,
+        canvasLeft: Int = 0,
+        canvasRight: Int = 1024,
+        canvasBottom: Int = 768,
+        innerWidth: Int = 1024,
+        innerHeight: Int = 768
+    ) {
+        mockBrowserEnvironmentInternal(
+            top,
+            right,
+            bottom,
+            left,
+            viewportFitCover,
+            canvasTop,
+            canvasLeft,
+            canvasRight,
+            canvasBottom,
+            innerWidth,
+            innerHeight
+        )
+    }
+
+    private fun cleanupMocks() {
+        cleanupMocksInternal()
+    }
+
+    @Test
+    fun testBasicSafeArea() = runApplicationTest {
+        mockBrowserEnvironment(top = 10, right = 20, bottom = 30, left = 40)
+
+        var capturedInsets: PlatformWindowInsets? = null
+        createComposeWindow(
+            configure = { enableBrowserWindowInsets = true }
+        ) {
+            capturedInsets = LocalPlatformWindowInsets.current
+        }
+
+        awaitIdle()
+
+        val insets = capturedInsets ?: error("Insets not captured")
+        val density = Density(window.devicePixelRatio.toFloat())
+
+        with(density) {
+            assertEquals(10.dp.roundToPx(), insets.statusBars.top, "Status bars top")
+            assertEquals(30.dp.roundToPx(), insets.navigationBars.bottom, "Navigation bars bottom")
+
+            assertEquals(40.dp.roundToPx(), insets.displayCutout.left, "Display cutout left")
+            assertEquals(10.dp.roundToPx(), insets.displayCutout.top, "Display cutout top")
+            assertEquals(20.dp.roundToPx(), insets.displayCutout.right, "Display cutout right")
+            assertEquals(30.dp.roundToPx(), insets.displayCutout.bottom, "Display cutout bottom")
+        }
+    }
+
+    @Test
+    fun testDisabledBrowserWindowInsets() = runApplicationTest {
+        mockBrowserEnvironment(top = 10, right = 20, bottom = 30, left = 40)
+
+        var capturedInsets: PlatformWindowInsets? = null
+        createComposeWindow(
+            configure = { enableBrowserWindowInsets = false }
+        ) {
+            capturedInsets = LocalPlatformWindowInsets.current
+        }
+
+        awaitIdle()
+
+        val insets = capturedInsets ?: error("Insets not captured")
+        assertEquals(0, insets.statusBars.top, "Status bars top should be 0")
+        assertEquals(0, insets.navigationBars.bottom, "Navigation bars bottom should be 0")
+    }
+
+    @Test
+    fun testDensityConversion() = runApplicationTest {
+        mockBrowserEnvironment(top = 15)
+
+        var capturedInsets: PlatformWindowInsets? = null
+        createComposeWindow(
+            configure = { enableBrowserWindowInsets = true }
+        ) {
+            capturedInsets = LocalPlatformWindowInsets.current
+        }
+
+        awaitIdle()
+
+        val insets = capturedInsets ?: error("Insets not captured")
+        val density = Density(window.devicePixelRatio.toFloat())
+
+        with(density) {
+            assertEquals(15.dp.roundToPx(), insets.statusBars.top, "Density conversion check")
+        }
+    }
+
+    @Test
+    fun testSafeAreaWithCanvasOffset() = runApplicationTest {
+        // Safe area top is 20px, but canvas starts at 15px from the top.
+        // Resulting inset should be 20 - 15 = 5px.
+        mockBrowserEnvironment(
+            top = 20,
+            canvasTop = 15,
+            innerHeight = 100,
+            canvasBottom = 100
+        )
+
+        var capturedInsets: PlatformWindowInsets? = null
+        createComposeWindow(
+            configure = { enableBrowserWindowInsets = true }
+        ) {
+            capturedInsets = LocalPlatformWindowInsets.current
+        }
+
+        awaitIdle()
+
+        val insets = capturedInsets ?: error("Insets not captured")
+        val density = Density(window.devicePixelRatio.toFloat())
+
+        with(density) {
+            assertEquals(
+                5.dp.roundToPx(),
+                insets.statusBars.top,
+                "Top inset should be clipped by canvas offset"
+            )
+        }
+    }
+
+    @Test
+    fun testDynamicUpdateOnResize() = runApplicationTest {
+        mockBrowserEnvironment(top = 10)
+
+        var capturedInsets: PlatformWindowInsets? = null
+        createComposeWindow(
+            configure = { enableBrowserWindowInsets = true }
+        ) {
+            capturedInsets = LocalPlatformWindowInsets.current
+        }
+
+        awaitIdle()
+
+        val insets = capturedInsets ?: error("Insets not captured")
+        val density = Density(window.devicePixelRatio.toFloat())
+
+        with(density) {
+            assertEquals(10.dp.roundToPx(), insets.statusBars.top, "Initial top inset")
+        }
+
+        // Update mock and trigger resize
+        mockBrowserEnvironment(top = 50)
+        window.dispatchEvent(Event("resize"))
+
+        awaitIdle()
+
+        with(density) {
+            assertEquals(50.dp.roundToPx(), insets.statusBars.top, "Updated top inset after resize")
+        }
+    }
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun mockBrowserEnvironmentInternal(
+    safeAreaTop: Int,
+    safeAreaRight: Int,
+    safeAreaBottom: Int,
+    safeAreaLeft: Int,
+    hasViewportFitCover: Boolean,
+    canvasTop: Int,
+    canvasLeft: Int,
+    canvasRight: Int,
+    canvasBottom: Int,
+    innerWidth: Int,
+    innerHeight: Int
+): Unit = js(
+    """(function() {
+        window._mockValues = {
+            top: safeAreaTop,
+            right: safeAreaRight,
+            bottom: safeAreaBottom,
+            left: safeAreaLeft,
+            viewportFitCover: hasViewportFitCover,
+            canvasTop: canvasTop,
+            canvasLeft: canvasLeft,
+            canvasRight: canvasRight,
+            canvasBottom: canvasBottom,
+            innerWidth: innerWidth,
+            innerHeight: innerHeight
+        };
+
+        if (!window._oldGetComputedStyle) {
+            window._oldGetComputedStyle = window.getComputedStyle;
+            window.getComputedStyle = function(el) {
+                var style = window._oldGetComputedStyle(el);
+                if (el === document.documentElement) {
+                    return {
+                        getPropertyValue: function(prop) {
+                            if (prop === '--cmp-safe-top') return window._mockValues.top + 'px';
+                            if (prop === '--cmp-safe-right') return window._mockValues.right + 'px';
+                            if (prop === '--cmp-safe-bottom') return window._mockValues.bottom + 'px';
+                            if (prop === '--cmp-safe-left') return window._mockValues.left + 'px';
+                            return style.getPropertyValue(prop);
+                        }
+                    };
+                }
+                return style;
+            };
+        }
+
+        if (!window._oldQuerySelector) {
+            window._oldQuerySelector = document.querySelector;
+            document.querySelector = function(selector) {
+                if (selector === 'meta[name=viewport]') {
+                    return {
+                        getAttribute: function(name) {
+                            if (name === 'content') {
+                                return window._mockValues.viewportFitCover ? 'viewport-fit=cover' : '';
+                            }
+                            return null;
+                        }
+                    };
+                }
+                return window._oldQuerySelector.call(document, selector);
+            };
+        }
+
+        if (!window._oldInnerWidth) {
+            window._oldInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth') || { value: window.innerWidth };
+            window._oldInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight') || { value: window.innerHeight };
+            Object.defineProperty(window, 'innerWidth', { 
+                get: function() { return window._mockValues.innerWidth; },
+                configurable: true 
+            });
+            Object.defineProperty(window, 'innerHeight', { 
+                get: function() { return window._mockValues.innerHeight; },
+                configurable: true 
+            });
+        }
+
+        if (!window._oldGetBoundingClientRect) {
+            window._oldGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+            Element.prototype.getBoundingClientRect = function() {
+                if (this.nodeName === 'CANVAS' || this.id === 'canvasApp') {
+                     return {
+                        top: window._mockValues.canvasTop,
+                        left: window._mockValues.canvasLeft,
+                        right: window._mockValues.canvasRight,
+                        bottom: window._mockValues.canvasBottom,
+                        width: window._mockValues.canvasRight - window._mockValues.canvasLeft,
+                        height: window._mockValues.canvasBottom - window._mockValues.canvasTop,
+                        x: window._mockValues.canvasLeft,
+                        y: window._mockValues.canvasTop
+                    };
+                }
+                return window._oldGetBoundingClientRect.call(this);
+            };
+        }
+    })()"""
+)
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun cleanupMocksInternal(): Unit = js(
+    """(function() {
+        if (window._oldGetComputedStyle) {
+            window.getComputedStyle = window._oldGetComputedStyle;
+            delete window._oldGetComputedStyle;
+        }
+        if (window._oldQuerySelector) {
+            document.querySelector = window._oldQuerySelector;
+            delete window._oldQuerySelector;
+        }
+        if (window._oldInnerWidth) {
+            if (window._oldInnerWidth.get) {
+                Object.defineProperty(window, 'innerWidth', window._oldInnerWidth);
+                Object.defineProperty(window, 'innerHeight', window._oldInnerHeight);
+            } else {
+                window.innerWidth = window._oldInnerWidth.value;
+                window.innerHeight = window._oldInnerHeight.value;
+            }
+            delete window._oldInnerWidth;
+            delete window._oldInnerHeight;
+        }
+        if (window._oldGetBoundingClientRect) {
+            Element.prototype.getBoundingClientRect = window._oldGetBoundingClientRect;
+            delete window._oldGetBoundingClientRect;
+        }
+        delete window._mockValues;
+    })()"""
+)


### PR DESCRIPTION
Added support for system window insets on Web. Compose scenes can now render edge-to-edge while respecting the safe area and the keyboard, exposing everything through the standard `WindowInsets` APIs (`WindowInsets.safeDrawing`, `WindowInsets.ime`, etc.).


https://github.com/user-attachments/assets/b0a60f85-90ab-438c-9857-f0c15627f5f9



### New experimental API

A new configuration flag on `ComposeViewportConfiguration`:

```kotlin
ComposeViewport(configure = { enableBrowserWindowInsets = true }) {
    // content that reacts to WindowInsets.safeDrawing, WindowInsets.ime, ...
}
```

 - Defaults to false, so existing behavior is unchanged. When enabled, the scene reads safe area insets and tracks IME geometry, and reports them through the standard WindowInsets APIs.
 - Requires the page to opt in to edge-to-edge rendering via the viewport meta tag:
   ```
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   ```

Without `viewport-fit=cover` the browser applies safe area padding automatically and all `env(safe-area-inset-*)` variables return `0px`, so insets would always be zero. If the flag is enabled but the meta tag is missing, a warning is logged to the console.

Fixes https://youtrack.jetbrains.com/issue/CMP-10141

## Testing
Added new web tests

## Release Notes
### Features - Web
- Added experimental support for system window insets on Web.
