### PR TITLE
Fix dropped edge taps on iOS

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -311,7 +311,7 @@ internal class ComposeSceneMediator(
         onCancelScroll = ::onCancelScroll,
         onHoverEvent = ::onHoverEvent,
         onKeyboardPresses = ::onKeyboardPresses,
-        ignoreTouchChanges = navigationEventInput::isBackGestureTrackingTouches,
+        isHigherPriorityGestureTrackingTouches = navigationEventInput::isBackGestureTrackingTouches,
         onRemoveSubview = {
             CoroutineScope(coroutineContext).launch {
                 finishUnattachedKeysPresses()
@@ -332,7 +332,7 @@ internal class ComposeSceneMediator(
         isPointInsideInteractionBounds = ::isPointInsideInteractionBounds,
         onTouchesEvent = ::onTouchesEvent,
         onCancelAllTouches = ::onCancelAllTouches,
-        ignoreTouchChanges = navigationEventInput::isBackGestureTrackingTouches
+        isHigherPriorityGestureTrackingTouches = navigationEventInput::isBackGestureTrackingTouches
     )
 
     val backgroundView: UIView get() = _backgroundView

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
@@ -108,12 +108,18 @@ private class TouchesGestureRecognizer(
     private var onTouchesEvent: (touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> PointerEventResult,
     private var onCancelAllTouches: (touches: Set<*>) -> Unit,
     private var canIgnoreDragGesture: (UIGestureRecognizer) -> Boolean,
-    private var ignoreTouchesChanges: () -> Boolean
+    private var isHigherPriorityGestureTrackingTouches: () -> Boolean
 ) : CMPGestureRecognizer(target = null, action = null) {
     /**
      * Touches that are currently tracked by the gesture recognizer.
      */
     private val trackedTouches: MutableMap<UITouch, UIView?> = mutableMapOf()
+
+    /**
+     * [trackedTouches] whose move callbacks were suppressed while a higher-priority
+     * gesture recognizer was still deciding whether to take over the sequence.
+     */
+    private val trackedTouchesWithSuppressedMoves: MutableSet<UITouch> = mutableSetOf()
 
     val hasTrackedTouches: Boolean get() = trackedTouches.isNotEmpty()
 
@@ -136,11 +142,7 @@ private class TouchesGestureRecognizer(
     override fun touchesBegan(touches: Set<*>, withEvent: UIEvent) {
         super.touchesBegan(touches, withEvent)
 
-        if (ignoreTouchesChanges()) {
-            return
-        }
-
-        val touchesToInteractionMode = touches.associate { touch ->
+        val touchesToHitTestResult = touches.associate { touch ->
             touch as UITouch
             val point = touch.locationInView(view)
             val hitTestResult = view?.hitTest(point, withEvent)?.takeIf { it != view }
@@ -149,7 +151,7 @@ private class TouchesGestureRecognizer(
 
         fun startTouchesEvent() {
             val isInitialTouches = trackedTouches.isEmpty()
-            trackedTouches.putAll(touchesToInteractionMode)
+            trackedTouches.putAll(touchesToHitTestResult)
             onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.BEGAN)
             if (isInitialTouches) {
                 setState(UIGestureRecognizerStatePossible)
@@ -158,7 +160,7 @@ private class TouchesGestureRecognizer(
             }
         }
 
-        val interactionMode = touchesToInteractionMode.map {
+        val interactionMode = touchesToHitTestResult.map {
             it.value?.findAncestorInteractionMode(it.key)
         }.findMostRestrictedInteractionMode()
         when (interactionMode) {
@@ -180,7 +182,8 @@ private class TouchesGestureRecognizer(
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent) {
         super.touchesMoved(touches, withEvent)
 
-        if (ignoreTouchesChanges()) {
+        if (isHigherPriorityGestureTrackingTouches()) {
+            markTrackedTouchesAsSuppressedMoves(touches)
             return
         }
 
@@ -213,16 +216,21 @@ private class TouchesGestureRecognizer(
     override fun touchesEnded(touches: Set<*>, withEvent: UIEvent) {
         super.touchesEnded(touches, withEvent)
 
-        if (ignoreTouchesChanges()) {
-            cancelAllTrackedTouches()
-            return
-        }
-
         fun endTouchesEvent() {
             onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.ENDED)
             stopTrackingTouches(touches)
             if (trackedTouches.isEmpty()) {
                 setState(UIGestureRecognizerStateEnded)
+            }
+        }
+
+        if (isHigherPriorityGestureTrackingTouches()) {
+            val touchesWereNotTracked = !touches.containsAnyTrackedTouches()
+            val moveTouchesWereSuppressed = touches.containsAnyTrackedTouchesWithSuppressedMoves()
+
+            if (touchesWereNotTracked || moveTouchesWereSuppressed) {
+                cancelAllTrackedTouches()
+                return
             }
         }
 
@@ -248,6 +256,7 @@ private class TouchesGestureRecognizer(
         setState(UIGestureRecognizerStateCancelled)
         onCancelAllTouches(trackedTouches.keys)
         trackedTouches.clear()
+        trackedTouchesWithSuppressedMoves.clear()
         cancelTouchesFailure()
     }
 
@@ -370,8 +379,9 @@ private class TouchesGestureRecognizer(
         onTouchesEvent = { _, _, _ -> PointerEventResult(anyMovementConsumed = false) }
         onCancelAllTouches = {}
         canIgnoreDragGesture = { false }
-        ignoreTouchesChanges = { false }
+        isHigherPriorityGestureTrackingTouches = { false }
         trackedTouches.clear()
+        trackedTouchesWithSuppressedMoves.clear()
     }
 
     /**
@@ -411,8 +421,39 @@ private class TouchesGestureRecognizer(
      */
     private fun stopTrackingTouches(touches: Set<*>) {
         for (touch in touches) {
-            trackedTouches.remove(touch as UITouch)
+            touch as UITouch
+            trackedTouches.remove(touch)
+            trackedTouchesWithSuppressedMoves.remove(touch)
         }
+    }
+
+    private fun markTrackedTouchesAsSuppressedMoves(touches: Set<*>) {
+        for (touch in touches) {
+            touch as UITouch
+            if (touch in trackedTouches) {
+                trackedTouchesWithSuppressedMoves.add(touch)
+            }
+        }
+    }
+
+    private fun Set<*>.containsAnyTrackedTouches(): Boolean {
+        for (touch in this) {
+            touch as UITouch
+            if (touch in trackedTouches) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun Set<*>.containsAnyTrackedTouchesWithSuppressedMoves(): Boolean {
+        for (touch in this) {
+            touch as UITouch
+            if (touch in trackedTouchesWithSuppressedMoves) {
+                return true
+            }
+        }
+        return false
     }
 }
 
@@ -515,7 +556,7 @@ internal class OverlayInputView(
     onCancelScroll: () -> Unit,
     private var onHoverEvent: (position: DpOffset, event: UIEvent?, eventKind: TouchesEventKind) -> Unit,
     private var onKeyboardPresses: (Set<*>) -> Unit,
-    ignoreTouchChanges: () -> Boolean,
+    isHigherPriorityGestureTrackingTouches: () -> Boolean,
     private var onRemoveSubview: () -> Unit,
 ) : CMPScrollView(CGRectZero.readValue()) {
     /**
@@ -529,7 +570,7 @@ internal class OverlayInputView(
         onTouchesEvent = ::handleTouchesEvent,
         onCancelAllTouches = ::handleCancelAllTouches,
         canIgnoreDragGesture = { canIgnoreDragGesture(it) },
-        ignoreTouchesChanges = ignoreTouchChanges
+        isHigherPriorityGestureTrackingTouches = isHigherPriorityGestureTrackingTouches
     )
 
     private val scrollGestureRecognizer by lazy {
@@ -746,7 +787,7 @@ internal class BackgroundInputView(
     private var isPointInsideInteractionBounds: (CValue<CGPoint>) -> Boolean,
     onTouchesEvent: (touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> PointerEventResult,
     onCancelAllTouches: (touches: Set<*>) -> Unit,
-    ignoreTouchChanges: () -> Boolean,
+    isHigherPriorityGestureTrackingTouches: () -> Boolean,
 ) : UIView(CGRectZero.readValue()) {
 
     private var onAppeared: (() -> Unit)? = null
@@ -788,7 +829,7 @@ internal class BackgroundInputView(
         onTouchesEvent = onTouchesEvent,
         onCancelAllTouches = onCancelAllTouches,
         canIgnoreDragGesture = { false },
-        ignoreTouchesChanges = ignoreTouchChanges
+        isHigherPriorityGestureTrackingTouches = isHigherPriorityGestureTrackingTouches
     )
 
     init {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/ScreenEdgeTapTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/ScreenEdgeTapTest.kt
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.NavigationEventTransitionState
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import platform.UIKit.UITraitEnvironmentLayoutDirectionLeftToRight
+import platform.UIKit.UITraitEnvironmentLayoutDirectionRightToLeft
+
+internal class ScreenEdgeTapInHostingViewTest : ScreenEdgeTapTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = true, it) }
+)
+
+internal class ScreenEdgeTapInHostingViewControllerTest : ScreenEdgeTapTest(
+    runUIKitInstrumentedTest = { runUIKitInstrumentedTest(useHostingView = false, it) }
+)
+
+internal abstract class ScreenEdgeTapTest(
+    private val runUIKitInstrumentedTest: (UIKitInstrumentedTest.() -> Unit) -> Unit
+) {
+    @Test
+    fun testRepeatedTapsFromLeftEdgeDispatchClicksToComposeInLtr() = runUIKitInstrumentedTest {
+        runRepeatedEdgeTapTest(
+            initialLayoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight,
+            edge = Edge.Left,
+            expectedMessagePrefix = "left edge taps should reach Compose in LTR"
+        )
+    }
+
+    @Test
+    fun testRepeatedTapsFromRightEdgeDispatchClicksToComposeInLtr() = runUIKitInstrumentedTest {
+        runRepeatedEdgeTapTest(
+            initialLayoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight,
+            edge = Edge.Right,
+            expectedMessagePrefix = "right edge taps should reach Compose in LTR"
+        )
+    }
+
+    @Test
+    fun testRepeatedTapsFromLeftEdgeDispatchClicksToComposeInRtl() = runUIKitInstrumentedTest {
+        runRepeatedEdgeTapTest(
+            initialLayoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft,
+            edge = Edge.Left,
+            expectedMessagePrefix = "left edge taps should reach Compose in RTL"
+        )
+    }
+
+    @Test
+    fun testRepeatedTapsFromRightEdgeDispatchClicksToComposeInRtl() = runUIKitInstrumentedTest {
+        runRepeatedEdgeTapTest(
+            initialLayoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft,
+            edge = Edge.Right,
+            expectedMessagePrefix = "right edge taps should reach Compose in RTL"
+        )
+    }
+
+    @Test
+    fun testChangingLtrToRtlStillDispatchesRepeatedEdgeTapsToCompose() = runUIKitInstrumentedTest {
+        var tapCount = -1
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+        var composeLayoutDirection: LayoutDirection? = null
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            TapTestContent(
+                onTapCountChanged = { tapCount = it },
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it },
+                onComposeLayoutDirectionChanged = { composeLayoutDirection = it }
+            )
+        }
+
+        waitUntil("tap surface should be ready in LTR") {
+            tapCount == 0 && backCompletedCount == 0 && composeLayoutDirection == LayoutDirection.Ltr
+        }
+
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Left,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "left edge taps should reach Compose before switching to RTL"
+        )
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Right,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "right edge taps should reach Compose before switching to RTL"
+        )
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionRightToLeft)
+
+        waitUntil("compose layout direction should switch to RTL") {
+            composeLayoutDirection == LayoutDirection.Rtl
+        }
+
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Left,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "left edge taps should still reach Compose after switching to RTL"
+        )
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Right,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "right edge taps should still reach Compose after switching to RTL"
+        )
+    }
+
+    @Test
+    fun testChangingRtlToLtrStillDispatchesRepeatedEdgeTapsToCompose() = runUIKitInstrumentedTest {
+        var tapCount = -1
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+        var composeLayoutDirection: LayoutDirection? = null
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionRightToLeft) {
+            TapTestContent(
+                onTapCountChanged = { tapCount = it },
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it },
+                onComposeLayoutDirectionChanged = { composeLayoutDirection = it }
+            )
+        }
+
+        waitUntil("tap surface should be ready in RTL") {
+            tapCount == 0 && backCompletedCount == 0 && composeLayoutDirection == LayoutDirection.Rtl
+        }
+
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Left,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "left edge taps should reach Compose before switching to LTR"
+        )
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Right,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "right edge taps should reach Compose before switching to LTR"
+        )
+
+        setLayoutDirection(UITraitEnvironmentLayoutDirectionLeftToRight)
+
+        waitUntil("compose layout direction should switch to LTR") {
+            composeLayoutDirection == LayoutDirection.Ltr
+        }
+
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Left,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "left edge taps should still reach Compose after switching to LTR"
+        )
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = Edge.Right,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = "right edge taps should still reach Compose after switching to LTR"
+        )
+    }
+
+    private fun UIKitInstrumentedTest.runRepeatedEdgeTapTest(
+        initialLayoutDirection: Long,
+        edge: Edge,
+        expectedMessagePrefix: String
+    ) {
+        var tapCount = -1
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = initialLayoutDirection) {
+            TapTestContent(
+                onTapCountChanged = { tapCount = it },
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it }
+            )
+        }
+
+        waitUntil("tap surface should be ready") {
+            tapCount == 0 && backCompletedCount == 0
+        }
+
+        assertRepeatedEdgeTapsTriggerComposeClicks(
+            edge = edge,
+            startingTapCount = tapCount,
+            currentTapCount = { tapCount },
+            currentTransitionState = { transitionState },
+            currentBackCompletedCount = { backCompletedCount },
+            messagePrefix = expectedMessagePrefix
+        )
+    }
+
+    private fun UIKitInstrumentedTest.assertRepeatedEdgeTapsTriggerComposeClicks(
+        edge: Edge,
+        startingTapCount: Int,
+        currentTapCount: () -> Int,
+        currentTransitionState: () -> NavigationEventTransitionState,
+        currentBackCompletedCount: () -> Int,
+        messagePrefix: String
+    ) {
+        val tapPositions = edgeTapPositions(edge)
+        tapPositions.forEach { position ->
+            tapFromEdge(position)
+        }
+
+        val expectedTapCount = startingTapCount + tapPositions.size
+        waitUntil(
+            "$messagePrefix: " +
+                "expected $expectedTapCount clicks got ${currentTapCount()} clicks"
+        ) { currentTapCount() == expectedTapCount }
+        assertEquals(
+            expectedTapCount,
+            currentTapCount(),
+            message = "$messagePrefix: all edge taps should be delivered to Compose"
+        )
+        assertTrue(
+            currentTransitionState() is NavigationEventTransitionState.Idle,
+            message = "$messagePrefix: taps should not start back navigation"
+        )
+        assertEquals(
+            0,
+            currentBackCompletedCount(),
+            message = "$messagePrefix: taps should not complete back navigation"
+        )
+    }
+
+    private fun UIKitInstrumentedTest.edgeTapPositions(edge: Edge): List<DpOffset> {
+        val verticalFractions = listOf(0.1f, 0.3f, 0.5f, 0.7f, 0.9f)
+        return verticalFractions.map { fraction ->
+            val y = screenBounds.top + (screenBounds.bottom - screenBounds.top) * fraction
+            when (edge) {
+                Edge.Left -> DpOffset(screenBounds.left, y)
+                Edge.Right -> DpOffset(screenBounds.right - 1.dp, y)
+            }
+        }
+    }
+
+    private fun UIKitInstrumentedTest.tapFromEdge(position: DpOffset) {
+        touchDown(position, fromEdge = true).up()
+    }
+}
+
+@Composable
+private fun TapTestContent(
+    onTapCountChanged: (Int) -> Unit = {},
+    onTransitionStateChanged: (NavigationEventTransitionState) -> Unit = {},
+    onBackCompletedCountChanged: (Int) -> Unit = {},
+    onComposeLayoutDirectionChanged: (LayoutDirection) -> Unit = {}
+) {
+    var tapCount by remember { mutableIntStateOf(0) }
+    var backCompletedCount by remember { mutableIntStateOf(0) }
+    val navigationEventState = rememberNavigationEventState(
+        currentInfo = NavigationEventInfo.None,
+        backInfo = listOf<NavigationEventInfo>(NavigationEventInfo.None)
+    )
+
+    val composeLayoutDirection = LocalLayoutDirection.current
+    SideEffect {
+        onComposeLayoutDirectionChanged(composeLayoutDirection)
+    }
+
+    onTapCountChanged(tapCount)
+    onTransitionStateChanged(navigationEventState.transitionState)
+    onBackCompletedCountChanged(backCompletedCount)
+
+    NavigationBackHandler(
+        state = navigationEventState,
+        onBackCompleted = {
+            backCompletedCount += 1
+        }
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(TAP_SURFACE)
+            .clickable {
+                tapCount += 1
+            }
+    )
+}
+
+private const val TAP_SURFACE = "tapSurface"
+
+private enum class Edge {
+    Left,
+    Right
+}


### PR DESCRIPTION
Fixes a regression in touch handling while preventing Compose from processing touches that should belong to the UIKit back-swipe gesture. 

Previously, if the back gesture recognizer was only tracking touches in `Possible`, `TouchesGestureRecognizer` could stop forwarding the touch to Compose too early. That fixed the drawer opening during back swipe conflict (#3165 ), but it also caused simple taps near the screen edge to be dropped.

Fixes [CMP-10465](https://youtrack.jetbrains.com/issue/CMP-10465) [iOS] Back button doesn't always respond to taps

## Testing
Adds `ScreenEdgeTapTest` test suite

This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix an issue where taps near the screen edge could be missed when the back-swipe gesture recognizer was tracking touches