### PR TITLE
Add native touch support on Windows with multi-touch and pen input

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -67,4 +67,5 @@ val Components = Screen.Selection(
     Screen.Example("WindowAdaptiveInfo") { AdaptiveExample() },
     Screen.Example("Drag and Drop") { DragAndDropExample() },
     Screen.Example("Pen Input") { PenInputExample() },
+    Screen.Example("Multitouch") { MultitouchExample() },
 )

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/MultitouchExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/MultitouchExample.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+private val Palette = listOf(
+    Color(0xFF0000AA),
+    Color(0xFF00AA00),
+    Color(0xFFAA0000),
+    Color(0xFFAA00AA),
+    Color(0xFF00AAAA),
+    Color(0xFFAA5500),
+    Color(0xFF5555FF),
+    Color(0xFF55AA55),
+)
+
+private data class TouchPointer(
+    val position: Offset,
+    val type: PointerType,
+)
+
+@Composable
+fun MultitouchExample() {
+    val pointers = remember { mutableStateMapOf<PointerId, TouchPointer>() }
+    var lastInfo by remember { mutableStateOf("Touch the area below with one or more pointers") }
+
+    Column(
+        Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = lastInfo,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+        Canvas(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(Color(0xFFF5F5F5))
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            for (change in event.changes) {
+                                if (change.pressed) {
+                                    pointers[change.id] = TouchPointer(change.position, change.type)
+                                } else {
+                                    pointers.remove(change.id)
+                                }
+                                change.consume()
+                            }
+                            if (pointers.isNotEmpty()) {
+                                lastInfo = "pointers=${pointers.size}, " +
+                                    "types=${pointers.values.map { it.type.name() }.toSet().joinToString()}"
+                            }
+                        }
+                    }
+                }
+        ) {
+            for ((id, pointer) in pointers) {
+                val color = Palette[(id.value % Palette.size).toInt()]
+                drawCircle(
+                    color = color.copy(alpha = 0.3f),
+                    radius = 32.dp.toPx(),
+                    center = pointer.position,
+                )
+                drawCircle(
+                    color = color,
+                    radius = 32.dp.toPx(),
+                    center = pointer.position,
+                    style = Stroke(width = 2.dp.toPx()),
+                )
+            }
+        }
+    }
+}
+
+private fun PointerType.name(): String = when (this) {
+    PointerType.Touch -> "Touch"
+    PointerType.Mouse -> "Mouse"
+    PointerType.Stylus -> "Stylus"
+    PointerType.Eraser -> "Eraser"
+    else -> "Unknown"
+}

--- a/compose/ui/ui/build-fork.gradle
+++ b/compose/ui/ui/build-fork.gradle
@@ -221,6 +221,9 @@ androidXMultiplatform {
 
         desktopMain {
             dependsOn(skikoMain)
+            dependencies {
+                implementation(libs.jnaPlatform)
+            }
         }
 
         desktopTest {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -223,6 +223,9 @@ androidXMultiplatform {
 
         desktopMain {
             dependsOn(skikoMain)
+            dependencies {
+                implementation(libs.jnaPlatform)
+            }
         }
 
         desktopTest {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
@@ -105,6 +105,22 @@ internal object ComposeFeatureFlags {
     val redispatchUnconsumedMouseWheelEvents = FeatureFlag {
         System.getProperty("compose.swing.redispatchMouseWheelEvents", "true").toBoolean()
     }
+
+    /**
+     * Indicates whether the window should receive raw touch input on Windows.
+     *
+     * By default, Windows synthesizes mouse events for touch input, so touch screens are
+     * handled as a mouse with a single pointer. Enabling this flag makes Compose receive
+     * native touch events with [androidx.compose.ui.input.pointer.PointerType.Touch]
+     * (or [androidx.compose.ui.input.pointer.PointerType.Stylus] for a pen) pointers
+     * instead, which restores touch semantics (such as touch slop) and enables multi-touch
+     * gestures.
+     *
+     * This flag has no effect on other operating systems.
+     */
+    val useWindowsNativeTouch = FeatureFlag {
+        System.getProperty("compose.windows.nativeTouch").toBoolean()
+    }
 }
 
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.isClearFocusOnMouseDownEnabled
@@ -113,6 +114,7 @@ import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
+import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkikoRenderDelegate
 import org.jetbrains.skiko.hostOs
 import org.jetbrains.skiko.swing.SkiaSwingLayer
@@ -422,6 +424,14 @@ internal class ComposeSceneMediator(
 
     var isClearFocusOnMouseDownEnabled: Boolean = ComposeUiFlags.isClearFocusOnMouseDownEnabled
 
+    private var windowsTouchBridge: WindowsTouchBridge? = null
+
+    /**
+     * The currently active touch pointers. Required to send the complete list of pointers
+     * with each touch event.
+     */
+    private val touchPointers = linkedMapOf<PointerId, ComposeScenePointer>()
+
     init {
         // Transparency is used during redrawer creation that triggered by [addNotify], so
         // it must be set to correct value before adding to the hierarchy to handle cases
@@ -588,6 +598,77 @@ internal class ComposeSceneMediator(
         }
     }
 
+    /**
+     * Enables receiving raw touch input instead of the mouse events synthesized by Windows.
+     *
+     * @see ComposeFeatureFlags.useWindowsNativeTouch
+     */
+    private fun initializeWindowsTouchBridge() {
+        if (windowsTouchBridge != null || windowHandle == 0L) {
+            return
+        }
+        windowsTouchBridge = try {
+            WindowsTouchBridge(windowHandle, ::onTouchEvent, ::onTouchCancel)
+        } catch (e: IllegalStateException) {
+            // The window procedure cannot be subclassed. Mouse events synthesized from
+            // touch input are still received in this case.
+            null
+        }
+    }
+
+    private fun onTouchEvent(
+        id: Long,
+        screenPosition: Offset,
+        state: TouchState,
+        type: PointerType,
+        pressure: Float
+    ) = catchExceptions {
+        // The bridge can send events after the window is disposed or hidden
+        if (isDisposed || !contentComponent.isShowing) {
+            return@catchExceptions
+        }
+        processMouseEvent {
+            // [screenPosition] is in physical pixels, while [locationOnScreen] is in
+            // density-independent AWT coordinates
+            val density = contentComponent.density.density
+            val locationOnScreen = contentComponent.locationOnScreen
+            val sceneOffset = sceneBoundsInPx?.topLeft ?: Offset.Zero
+            val position = Offset(
+                screenPosition.x - locationOnScreen.x * density,
+                screenPosition.y - locationOnScreen.y * density
+            ) - sceneOffset
+
+            val pointerId = PointerId(id)
+            touchPointers[pointerId] = ComposeScenePointer(
+                id = pointerId,
+                position = position,
+                pressed = state != TouchState.Up,
+                type = type,
+                pressure = pressure,
+            )
+            val pointers = touchPointers.values.toList()
+            if (state == TouchState.Up) {
+                touchPointers.remove(pointerId)
+            }
+            scene.sendPointerEvent(
+                eventType = when (state) {
+                    TouchState.Down -> PointerEventType.Press
+                    TouchState.Move -> PointerEventType.Move
+                    TouchState.Up -> PointerEventType.Release
+                },
+                pointers = pointers,
+            )
+        }
+    }
+
+    private fun onTouchCancel() = catchExceptions {
+        if (isDisposed || touchPointers.isEmpty()) {
+            return@catchExceptions
+        }
+        touchPointers.clear()
+        scene.cancelPointerInput()
+    }
+
     private fun onKeyEvent(event: KeyEvent) = catchExceptions {
         // AWT can send events after the window is disposed
         if (isDisposed) {
@@ -614,6 +695,8 @@ internal class ComposeSceneMediator(
         isDisposed = true
 
         unsubscribeFromInputEvents()
+        windowsTouchBridge?.dispose()
+        windowsTouchBridge = null
 
         container.remove(contentComponent)
         container.remove(invisibleComponent)
@@ -638,6 +721,10 @@ internal class ComposeSceneMediator(
 
         architectureComponentsOwner.navigationEventDispatcherOwner
             .navigationEventDispatcher.addInput(navigationEventInput)
+
+        if (ComposeFeatureFlags.useWindowsNativeTouch.value && hostOs == OS.Windows) {
+            initializeWindowsTouchBridge()
+        }
 
         _onComponentAttached?.invoke()
         _onComponentAttached = null

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowsTouchBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowsTouchBridge.desktop.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scene
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerType
+import com.sun.jna.CallbackReference
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+import com.sun.jna.platform.win32.BaseTSD
+import com.sun.jna.platform.win32.User32
+import com.sun.jna.platform.win32.WinDef
+import com.sun.jna.platform.win32.WinNT
+import com.sun.jna.platform.win32.WinUser
+import javax.swing.SwingUtilities
+
+internal enum class TouchState {
+    Down,
+    Move,
+    Up
+}
+
+/**
+ * Receives raw touch and pen input (`WM_POINTER`) for a window on Windows.
+ *
+ * AWT doesn't handle pointer messages, so they reach `DefWindowProc`, which synthesizes
+ * mouse events for them, and touch screens are handled as a mouse. This class subclasses
+ * the window procedure to handle `WM_POINTER` messages before the mouse event synthesis
+ * happens. Hovering pointers (such as a pen in range of the digitizer, but not touching it)
+ * are not handled and remain reported as mouse moves.
+ *
+ * [dispose] restores the original window procedure.
+ *
+ * @param windowHandle the HWND of the top-level window to receive pointer input for
+ * @param onTouchEvent the touch event callback; called on the event dispatch thread with
+ * the pointer position in the screen coordinate space, in physical pixels. [PointerType] is
+ * [PointerType.Stylus] for input coming from a pen ([PointerType.Eraser] if the pen is
+ * inverted or its eraser button is pressed), and [PointerType.Touch] otherwise
+ * @param onTouchCancel called on the event dispatch thread when the ongoing touch input is
+ * canceled, for example when the pointer is captured by the system for an edge gesture
+ *
+ * @throws IllegalStateException if [windowHandle] is not a valid window handle
+ */
+internal class WindowsTouchBridge(
+    windowHandle: Long,
+    private val onTouchEvent: (
+        id: Long,
+        position: Offset,
+        state: TouchState,
+        type: PointerType,
+        pressure: Float
+    ) -> Unit,
+    private val onTouchCancel: () -> Unit,
+) {
+    private val user32 = PointerInputUser32.INSTANCE
+
+    /**
+     * AWT dispatches input events to the first heavyweight child of the top-level window
+     * rather than to the window itself, so its window procedure is the one to subclass.
+     */
+    private val hwnd: WinDef.HWND
+
+    // Keep a strong reference to the callback to prevent its garbage collection while
+    // the native code holds a pointer to it.
+    private val windowProc: WindowProc
+
+    private val originalWindowProc: BaseTSD.LONG_PTR
+
+    private var isDisposed = false
+
+    init {
+        require(windowHandle != 0L) { "Invalid window handle: 0" }
+
+        val window = WinDef.HWND(Pointer.createConstant(windowHandle))
+        check(user32.IsWindow(window)) {
+            "Invalid window handle: 0x${windowHandle.toString(16)}"
+        }
+        hwnd = user32.GetWindow(window, GW_CHILD) ?: window
+
+        windowProc = WindowProc()
+        originalWindowProc = user32.GetWindowLongPtrA(hwnd, GWLP_WNDPROC)
+        val callbackPointer = CallbackReference.getFunctionPointer(windowProc)
+        user32.SetWindowLongPtrA(
+            hwnd,
+            GWLP_WNDPROC,
+            BaseTSD.LONG_PTR(Pointer.nativeValue(callbackPointer))
+        )
+    }
+
+    /**
+     * Restores the original window procedure.
+     */
+    fun dispose() {
+        if (isDisposed) {
+            return
+        }
+        isDisposed = true
+        user32.SetWindowLongPtrA(hwnd, GWLP_WNDPROC, originalWindowProc)
+    }
+
+    private inner class WindowProc : WinUser.WindowProc {
+        override fun callback(
+            hwnd: WinDef.HWND,
+            uMsg: Int,
+            wParam: WinDef.WPARAM,
+            lParam: WinDef.LPARAM
+        ): WinDef.LRESULT = when (uMsg) {
+            WM_POINTERDOWN, WM_POINTERUPDATE, WM_POINTERUP ->
+                if (onPointerMessage(uMsg, wParam)) {
+                    // Mark the message as handled to prevent mouse event synthesis
+                    WinDef.LRESULT(0)
+                } else {
+                    user32.CallWindowProcA(originalWindowProc, hwnd, uMsg, wParam, lParam)
+                }
+            WM_POINTERCAPTURECHANGED -> {
+                SwingUtilities.invokeLater(onTouchCancel)
+                WinDef.LRESULT(0)
+            }
+            else -> user32.CallWindowProcA(originalWindowProc, hwnd, uMsg, wParam, lParam)
+        }
+    }
+
+    /**
+     * Handles a `WM_POINTER` message, and returns whether it was handled.
+     *
+     * Messages of hovering pointers, and of pointer types other than touch and pen, are
+     * not handled and should be passed to the original window procedure.
+     */
+    private fun onPointerMessage(uMsg: Int, wParam: WinDef.WPARAM): Boolean {
+        // The low-order word of wParam contains the pointer identifier
+        val pointerId = (wParam.toLong() and 0xFFFF).toInt()
+        val info = POINTER_INFO()
+        if (!user32.GetPointerInfo(pointerId, info)) {
+            return false
+        }
+        if (info.pointerType != PT_TOUCH && info.pointerType != PT_PEN) {
+            return false
+        }
+        val state = when (uMsg) {
+            WM_POINTERDOWN -> TouchState.Down
+            WM_POINTERUP -> TouchState.Up
+            else -> TouchState.Move
+        }
+        // Don't handle hovering pointers to keep reporting them as mouse moves
+        if (state == TouchState.Move && info.pointerFlags and POINTER_FLAG_INCONTACT == 0) {
+            return false
+        }
+        if (info.pointerFlags and POINTER_FLAG_CANCELED != 0) {
+            SwingUtilities.invokeLater(onTouchCancel)
+            return true
+        }
+
+        var type = PointerType.Touch
+        var pressure = 1f
+        if (info.pointerType == PT_PEN) {
+            type = PointerType.Stylus
+            val penInfo = POINTER_PEN_INFO()
+            if (user32.GetPointerPenInfo(pointerId, penInfo)) {
+                if (penInfo.penFlags and (PEN_FLAG_INVERTED or PEN_FLAG_ERASER) != 0) {
+                    type = PointerType.Eraser
+                }
+                if (penInfo.penMask and PEN_MASK_PRESSURE != 0) {
+                    pressure = penInfo.pressure / 1024f
+                }
+            }
+        }
+        val position = Offset(
+            info.ptPixelLocation.x.toFloat(),
+            info.ptPixelLocation.y.toFloat()
+        )
+        SwingUtilities.invokeLater {
+            onTouchEvent(pointerId.toLong(), position, state, type, pressure)
+        }
+        return true
+    }
+}
+
+// See https://learn.microsoft.com/en-us/windows/win32/inputmsg/messages
+private const val WM_POINTERUPDATE = 0x0245
+private const val WM_POINTERDOWN = 0x0246
+private const val WM_POINTERUP = 0x0247
+private const val WM_POINTERCAPTURECHANGED = 0x024C
+private const val PT_TOUCH = 2
+private const val PT_PEN = 3
+private const val POINTER_FLAG_INCONTACT = 0x00000004
+private const val POINTER_FLAG_CANCELED = 0x00008000
+private const val PEN_FLAG_INVERTED = 0x00000002
+private const val PEN_FLAG_ERASER = 0x00000004
+private const val PEN_MASK_PRESSURE = 0x00000001
+private const val GWLP_WNDPROC = -4
+private const val GW_CHILD = 5
+
+/**
+ * [User32] extended with the pointer input functions that are missing from JNA.
+ */
+internal interface PointerInputUser32 : User32 {
+    /** Retrieves a handle to a window that has the specified relationship to [hWnd]. */
+    fun GetWindow(hWnd: WinDef.HWND, uCmd: Int): WinDef.HWND?
+
+    /** Retrieves the information of the pointer with the given identifier. */
+    fun GetPointerInfo(pointerId: Int, pointerInfo: POINTER_INFO): Boolean
+
+    /** Retrieves the pen-specific information of the pointer with the given identifier. */
+    fun GetPointerPenInfo(pointerId: Int, penInfo: POINTER_PEN_INFO): Boolean
+
+    /** Retrieves information about the specified window, such as its window procedure. */
+    fun GetWindowLongPtrA(hWnd: WinDef.HWND, nIndex: Int): BaseTSD.LONG_PTR
+
+    /** Changes an attribute of the specified window, such as its window procedure. */
+    fun SetWindowLongPtrA(hWnd: WinDef.HWND, nIndex: Int, dwNewLong: BaseTSD.LONG_PTR): BaseTSD.LONG_PTR
+
+    /** Passes message information to the specified window procedure. */
+    fun CallWindowProcA(
+        lpPrevWndFunc: BaseTSD.LONG_PTR,
+        hWnd: WinDef.HWND,
+        uMsg: Int,
+        wParam: WinDef.WPARAM,
+        lParam: WinDef.LPARAM
+    ): WinDef.LRESULT
+
+    companion object {
+        val INSTANCE: PointerInputUser32 = Native.load("user32", PointerInputUser32::class.java)
+    }
+}
+
+/**
+ * The `POINTER_INFO` structure with the information common to all pointer types.
+ *
+ * See https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-pointer_info
+ */
+@Structure.FieldOrder(
+    "pointerType",
+    "pointerId",
+    "frameId",
+    "pointerFlags",
+    "sourceDevice",
+    "hwndTarget",
+    "ptPixelLocation",
+    "ptHimetricLocation",
+    "ptPixelLocationRaw",
+    "ptHimetricLocationRaw",
+    "dwTime",
+    "historyCount",
+    "InputData",
+    "dwKeyStates",
+    "PerformanceCount",
+    "ButtonChangeType"
+)
+internal class POINTER_INFO : Structure() {
+    @JvmField var pointerType: Int = 0
+    @JvmField var pointerId: Int = 0
+    @JvmField var frameId: Int = 0
+    @JvmField var pointerFlags: Int = 0
+    @JvmField var sourceDevice: WinNT.HANDLE? = null
+    @JvmField var hwndTarget: WinDef.HWND? = null
+    @JvmField var ptPixelLocation: WinDef.POINT = WinDef.POINT()
+    @JvmField var ptHimetricLocation: WinDef.POINT = WinDef.POINT()
+    @JvmField var ptPixelLocationRaw: WinDef.POINT = WinDef.POINT()
+    @JvmField var ptHimetricLocationRaw: WinDef.POINT = WinDef.POINT()
+    @JvmField var dwTime: Int = 0
+    @JvmField var historyCount: Int = 0
+    @JvmField var InputData: Int = 0
+    @JvmField var dwKeyStates: Int = 0
+    @JvmField var PerformanceCount: Long = 0
+    @JvmField var ButtonChangeType: Int = 0
+}
+
+/**
+ * The `POINTER_PEN_INFO` structure with the pen-specific pointer information.
+ *
+ * See https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-pointer_pen_info
+ */
+@Structure.FieldOrder(
+    "pointerInfo",
+    "penFlags",
+    "penMask",
+    "pressure",
+    "rotation",
+    "tiltX",
+    "tiltY"
+)
+internal class POINTER_PEN_INFO : Structure() {
+    @JvmField var pointerInfo: POINTER_INFO = POINTER_INFO()
+    @JvmField var penFlags: Int = 0
+    @JvmField var penMask: Int = 0
+    @JvmField var pressure: Int = 0
+    @JvmField var rotation: Int = 0
+    @JvmField var tiltX: Int = 0
+    @JvmField var tiltY: Int = 0
+}

--- a/gradle/libs-fork.versions.toml
+++ b/gradle/libs-fork.versions.toml
@@ -48,6 +48,7 @@ incap = "0.2"
 javaxInject = "1"
 jbrApi = "1.9.0"
 jcodec = "0.2.5"
+jna = "5.19.1"
 kotlin18 = "1.8.22"
 kotlin19 = "1.9.24"
 # Use the most up-to-date patch
@@ -179,6 +180,7 @@ javaxInject = { module = "javax.inject:javax.inject", version.ref = "javaxInject
 jbrApi = { module = "org.jetbrains.runtime:jbr-api", version.ref = "jbrApi" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodecJavaSe = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+jnaPlatform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.16.2" }
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 jsqlparser = { module = "com.github.jsqlparser:jsqlparser", version = "3.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ incap = "0.2"
 javaxInject = "1"
 jbrApi = "1.9.0"
 jcodec = "0.2.5"
+jna = "5.19.1"
 kotlin18 = "1.8.22"
 kotlin19 = "1.9.24"
 # Use the most up-to-date patch
@@ -179,6 +180,7 @@ javaxInject = { module = "javax.inject:javax.inject", version.ref = "javaxInject
 jbrApi = { module = "org.jetbrains.runtime:jbr-api", version.ref = "jbrApi" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodecJavaSe = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }
+jnaPlatform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.16.2" }
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 jsqlparser = { module = "com.github.jsqlparser:jsqlparser", version = "3.1" }


### PR DESCRIPTION
## Issue

Compose for Desktop has no native touch support on Windows. AWT doesn't handle touch, and Windows synthesizes mouse events for it, so a touch screen is treated as a mouse with a single pointer: every finger becomes `PointerType.Mouse`, only one contact is tracked, there is no touch slop, no multi-touch gestures like pinch-to-zoom, and drag-to-scroll is unreliable. Pens lose their type, pressure and eraser state the same way.

This PR adds a full native touch input pipeline for Windows rather than patching the symptoms:

- Multiple simultaneous fingers, each tracked as its own pointer
- Real pointer type mapping: fingers arrive as `PointerType.Touch`, pens as `PointerType.Stylus`, and an inverted pen or pressed eraser button as `PointerType.Eraser`
- Pen pressure reported through `ComposeScenePointer.pressure`
- Proper cancellation when the system takes over a gesture

Fixes [CMP-1609](https://youtrack.jetbrains.com/issue/CMP-1609)
Relates to [CMP-2209](https://youtrack.jetbrains.com/issue/CMP-2209), [CMP-6429](https://youtrack.jetbrains.com/issue/CMP-6429), [CMP-9125](https://youtrack.jetbrains.com/issue/CMP-9125), [CMP-5945](https://youtrack.jetbrains.com/issue/CMP-5945)

## Changes

- Added `WindowsTouchBridge` that subclasses the window procedure and handles `WM_POINTER` messages before the mouse event synthesis happens. The [pointer input API](https://learn.microsoft.com/en-us/windows/win32/inputmsg/messages) (Windows 8+) is used instead of the legacy `WM_TOUCH`, which is emulated on top of it and requires a thread-affine registration call.
- `ComposeSceneMediator` keeps track of the active contacts and sends each event to `ComposeScene` with the complete list of pressed pointers, which is what makes multi-finger gestures work.
- Pointer types are mapped from the native data: `PT_TOUCH` to `Touch`, `PT_PEN` to `Stylus` with the pressure from `GetPointerPenInfo`, and `PEN_FLAG_INVERTED`/`PEN_FLAG_ERASER` to `Eraser`.
- `WM_POINTERCAPTURECHANGED` and `POINTER_FLAG_CANCELED` (for example, the system capturing the pointer for an edge gesture) cancel the ongoing pointer input to avoid stuck pointers.
- Hovering pointers (a pen in range but not touching) are not intercepted and are still reported as mouse moves, so the hover cursor keeps working.
- `EnableMouseInPointer` is intentionally not called: it's process-global and would reroute the mouse input AWT relies on. Touch and pen produce `WM_POINTER` messages without it.
- The feature is opt-in behind the `compose.windows.nativeTouch` system property and has no effect on other operating systems.
- Since AWT provides no touch API, the implementation uses JNA, which adds a `net.java.dev.jna:jna-platform:5.19.1` dependency to the desktop target of `compose:ui:ui` (declared in both version catalogs).
- Added a `Multitouch` example to the mpp demo that visualizes the active pointers.

Implementation notes:
- AWT dispatches input to the first heavyweight child of the top-level window rather than the window itself, so the bridge subclasses the window procedure of the child of the given `windowHandle`.
- Pen tilt and rotation are available from `GetPointerPenInfo` but not mapped, since `ComposeScenePointer` has no corresponding fields.
- The bridge is internal and flag-gated, so if this later moves to a lower layer (JBR or Skiko), only the bridge class changes.

## Testing

Tested on Windows 11, Recording attached below.

https://github.com/user-attachments/assets/7ab61c89-f97e-4495-a382-95fcf04bdfd7


`./gradlew :compose:mpp:demo:runDesktop -Dcompose.windows.nativeTouch=true
`
Verified:
- The `Components/Multitouch` example shows one pointer per finger with `types=Touch` (`Stylus` for a pen). Without the flag it shows a single `Mouse` pointer.
- Scrolling a `LazyColumn` with a finger, touch slop, pinch-to-zoom via `detectTransformGestures`.
- Pen pressure in the `Components/Pen Input` example (this makes the demo introduced in #3079 functional on Windows).

This should be tested by QA.

## Release Notes
### Features - Desktop
- Added experimental native touch and pen support on Windows with multi-touch gestures, pointer type mapping (touch, stylus, eraser) and pen pressure. Enable it with the `compose.windows.nativeTouch` system property

