### PR TITLE
Add isAlive checks to access accessibility node data

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -563,7 +563,7 @@ private class AccessibilityElement(
     private val scrollableProtocol = objc_getProtocol("UIFocusItemScrollableContainer")!!
     override fun conformsToProtocol(aProtocol: Protocol?): Boolean {
         if (protocol_isEqual(proto = aProtocol, other = scrollableProtocol)) {
-            return runIfAlive { node.canScroll } ?: false
+            return getIfAlive { node.canScroll } ?: false
         }
         return super.conformsToProtocol(aProtocol)
     }
@@ -647,9 +647,16 @@ private class AccessibilityElement(
         return value as T
     }
 
-    private inline fun <T> runIfAlive(crossinline block: () -> T?): T? {
+    private inline fun <T> getIfAlive(crossinline block: () -> T?): T? {
         if (!isAlive) {
             return null
+        }
+        return block()
+    }
+
+    private inline fun runIfAlive(crossinline block: () -> Unit) {
+        if (!isAlive) {
+            return
         }
         return block()
     }
@@ -670,30 +677,30 @@ private class AccessibilityElement(
 
     override fun accessibilityElementDidBecomeFocused() = runIfAlive {
         node.accessibilityElementDidBecomeFocused()
-    } ?: Unit
+    }
 
     override fun accessibilityElementDidLoseFocus() = runIfAlive {
         node.accessibilityElementDidLoseFocus()
-    } ?: Unit
+    }
 
-    override fun accessibilityActivate(): Boolean = runIfAlive {
+    override fun accessibilityActivate(): Boolean = getIfAlive {
         node.accessibilityActivate()
     } ?: false
 
     override fun accessibilityIncrement() = runIfAlive {
         node.accessibilityIncrement()
-    } ?: Unit
+    }
 
     override fun accessibilityDecrement() = runIfAlive {
         node.accessibilityDecrement()
-    } ?: Unit
+    }
 
     override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean =
-        runIfAlive {
+        getIfAlive {
             node.accessibilityScroll(direction)
         } ?: false
 
-    override fun isAccessibilityElement(): Boolean = runIfAlive {
+    override fun isAccessibilityElement(): Boolean = getIfAlive {
         // Node visibility changes don't trigger accessibility semantic recalculation.
         // This value should not be cached. See [SemanticsNode.isScreenReaderFocusable()]
         node.isAccessibilityElement
@@ -719,7 +726,7 @@ private class AccessibilityElement(
             node.accessibilityTraits
         }
 
-    override fun accessibilityPerformEscape(): Boolean = runIfAlive {
+    override fun accessibilityPerformEscape(): Boolean = getIfAlive {
         if (node.accessibilityPerformEscape()) {
             true
         } else {
@@ -728,7 +735,7 @@ private class AccessibilityElement(
     } ?: false
 
     override fun accessibilityContainerType(): UIAccessibilityContainerType =
-        runIfAlive {
+        getIfAlive {
             node.accessibilityContainerType
         } ?: UIAccessibilityContainerTypeNone
 
@@ -751,7 +758,7 @@ private class AccessibilityElement(
 
     // UIFocusItemProtocol & UIFocusItemContainerProtocol
 
-    override fun canBecomeFocused(): Boolean = runIfAlive { node.canBecomeFocused } ?: false
+    override fun canBecomeFocused(): Boolean = getIfAlive { node.canBecomeFocused } ?: false
 
     override fun didUpdateFocusInContext(
         context: UIFocusUpdateContext,
@@ -763,7 +770,7 @@ private class AccessibilityElement(
         if (context.nextFocusedItem === this) {
             node.didBecomeFocused()
         }
-    } ?: Unit
+    }
 
     override fun focusItemContainer(): UIFocusItemContainerProtocol = this
 
@@ -824,18 +831,18 @@ private class AccessibilityElement(
     override fun isTransparentFocusItem(): Boolean = true
 
     override fun drawsFocusRingWhenChildrenFocused(): Boolean =
-        runIfAlive { node.canScroll } ?: false
+        getIfAlive { node.canScroll } ?: false
 
     // Scrolling
 
     override fun visibleSize(): CValue<CGSize> =
-        runIfAlive { node.scrollVisibleSize } ?: CGSizeZero.readValue()
+        getIfAlive { node.scrollVisibleSize } ?: CGSizeZero.readValue()
 
     override fun contentSize(): CValue<CGSize> =
-        runIfAlive { node.scrollContentSize } ?: CGSizeZero.readValue()
+        getIfAlive { node.scrollContentSize } ?: CGSizeZero.readValue()
 
     override fun contentOffset(): CValue<CGPoint> =
-        runIfAlive { node.scrollContentOffset } ?: CGPointZero.readValue()
+        getIfAlive { node.scrollContentOffset } ?: CGPointZero.readValue()
 
     override fun setContentOffset(contentOffset: CValue<CGPoint>) = runIfAlive {
         val currentContentOffset = contentOffset()
@@ -860,8 +867,7 @@ private class AccessibilityElement(
             node.scrollBy(delta)
             timerJob.cancel()
         }
-        Unit
-    } ?: Unit
+    }
 
     // UICoordinateSpaceProtocol
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -563,7 +563,7 @@ private class AccessibilityElement(
     private val scrollableProtocol = objc_getProtocol("UIFocusItemScrollableContainer")!!
     override fun conformsToProtocol(aProtocol: Protocol?): Boolean {
         if (protocol_isEqual(proto = aProtocol, other = scrollableProtocol)) {
-            return runIfAlive(false) { node.canScroll }
+            return runIfAlive { node.canScroll } ?: false
         }
         return super.conformsToProtocol(aProtocol)
     }
@@ -586,7 +586,7 @@ private class AccessibilityElement(
     }
 
     private fun nodeSemanticsElements(): List<Any> =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityElements, emptyList()) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityElements, emptyList()) {
             listOfNotNull(node.accessibilityInteropView?.also {
                 it.actualAccessibilityContainer = this
             })
@@ -623,23 +623,23 @@ private class AccessibilityElement(
         cachedProperties.clear()
     }
 
-    private inline fun <T> getOrElseIfAlive(
+    private inline fun <T> getCachedIfAlive(
         key: CachedAccessibilityPropertyKey<T>,
         defaultValue: T,
-        crossinline block: () -> T
-    ): T = getOrElseIfAlive(key, block) ?: defaultValue
+        crossinline getValue: () -> T
+    ): T = getCachedIfAlive(key, getValue) ?: defaultValue
 
     @Suppress("UNCHECKED_CAST") // cast is safe because the set value is constrained by the key T
-    private inline fun <T> getOrElseIfAlive(
+    private inline fun <T> getCachedIfAlive(
         key: CachedAccessibilityPropertyKey<T>,
-        crossinline block: () -> T
+        crossinline getValue: () -> T
     ): T? {
         if (!isAlive) {
             return null
         }
 
         val value = cachedProperties.getOrElse(key) {
-            val newValue = block()
+            val newValue = getValue()
             cachedProperties[key] = newValue
             newValue
         }
@@ -647,14 +647,9 @@ private class AccessibilityElement(
         return value as T
     }
 
-    private inline fun runIfAlive(crossinline block: () -> Unit) = runIfAlive(Unit, block)
-
-    private inline fun <T> runIfAlive(
-        defaultValue: T,
-        crossinline block: () -> T
-    ): T {
+    private inline fun <T> runIfAlive(crossinline block: () -> T?): T? {
         if (!isAlive) {
-            return defaultValue
+            return null
         }
         return block()
     }
@@ -662,80 +657,80 @@ private class AccessibilityElement(
     override fun accessibilityLabel(): String? = accessibilityAttributedLabel()?.string
 
     override fun accessibilityAttributedLabel(): NSAttributedString? =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedLabel) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedLabel) {
             makeAccessibilityAttributedLabel()
         }
 
     override fun accessibilityValue(): String? = accessibilityAttributedValue()?.string
 
     override fun accessibilityAttributedValue(): NSAttributedString? =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedValue) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedValue) {
             node.accessibilityAttributedValue
         }
 
     override fun accessibilityElementDidBecomeFocused() = runIfAlive {
         node.accessibilityElementDidBecomeFocused()
-    }
+    } ?: Unit
 
     override fun accessibilityElementDidLoseFocus() = runIfAlive {
         node.accessibilityElementDidLoseFocus()
-    }
+    } ?: Unit
 
-    override fun accessibilityActivate(): Boolean = runIfAlive(false) {
+    override fun accessibilityActivate(): Boolean = runIfAlive {
         node.accessibilityActivate()
-    }
+    } ?: false
 
     override fun accessibilityIncrement() = runIfAlive {
         node.accessibilityIncrement()
-    }
+    } ?: Unit
 
     override fun accessibilityDecrement() = runIfAlive {
         node.accessibilityDecrement()
-    }
+    } ?: Unit
 
     override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean =
-        runIfAlive(false) {
+        runIfAlive {
             node.accessibilityScroll(direction)
-        }
+        } ?: false
 
-    override fun isAccessibilityElement(): Boolean = runIfAlive(defaultValue = false) {
+    override fun isAccessibilityElement(): Boolean = runIfAlive {
         // Node visibility changes don't trigger accessibility semantic recalculation.
         // This value should not be cached. See [SemanticsNode.isScreenReaderFocusable()]
         node.isAccessibilityElement
-    }
+    } ?: false
 
     override fun accessibilityIdentifier(): String? =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityIdentifier) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityIdentifier) {
             node.accessibilityIdentifier
         }
 
     override fun accessibilityHint(): String? =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityHint) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityHint) {
             node.accessibilityHint
         }
 
     override fun accessibilityCustomActions(): List<UIAccessibilityCustomAction> =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityCustomActions, emptyList()) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityCustomActions, emptyList()) {
             node.accessibilityCustomActions
         }
 
     override fun accessibilityTraits(): UIAccessibilityTraits =
-        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityTraits, UIAccessibilityTraitNone) {
+        getCachedIfAlive(CachedAccessibilityPropertyKeys.accessibilityTraits, UIAccessibilityTraitNone) {
             node.accessibilityTraits
         }
 
-    override fun accessibilityPerformEscape(): Boolean = runIfAlive(defaultValue = false) {
+    override fun accessibilityPerformEscape(): Boolean = runIfAlive {
         if (node.accessibilityPerformEscape()) {
             true
         } else {
             super.accessibilityPerformEscape()
         }
-    }
+    } ?: false
 
     override fun accessibilityContainerType(): UIAccessibilityContainerType =
-        runIfAlive(UIAccessibilityContainerTypeNone) {
+        runIfAlive {
             node.accessibilityContainerType
-        }
+        } ?: UIAccessibilityContainerTypeNone
 
     private fun debugContainmentChain() = debugContainmentChain(this)
 
@@ -756,7 +751,7 @@ private class AccessibilityElement(
 
     // UIFocusItemProtocol & UIFocusItemContainerProtocol
 
-    override fun canBecomeFocused(): Boolean = runIfAlive(false) { node.canBecomeFocused }
+    override fun canBecomeFocused(): Boolean = runIfAlive { node.canBecomeFocused } ?: false
 
     override fun didUpdateFocusInContext(
         context: UIFocusUpdateContext,
@@ -768,7 +763,7 @@ private class AccessibilityElement(
         if (context.nextFocusedItem === this) {
             node.didBecomeFocused()
         }
-    }
+    } ?: Unit
 
     override fun focusItemContainer(): UIFocusItemContainerProtocol = this
 
@@ -829,18 +824,18 @@ private class AccessibilityElement(
     override fun isTransparentFocusItem(): Boolean = true
 
     override fun drawsFocusRingWhenChildrenFocused(): Boolean =
-        runIfAlive(false) { node.canScroll }
+        runIfAlive { node.canScroll } ?: false
 
     // Scrolling
 
     override fun visibleSize(): CValue<CGSize> =
-        runIfAlive(CGSizeZero.readValue()) { node.scrollVisibleSize }
+        runIfAlive { node.scrollVisibleSize } ?: CGSizeZero.readValue()
 
     override fun contentSize(): CValue<CGSize> =
-        runIfAlive(CGSizeZero.readValue()) { node.scrollContentSize }
+        runIfAlive { node.scrollContentSize } ?: CGSizeZero.readValue()
 
     override fun contentOffset(): CValue<CGPoint> =
-        runIfAlive(CGPointZero.readValue()) { node.scrollContentOffset }
+        runIfAlive { node.scrollContentOffset } ?: CGPointZero.readValue()
 
     override fun setContentOffset(contentOffset: CValue<CGPoint>) = runIfAlive {
         val currentContentOffset = contentOffset()
@@ -865,7 +860,8 @@ private class AccessibilityElement(
             node.scrollBy(delta)
             timerJob.cancel()
         }
-    }
+        Unit
+    } ?: Unit
 
     // UICoordinateSpaceProtocol
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -563,7 +563,7 @@ private class AccessibilityElement(
     private val scrollableProtocol = objc_getProtocol("UIFocusItemScrollableContainer")!!
     override fun conformsToProtocol(aProtocol: Protocol?): Boolean {
         if (protocol_isEqual(proto = aProtocol, other = scrollableProtocol)) {
-            return node.canScroll
+            return runIfAlive(false) { node.canScroll }
         }
         return super.conformsToProtocol(aProtocol)
     }
@@ -586,7 +586,7 @@ private class AccessibilityElement(
     }
 
     private fun nodeSemanticsElements(): List<Any> =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityElements) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityElements, emptyList()) {
             listOfNotNull(node.accessibilityInteropView?.also {
                 it.actualAccessibilityContainer = this
             })
@@ -623,15 +623,21 @@ private class AccessibilityElement(
         cachedProperties.clear()
     }
 
-    /**
-     * Returns the value for the given [key] from the cache if it's present, otherwise computes the
-     * value using the given [block] and caches it.
-     */
+    private inline fun <T> getOrElseIfAlive(
+        key: CachedAccessibilityPropertyKey<T>,
+        defaultValue: T,
+        crossinline block: () -> T
+    ): T = getOrElseIfAlive(key, block) ?: defaultValue
+
     @Suppress("UNCHECKED_CAST") // cast is safe because the set value is constrained by the key T
-    private inline fun <T> getOrElse(
+    private inline fun <T> getOrElseIfAlive(
         key: CachedAccessibilityPropertyKey<T>,
         crossinline block: () -> T
-    ): T {
+    ): T? {
+        if (!isAlive) {
+            return null
+        }
+
         val value = cachedProperties.getOrElse(key) {
             val newValue = block()
             cachedProperties[key] = newValue
@@ -641,96 +647,85 @@ private class AccessibilityElement(
         return value as T
     }
 
+    private inline fun runIfAlive(crossinline block: () -> Unit) = runIfAlive(Unit, block)
+
+    private inline fun <T> runIfAlive(
+        defaultValue: T,
+        crossinline block: () -> T
+    ): T {
+        if (!isAlive) {
+            return defaultValue
+        }
+        return block()
+    }
+
     override fun accessibilityLabel(): String? = accessibilityAttributedLabel()?.string
 
     override fun accessibilityAttributedLabel(): NSAttributedString? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityAttributedLabel) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedLabel) {
             makeAccessibilityAttributedLabel()
         }
 
     override fun accessibilityValue(): String? = accessibilityAttributedValue()?.string
 
     override fun accessibilityAttributedValue(): NSAttributedString? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityAttributedValue) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityAttributedValue) {
             node.accessibilityAttributedValue
         }
 
-    override fun accessibilityElementDidBecomeFocused() {
-        if (!isAlive) {
-            return
-        }
-
+    override fun accessibilityElementDidBecomeFocused() = runIfAlive {
         node.accessibilityElementDidBecomeFocused()
     }
 
-    override fun accessibilityElementDidLoseFocus() {
+    override fun accessibilityElementDidLoseFocus() = runIfAlive {
         node.accessibilityElementDidLoseFocus()
     }
 
-    override fun accessibilityActivate(): Boolean {
-        if (!isAlive) {
-            return false
-        }
-
-        return node.accessibilityActivate()
+    override fun accessibilityActivate(): Boolean = runIfAlive(false) {
+        node.accessibilityActivate()
     }
 
-    override fun accessibilityIncrement() {
-        if (!isAlive) {
-            return
-        }
-
+    override fun accessibilityIncrement() = runIfAlive {
         node.accessibilityIncrement()
     }
 
-    override fun accessibilityDecrement() {
-        if (!isAlive) {
-            return
-        }
-
+    override fun accessibilityDecrement() = runIfAlive {
         node.accessibilityDecrement()
     }
 
-    override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean {
-        if (!isAlive) {
-            return false
+    override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean =
+        runIfAlive(false) {
+            node.accessibilityScroll(direction)
         }
 
-        return node.accessibilityScroll(direction)
-    }
-
-    override fun isAccessibilityElement(): Boolean {
+    override fun isAccessibilityElement(): Boolean = runIfAlive(defaultValue = false) {
         // Node visibility changes don't trigger accessibility semantic recalculation.
         // This value should not be cached. See [SemanticsNode.isScreenReaderFocusable()]
-        return isAlive && node.isAccessibilityElement
+        node.isAccessibilityElement
     }
 
     override fun accessibilityIdentifier(): String? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityIdentifier) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityIdentifier) {
             node.accessibilityIdentifier
         }
 
     override fun accessibilityHint(): String? =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityHint) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityHint) {
             node.accessibilityHint
         }
 
     override fun accessibilityCustomActions(): List<UIAccessibilityCustomAction> =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityCustomActions) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityCustomActions, emptyList()) {
             node.accessibilityCustomActions
         }
 
     override fun accessibilityTraits(): UIAccessibilityTraits =
-        getOrElse(CachedAccessibilityPropertyKeys.accessibilityTraits) {
+        getOrElseIfAlive(CachedAccessibilityPropertyKeys.accessibilityTraits, UIAccessibilityTraitNone) {
             node.accessibilityTraits
         }
 
-    override fun accessibilityPerformEscape(): Boolean {
-        if (!isAlive) {
-            return false
-        }
-
-        return if (node.accessibilityPerformEscape()) {
+    override fun accessibilityPerformEscape(): Boolean = runIfAlive(defaultValue = false) {
+        if (node.accessibilityPerformEscape()) {
             true
         } else {
             super.accessibilityPerformEscape()
@@ -738,7 +733,9 @@ private class AccessibilityElement(
     }
 
     override fun accessibilityContainerType(): UIAccessibilityContainerType =
-        node.accessibilityContainerType
+        runIfAlive(UIAccessibilityContainerTypeNone) {
+            node.accessibilityContainerType
+        }
 
     private fun debugContainmentChain() = debugContainmentChain(this)
 
@@ -759,16 +756,12 @@ private class AccessibilityElement(
 
     // UIFocusItemProtocol & UIFocusItemContainerProtocol
 
-    override fun canBecomeFocused(): Boolean = isAlive && node.canBecomeFocused
+    override fun canBecomeFocused(): Boolean = runIfAlive(false) { node.canBecomeFocused }
 
     override fun didUpdateFocusInContext(
         context: UIFocusUpdateContext,
         withAnimationCoordinator: UIFocusAnimationCoordinator
-    ) {
-        if (!isAlive) {
-            return
-        }
-
+    ) = runIfAlive {
         if (context.previouslyFocusedItem === this) {
             node.didResignFocused()
         }
@@ -835,17 +828,21 @@ private class AccessibilityElement(
 
     override fun isTransparentFocusItem(): Boolean = true
 
-    override fun drawsFocusRingWhenChildrenFocused(): Boolean = node.canScroll
+    override fun drawsFocusRingWhenChildrenFocused(): Boolean =
+        runIfAlive(false) { node.canScroll }
 
     // Scrolling
 
-    override fun visibleSize(): CValue<CGSize> = node.scrollVisibleSize
+    override fun visibleSize(): CValue<CGSize> =
+        runIfAlive(CGSizeZero.readValue()) { node.scrollVisibleSize }
 
-    override fun contentSize(): CValue<CGSize> = node.scrollContentSize
+    override fun contentSize(): CValue<CGSize> =
+        runIfAlive(CGSizeZero.readValue()) { node.scrollContentSize }
 
-    override fun contentOffset(): CValue<CGPoint> = node.scrollContentOffset
+    override fun contentOffset(): CValue<CGPoint> =
+        runIfAlive(CGPointZero.readValue()) { node.scrollContentOffset }
 
-    override fun setContentOffset(contentOffset: CValue<CGPoint>) {
+    override fun setContentOffset(contentOffset: CValue<CGPoint>) = runIfAlive {
         val currentContentOffset = contentOffset()
         val delta = CGPointMake(
             x = contentOffset.useContents { x } - currentContentOffset.useContents { x },


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10406/iOS-EXCBADACCESS-crash-in-AccessibilityElement.accessibilityTraits-when-AX-queries-drag-source-descriptors

## Release Notes
### Fixes - iOS
- Fix rare crash that occurs when iOS accesses a disposed AccessibilityElement.