### PR TITLE
Fix IndexOutOfBoundsException in MultiSelectionLayout when a new seletion starts past every selectable

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionLayout.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionLayout.kt
@@ -176,12 +176,9 @@ private class MultiSelectionLayout(
             when {
                 startSlot < endSlot -> CrossStatus.NOT_CROSSED
                 startSlot > endSlot -> CrossStatus.CROSSED
-                // because one of the slots is not-dragging, it must be on a text directly
-                // because one of the slots is on a text directly and the start/end slots are equal,
-                // they both must be odd. Given this, dividing the slot by 2 should give us the
-                // correct
-                // info index.
-                else -> infoList[startSlot / 2].rawCrossStatus
+                // Clamp: when the gesture starts past every selectable, both slots default
+                // to lastSlot = 2 * infoList.size, so slot / 2 would be out of bounds.
+                else -> infoList[(startSlot / 2).coerceAtMost(infoList.lastIndex)].rawCrossStatus
             }
 
     override val startInfo: SelectableInfo
@@ -303,7 +300,9 @@ private class MultiSelectionLayout(
 
     private fun slotToIndex(slot: Int, isMinimumSlot: Boolean): Int {
         val slotAdjustment = if (isMinimumSlot) 0 else 1
-        return (slot - slotAdjustment) / 2
+        // Clamp: when the gesture starts past every selectable, slots default
+        // to lastSlot = 2 * infoList.size, so slot / 2 would be out of bounds.
+        return ((slot - slotAdjustment) / 2).coerceIn(0, infoList.lastIndex)
     }
 
     private fun getInfoListIndexBySelectableId(id: Long): Int =


### PR DESCRIPTION
MultiSelectionLayout.crossStatus assumed that when startSlot == endSlot, at least one of them was the non-dragging handle anchored ON a text, so both slots had to be odd and `slot / 2` was a valid info index

That assumpton fails when a fresh mouse-down starts a NEEW selection and the gesture position lands past every selectable in the SelectionContainer so the SelectionLayoutBuilder.updateSlot returns AFTER for every appended info, so both startSlot and endSlot stay UNASSIGNED_SLOT and get defaulted to `lastSlot = 2 * infoList.size` inside of build() 

Now both slots are equal and even, `startSlot / 2 == infoList.size` is out of bounds, and every accessor that reads infoList through slotToIndex throws IndexOutOfBoundsException

## Testing

Reproduce with, on jvm desktop for ex with
```kotlin
    SelectionContainer(Modifier.fillMaxSize()) {
        Column {
            repeat(3) { BasicText("chunk ${it + 1}") }
            Spacer(Modifier.height(500.dp))
        }
    }
```

Mouse-press in the empty area below "chunk 3", it would throws `IndexOutOfBoundsException: Index 3 out of bounds for length 3` at MultiSelectionLayout.getCrossStatus(SelectionLayout.kt:184).
