### PR TITLE
Ensure floating cursor stays within text layout bounds on iOS

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -295,7 +295,8 @@ internal abstract class TextInputConnection(
         val virtualCursorPx = fingerPx + translation
         val cursorOffset = layout.getOffsetForPosition(virtualCursorPx)
 
-
+        // Re-anchor translation to the text edge, not the touch position — otherwise a fast
+        // swipe past the text makes the user drag that whole distance back (and cursor looks frozen)
         val line = layout.getLineForOffset(cursorOffset)
         val lineLeft = layout.getLineLeft(line)
         val lineRight = layout.getLineRight(line)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -289,11 +289,33 @@ internal abstract class TextInputConnection(
 
     override fun updateFloatingCursor(offset: DpOffset) {
         val translation = floatingCursorTranslation ?: return
-        val offsetPx = offset.toOffset(view.density)
-        val pos = textLayoutResult?.getOffsetForPosition(offsetPx + translation) ?: return
+        val layout = textLayoutResult ?: return
+
+        val fingerPx = offset.toOffset(view.density)
+        val virtualCursorPx = fingerPx + translation
+        val cursorOffset = layout.getOffsetForPosition(virtualCursorPx)
+
+
+        val line = layout.getLineForOffset(cursorOffset)
+        val lineLeft = layout.getLineLeft(line)
+        val lineRight = layout.getLineRight(line)
+        val textTop = layout.getLineTop(0)
+        val textBottom = layout.getLineBottom(layout.lineCount - 1)
+
+        val boundedX = virtualCursorPx.x.coerceIn(lineLeft, lineRight)
+        val boundedY = virtualCursorPx.y.coerceIn(textTop, textBottom)
+        val outOfBoundsX = virtualCursorPx.x != boundedX
+        val outOfBoundsY = virtualCursorPx.y != boundedY
+
+        if (outOfBoundsX || outOfBoundsY) {
+            floatingCursorTranslation = Offset(
+                x = if (outOfBoundsX) boundedX - fingerPx.x else translation.x,
+                y = if (outOfBoundsY) boundedY - fingerPx.y else translation.y,
+            )
+        }
 
         edit(requireUpdateView = false) {
-            setSelection(pos, pos)
+            setSelection(cursorOffset, cursorOffset)
         }
     }
 


### PR DESCRIPTION
Fixes [CMP-5702](https://youtrack.jetbrains.com/issue/CMP-5702) iOS. Floating cursor stop working horizontally after very quick swipe

## Testing
Before:    

https://github.com/user-attachments/assets/52a32e2b-d368-401e-b77e-7682c7ce3490  

After:  

https://github.com/user-attachments/assets/3fa6d2dc-1083-4fdd-9de3-4df912f795e2  


## Release Notes
### Fixes - iOS
- Fixed the floating cursor no longer responding horizontally after a very quick swipe on iOS

