### PR TITLE
Make web demo full screen and add a loading indicator

### DIFF
--- a/compose/mpp/demo/src/jsMain/resources/platform.css
+++ b/compose/mpp/demo/src/jsMain/resources/platform.css
@@ -16,7 +16,14 @@
 
 
 
-h1::before {
-    content: "compose multiplatform js demo";
-    display: block;
+body::after {
+	content: "JS";
+	position: fixed;
+	top: 4px;
+	right: 4px;
+	font-family: monospace;
+	font-size: 15px;
+	color: #AAA;
+	pointer-events: none;
+	z-index: 9999;
 }

--- a/compose/mpp/demo/src/wasmJsMain/resources/platform.css
+++ b/compose/mpp/demo/src/wasmJsMain/resources/platform.css
@@ -16,7 +16,14 @@
 
 
 
-h1::before {
-    content: "compose multiplatform wasm demo";
-    display: block;
+body::after {
+	content: "Wasm";
+	position: fixed;
+	top: 4px;
+	right: 4px;
+	font-family: monospace;
+	font-size: 15px;
+	color: #AAA;
+	pointer-events: none;
+	z-index: 9999;
 }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
@@ -63,20 +63,16 @@ fun defaultComposeDemo() {
         val navController = rememberNavController()
         val fontFamilyResolver = LocalFontFamilyResolver.current
         val fontsLoaded = remember { mutableStateOf(false) }
-        val app =
-            remember {
-                App(
-                    extraScreens =
-                        listOf(
-                            BugsScreen,
-                            Screen.Example("Web Clipboard API example") {
-                                WebClipboardDemo()
-                            },
-                            HtmlInteropDemos,
-                            HapticFeedbackExample,
-                        ),
-                )
-            }
+        val app = remember { App(
+            extraScreens = listOf(
+                BugsScreen,
+                Screen.Example("Web Clipboard API example") {
+                    WebClipboardDemo()
+                },
+                HtmlInteropDemos,
+                HapticFeedbackExample,
+            )
+        ) }
 
         if (fontsLoaded.value) {
             app.Content(navController)

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
@@ -59,20 +59,24 @@ fun main() {
     ExperimentalBrowserHistoryApi::class
 )
 fun defaultComposeDemo() {
-    ComposeViewport(viewportContainerId = "composeApplication") {
+    ComposeViewport {
         val navController = rememberNavController()
         val fontFamilyResolver = LocalFontFamilyResolver.current
         val fontsLoaded = remember { mutableStateOf(false) }
-        val app = remember { App(
-            extraScreens = listOf(
-                BugsScreen,
-                Screen.Example("Web Clipboard API example") {
-                    WebClipboardDemo()
-                },
-                HtmlInteropDemos,
-                HapticFeedbackExample,
-            )
-        ) }
+        val app =
+            remember {
+                App(
+                    extraScreens =
+                        listOf(
+                            BugsScreen,
+                            Screen.Example("Web Clipboard API example") {
+                                WebClipboardDemo()
+                            },
+                            HtmlInteropDemos,
+                            HapticFeedbackExample,
+                        ),
+                )
+            }
 
         if (fontsLoaded.value) {
             app.Content(navController)

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
@@ -53,7 +53,7 @@ internal fun setupBackingTextAreaDebugHints() {
         }
 """.trimIndent()
 
-    val container = document.getElementById("composeApplication") as HTMLDivElement
+    val container = document.body ?: error("No body found")
     val shadowRoot = (container.firstChild?.firstChild as HTMLDivElement).shadowRoot!!
 
     shadowRoot.prepend(shadowRootStyle)

--- a/compose/mpp/demo/src/webMain/resources/index.html
+++ b/compose/mpp/demo/src/webMain/resources/index.html
@@ -26,7 +26,8 @@
 </head>
 
 <body>
-<h1></h1>
-<div id="composeApplication"/>
+<div id="loading">
+  <img src="loading.svg" alt="Loading…" />
+</div>
 </body>
 </html>

--- a/compose/mpp/demo/src/webMain/resources/loading.svg
+++ b/compose/mpp/demo/src/webMain/resources/loading.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none">
+    <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.2" stroke-width="2"/>
+    <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="1s" repeatCount="indefinite"/>
+    </path>
+</svg>

--- a/compose/mpp/demo/src/webMain/resources/styles.css
+++ b/compose/mpp/demo/src/webMain/resources/styles.css
@@ -17,38 +17,18 @@
 
 html, body {
     width: 100%;
-    height: 100%;
+    height: 100dvh;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow-x: hidden;
 }
 
-body {
-    display: grid;
-    grid-template-rows: auto 1fr;
-}
-
-h1 {
-    padding: 0 16px;
-    font-size: 2em;
-}
-
-#composeApplication {
-    overflow: hidden;
-}
-
-body:has(textarea) {
-    background-color: aliceblue;
-}
-
-body:has(textarea:focus) {
-    background-color: #eaffe3;
-}
-
-body:has(input) {
-    background-color: aliceblue;
-}
-
-body:has(input:focus) {
-    background-color: #eaffe3;
+#loading {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: #555;
+	pointer-events: none;
 }


### PR DESCRIPTION
Changes:
- remove `<h1>` to make CompsoeViewport fill in the entire viewport
- add a small text label at the top right corner specifying the current kotlin target (js or wasm)
- add a loading indicator (svg)
- replaced `overflow: hidden` by `overflow-x: hidden`, so browser's pull-to-refresh works now

<img width="313" height="115" alt="Screenshot 2026-07-14 at 11 26 54" src="https://github.com/user-attachments/assets/001a18c4-c899-4d8d-8a06-aafac204c8e1" />


## Testing
Manual. Only demo is affected

## Release Notes
N/A


