### PR TITLE
Use didMoveToWindow callback to start CMPViewController lifecycle

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -7,14 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		55F0AA132F70000100ABC123 /* CMPFrameRateRange.m in Sources */ = {isa = PBXBuildFile; fileRef = 55F0AA122F70000100ABC123 /* CMPFrameRateRange.m */; };
 		99009B7A2F322B4700518C1F /* CMPMetalLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 99009B792F322B4700518C1F /* CMPMetalLayer.m */; };
 		99009B7B2F322B4700518C1F /* CMPMetalLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 99009B792F322B4700518C1F /* CMPMetalLayer.m */; };
 		991A97F72E1FB99300B47130 /* CMPScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 991A97F62E1FB99300B47130 /* CMPScrollView.m */; };
 		99293FF52F2B8A81001EC2A1 /* CMPDrawable.m in Sources */ = {isa = PBXBuildFile; fileRef = 99293FF32F2B8A81001EC2A1 /* CMPDrawable.m */; };
 		99293FF82F2B8A81001EC2A1 /* CMPDrawable.m in Sources */ = {isa = PBXBuildFile; fileRef = 99293FF32F2B8A81001EC2A1 /* CMPDrawable.m */; };
 		992EDDFB2E55EC8400FB44C5 /* CMPKeyValueObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 992EDDFA2E55EC8400FB44C5 /* CMPKeyValueObserver.m */; };
-		AABB11112F5A0000000000A3 /* CMPUIWindowSceneExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = AABB11112F5A0000000000A2 /* CMPUIWindowSceneExtensions.m */; };
+		9967254830010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
+		9967254930010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
+		9967254A30010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
 		9968C35B2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */; };
 		9968C3612D7746BD005E8DE4 /* CMPHoverGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C3602D7746BD005E8DE4 /* CMPHoverGestureRecognizer.m */; };
 		9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C38A2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m */; };
@@ -33,6 +34,7 @@
 		99D97A882BF73A9B0035552B /* CMPEditMenuView.m in Sources */ = {isa = PBXBuildFile; fileRef = 99D97A872BF73A9B0035552B /* CMPEditMenuView.m */; };
 		99DCAB0E2BD00F5C002E6AC7 /* CMPTextLoupeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */; };
 		A01609822EB42A3300FB9790 /* CMPLayoutRegion.m in Sources */ = {isa = PBXBuildFile; fileRef = A01609812EB42A3300FB9790 /* CMPLayoutRegion.m */; };
+		AABB11112F5A0000000000A3 /* CMPUIWindowSceneExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = AABB11112F5A0000000000A2 /* CMPUIWindowSceneExtensions.m */; };
 		C4C07E892F57037300A9DC94 /* CMPTextInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C07E882F57037300A9DC94 /* CMPTextInputView.m */; };
 		C4C07E8A2F57037300A9DC94 /* CMPEditMenuCustomAction.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C07E842F57037300A9DC94 /* CMPEditMenuCustomAction.m */; };
 		C4C07E8B2F57037300A9DC94 /* CMPTextInputStringTokenizer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C07E862F57037300A9DC94 /* CMPTextInputStringTokenizer.m */; };
@@ -80,8 +82,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		55F0AA112F70000100ABC123 /* CMPFrameRateRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPFrameRateRange.h; sourceTree = "<group>"; };
-		55F0AA122F70000100ABC123 /* CMPFrameRateRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPFrameRateRange.m; sourceTree = "<group>"; };
 		99009B782F322B4700518C1F /* CMPMetalLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPMetalLayer.h; sourceTree = "<group>"; };
 		99009B792F322B4700518C1F /* CMPMetalLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPMetalLayer.m; sourceTree = "<group>"; };
 		991A97F52E1FB99300B47130 /* CMPScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPScrollView.h; sourceTree = "<group>"; };
@@ -90,6 +90,8 @@
 		99293FF32F2B8A81001EC2A1 /* CMPDrawable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPDrawable.m; sourceTree = "<group>"; };
 		992EDDF92E55EC8400FB44C5 /* CMPKeyValueObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPKeyValueObserver.h; sourceTree = "<group>"; };
 		992EDDFA2E55EC8400FB44C5 /* CMPKeyValueObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPKeyValueObserver.m; sourceTree = "<group>"; };
+		9967254630010FBC0013BF47 /* CMPContainerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPContainerView.h; sourceTree = "<group>"; };
+		9967254730010FBC0013BF47 /* CMPContainerView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPContainerView.m; sourceTree = "<group>"; };
 		9968C3592D76FE16005E8DE4 /* CMPPanGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPPanGestureRecognizer.h; sourceTree = "<group>"; };
 		9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPPanGestureRecognizer.m; sourceTree = "<group>"; };
 		9968C35F2D7746BD005E8DE4 /* CMPHoverGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPHoverGestureRecognizer.h; sourceTree = "<group>"; };
@@ -98,8 +100,6 @@
 		9968C38A2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPScreenEdgePanGestureRecognizer.m; sourceTree = "<group>"; };
 		996EFEEA2B02CE5D0000FE0F /* libCMPUIKitUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCMPUIKitUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		996EFEF52B02CE8A0000FE0F /* CMPUIKitUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPUIKitUtils.h; sourceTree = "<group>"; };
-		AABB11112F5A0000000000A1 /* CMPUIWindowSceneExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPUIWindowSceneExtensions.h; sourceTree = "<group>"; };
-		AABB11112F5A0000000000A2 /* CMPUIWindowSceneExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPUIWindowSceneExtensions.m; sourceTree = "<group>"; };
 		997DFCDC2B18D135000B56B5 /* CMPViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPViewController.h; sourceTree = "<group>"; };
 		997DFCDD2B18D135000B56B5 /* CMPViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPViewController.m; sourceTree = "<group>"; };
 		997DFCE32B18D99E000B56B5 /* CMPUIKitUtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CMPUIKitUtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -122,6 +122,8 @@
 		99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPTextLoupeSession.m; sourceTree = "<group>"; };
 		A01609812EB42A3300FB9790 /* CMPLayoutRegion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPLayoutRegion.m; sourceTree = "<group>"; };
 		A0E69B242EB4227A0049B20F /* CMPLayoutRegion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPLayoutRegion.h; sourceTree = "<group>"; };
+		AABB11112F5A0000000000A1 /* CMPUIWindowSceneExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPUIWindowSceneExtensions.h; sourceTree = "<group>"; };
+		AABB11112F5A0000000000A2 /* CMPUIWindowSceneExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPUIWindowSceneExtensions.m; sourceTree = "<group>"; };
 		C4C07E832F57037300A9DC94 /* CMPEditMenuCustomAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPEditMenuCustomAction.h; sourceTree = "<group>"; };
 		C4C07E842F57037300A9DC94 /* CMPEditMenuCustomAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPEditMenuCustomAction.m; sourceTree = "<group>"; };
 		C4C07E852F57037300A9DC94 /* CMPTextInputStringTokenizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPTextInputStringTokenizer.h; sourceTree = "<group>"; };
@@ -177,24 +179,20 @@
 		996EFEEB2B02CE5D0000FE0F /* CMPUIKitUtils */ = {
 			isa = PBXGroup;
 			children = (
-				C4C07E832F57037300A9DC94 /* CMPEditMenuCustomAction.h */,
-				C4C07E842F57037300A9DC94 /* CMPEditMenuCustomAction.m */,
-				55F0AA112F70000100ABC123 /* CMPFrameRateRange.h */,
-				55F0AA122F70000100ABC123 /* CMPFrameRateRange.m */,
-				C4C07E852F57037300A9DC94 /* CMPTextInputStringTokenizer.h */,
-				C4C07E862F57037300A9DC94 /* CMPTextInputStringTokenizer.m */,
-				C4C07E872F57037300A9DC94 /* CMPTextInputView.h */,
-				C4C07E882F57037300A9DC94 /* CMPTextInputView.m */,
 				EA70A7E62B27106100300068 /* CMPAccessibilityElement.h */,
 				EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */,
 				99CC4B282ECE04AC007C5C44 /* CMPComposeContainerLifecycleDelegate.h */,
 				99CC4B2B2ECE07EA007C5C44 /* CMPComposeContainerLifecycleState.h */,
+				9967254630010FBC0013BF47 /* CMPContainerView.h */,
+				9967254730010FBC0013BF47 /* CMPContainerView.m */,
 				EADD028E2C9846D9003F66E8 /* CMPDragInteractionProxy.h */,
 				EADD028F2C9846D9003F66E8 /* CMPDragInteractionProxy.m */,
 				99293FF22F2B8A81001EC2A1 /* CMPDrawable.h */,
 				99293FF32F2B8A81001EC2A1 /* CMPDrawable.m */,
 				EADD02912C98484F003F66E8 /* CMPDropInteractionProxy.h */,
 				EADD02922C98484F003F66E8 /* CMPDropInteractionProxy.m */,
+				C4C07E832F57037300A9DC94 /* CMPEditMenuCustomAction.h */,
+				C4C07E842F57037300A9DC94 /* CMPEditMenuCustomAction.m */,
 				99D97A862BF73A9B0035552B /* CMPEditMenuView.h */,
 				99D97A872BF73A9B0035552B /* CMPEditMenuView.m */,
 				EA4B52942C2EDEF200FBB55C /* CMPGestureRecognizer.h */,
@@ -205,6 +203,8 @@
 				EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */,
 				992EDDF92E55EC8400FB44C5 /* CMPKeyValueObserver.h */,
 				992EDDFA2E55EC8400FB44C5 /* CMPKeyValueObserver.m */,
+				A0E69B242EB4227A0049B20F /* CMPLayoutRegion.h */,
+				A01609812EB42A3300FB9790 /* CMPLayoutRegion.m */,
 				EA70A7E72B27106100300068 /* CMPMacros.h */,
 				EAB33E162C12E746002CFF44 /* CMPMetalDrawablesHandler.h */,
 				EAB33E172C12E746002CFF44 /* CMPMetalDrawablesHandler.m */,
@@ -220,6 +220,10 @@
 				9968C38A2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m */,
 				991A97F52E1FB99300B47130 /* CMPScrollView.h */,
 				991A97F62E1FB99300B47130 /* CMPScrollView.m */,
+				C4C07E852F57037300A9DC94 /* CMPTextInputStringTokenizer.h */,
+				C4C07E862F57037300A9DC94 /* CMPTextInputStringTokenizer.m */,
+				C4C07E872F57037300A9DC94 /* CMPTextInputView.h */,
+				C4C07E882F57037300A9DC94 /* CMPTextInputView.m */,
 				99DCAB0C2BD00F5C002E6AC7 /* CMPTextLoupeSession.h */,
 				99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */,
 				996EFEF52B02CE8A0000FE0F /* CMPUIKitUtils.h */,
@@ -229,8 +233,6 @@
 				99CC4B2D2ECE0838007C5C44 /* CMPView.m */,
 				997DFCDC2B18D135000B56B5 /* CMPViewController.h */,
 				997DFCDD2B18D135000B56B5 /* CMPViewController.m */,
-				A0E69B242EB4227A0049B20F /* CMPLayoutRegion.h */,
-				A01609812EB42A3300FB9790 /* CMPLayoutRegion.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -407,7 +409,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55F0AA132F70000100ABC123 /* CMPFrameRateRange.m in Sources */,
 				997DFCDE2B18D135000B56B5 /* CMPViewController.m in Sources */,
 				9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */,
 				EAB33E182C12E746002CFF44 /* CMPMetalDrawablesHandler.m in Sources */,
@@ -426,6 +427,7 @@
 				EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */,
 				A01609822EB42A3300FB9790 /* CMPLayoutRegion.m in Sources */,
 				9968C3612D7746BD005E8DE4 /* CMPHoverGestureRecognizer.m in Sources */,
+				9967254830010FBC0013BF47 /* CMPContainerView.m in Sources */,
 				EA4B52962C2EDEF200FBB55C /* CMPGestureRecognizer.m in Sources */,
 				EA70A7EB2B27106100300068 /* CMPAccessibilityElement.m in Sources */,
 				99DCAB0E2BD00F5C002E6AC7 /* CMPTextLoupeSession.m in Sources */,
@@ -442,6 +444,7 @@
 				99A83D5A2F2CC4FB00BB5698 /* CMPMetalLayerTests.swift in Sources */,
 				99CC4B2F2ECE0838007C5C44 /* CMPView.m in Sources */,
 				99CC4B322ECE16C8007C5C44 /* CMPViewTests.swift in Sources */,
+				9967254930010FBC0013BF47 /* CMPContainerView.m in Sources */,
 				997DFCF52B18E276000B56B5 /* XCTestCase.swift in Sources */,
 				997DFCE62B18D99E000B56B5 /* CMPViewControllerTests.swift in Sources */,
 				997DFCEE2B18DB7B000B56B5 /* CMPViewController.m in Sources */,
@@ -456,6 +459,7 @@
 				EAC703E32B8C826E001ECDA6 /* CMPAccessibilityElement.m in Sources */,
 				EAC703E42B8C826E001ECDA6 /* CMPViewController.m in Sources */,
 				EAC703E52B8C826E001ECDA6 /* CMPOSLogger.m in Sources */,
+				9967254A30010FBC0013BF47 /* CMPContainerView.m in Sources */,
 				997DFCFD2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift in Sources */,
 				EAC703E62B8C826E001ECDA6 /* CMPOSLoggerInterval.m in Sources */,
 				99009B7A2F322B4700518C1F /* CMPMetalLayer.m in Sources */,

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9967254830010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
 		9967254930010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
 		9967254A30010FBC0013BF47 /* CMPContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967254730010FBC0013BF47 /* CMPContainerView.m */; };
+		9967259F3006775B0013BF47 /* CMPFrameRateRange.m in Sources */ = {isa = PBXBuildFile; fileRef = 9967259E3006775B0013BF47 /* CMPFrameRateRange.m */; };
 		9968C35B2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */; };
 		9968C3612D7746BD005E8DE4 /* CMPHoverGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C3602D7746BD005E8DE4 /* CMPHoverGestureRecognizer.m */; };
 		9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C38A2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m */; };
@@ -92,6 +93,8 @@
 		992EDDFA2E55EC8400FB44C5 /* CMPKeyValueObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPKeyValueObserver.m; sourceTree = "<group>"; };
 		9967254630010FBC0013BF47 /* CMPContainerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPContainerView.h; sourceTree = "<group>"; };
 		9967254730010FBC0013BF47 /* CMPContainerView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPContainerView.m; sourceTree = "<group>"; };
+		9967259D3006775B0013BF47 /* CMPFrameRateRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPFrameRateRange.h; sourceTree = "<group>"; };
+		9967259E3006775B0013BF47 /* CMPFrameRateRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPFrameRateRange.m; sourceTree = "<group>"; };
 		9968C3592D76FE16005E8DE4 /* CMPPanGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPPanGestureRecognizer.h; sourceTree = "<group>"; };
 		9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPPanGestureRecognizer.m; sourceTree = "<group>"; };
 		9968C35F2D7746BD005E8DE4 /* CMPHoverGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPHoverGestureRecognizer.h; sourceTree = "<group>"; };
@@ -195,6 +198,8 @@
 				C4C07E842F57037300A9DC94 /* CMPEditMenuCustomAction.m */,
 				99D97A862BF73A9B0035552B /* CMPEditMenuView.h */,
 				99D97A872BF73A9B0035552B /* CMPEditMenuView.m */,
+				9967259D3006775B0013BF47 /* CMPFrameRateRange.h */,
+				9967259E3006775B0013BF47 /* CMPFrameRateRange.m */,
 				EA4B52942C2EDEF200FBB55C /* CMPGestureRecognizer.h */,
 				EA4B52952C2EDEF200FBB55C /* CMPGestureRecognizer.m */,
 				9968C35F2D7746BD005E8DE4 /* CMPHoverGestureRecognizer.h */,
@@ -409,6 +414,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9967259F3006775B0013BF47 /* CMPFrameRateRange.m in Sources */,
 				997DFCDE2B18D135000B56B5 /* CMPViewController.m in Sources */,
 				9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */,
 				EAB33E182C12E746002CFF44 /* CMPMetalDrawablesHandler.m in Sources */,

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPContainerView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPContainerView.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface CMPContainerView : UIView
+
+@property (nonatomic, copy, nullable) void (^onDidMoveToWindowBlock)(void);
+
+@end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPContainerView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPContainerView.m
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CMPContainerView.h"
+
+@implementation CMPContainerView
+
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+
+    if (self.onDidMoveToWindowBlock != nil) {
+        self.onDidMoveToWindowBlock();
+    }
+}
+
+@end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -24,7 +24,6 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 
 #import "CMPAccessibilityElement.h"
 #import "CMPComposeContainerLifecycleDelegate.h"
-#import "CMPFrameRateRange.h"
 #import "CMPDragInteractionProxy.h"
 #import "CMPDrawable.h"
 #import "CMPDropInteractionProxy.h"
@@ -44,3 +43,4 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 #import "CMPView.h"
 #import "CMPUIWindowSceneExtensions.h"
 #import "CMPViewController.h"
+#import "CMPContainerView.h"

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -24,6 +24,7 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 
 #import "CMPAccessibilityElement.h"
 #import "CMPComposeContainerLifecycleDelegate.h"
+#import "CMPFrameRateRange.h"
 #import "CMPDragInteractionProxy.h"
 #import "CMPDrawable.h"
 #import "CMPDropInteractionProxy.h"

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -17,6 +17,7 @@
 #import "CMPViewController.h"
 #import <objc/runtime.h>
 #import "CMPComposeContainerLifecycleState.h"
+#import "CMPContainerView.h"
 
 #pragma mark - UIViewController + CMPUIKitUtilsPrivate
 
@@ -103,26 +104,51 @@
     }
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [self transitLifecycleToStarted];
-
-    [super viewWillAppear:animated];
-    [_lifecycleDelegate composeContainerWillAppear];
-    _isViewAppeared = YES;
+- (void)loadView {
+    self.view = [[CMPContainerView alloc] initWithFrame:CGRectZero];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    // In some cases viewWillAppear may not be called for the view controller.
-    // The code in the viewDidAppear used as a backup scenario for this case.
+- (void)viewDidLoad {
+    [super viewDidLoad];
 
-    [self transitLifecycleToStarted];
+    if (![self.view isKindOfClass:[CMPContainerView class]]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"CMPViewController's view must be a kind of CMPContainerView, but was %@", [self.view class]];
+    }
 
-    [super viewDidAppear:animated];
+    __weak typeof(self) weakSelf = self;
+    CMPContainerView *containerView = (CMPContainerView *)self.view;
+    containerView.onDidMoveToWindowBlock = ^{
+        [weakSelf onDidMoveToWindow];
+    };
+}
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    [self notifyContainerWillAppearIfNeeded];
+}
+
+- (void)onDidMoveToWindow {
+    if (self.view.window != nil) {
+        [self transitLifecycleToStarted];
+        [self notifyContainerWillAppearIfNeeded];
+    }
+}
+
+- (void)notifyContainerWillAppearIfNeeded {
     if (!_isViewAppeared) {
         _isViewAppeared = YES;
         [_lifecycleDelegate composeContainerWillAppear];
     }
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    // In some cases viewWillAppear may not be called for the view controller.
+    // The code in the viewDidAppear used as a backup scenario for this case.
+    [self onDidMoveToWindow];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.uikit.utils.CMPContainerView
 import androidx.compose.ui.unit.toDpSize
 import kotlin.math.max
 import kotlinx.cinterop.CValue
@@ -42,7 +43,7 @@ import platform.UIKit.UIWindow
 internal class ComposeContainerView(
     private val useOpaqueConfiguration: Boolean,
     private val transparentForTouches: Boolean,
-): UIView(frame = UIScreen.mainScreen.bounds) {
+): CMPContainerView(frame = UIScreen.mainScreen.bounds) {
     init {
         setClipsToBounds(true)
         setOpaque(useOpaqueConfiguration)


### PR DESCRIPTION
`viewDidAppear` is sometimes triggered too late that lead to visible issues when loading Compose content

Fixes https://youtrack.jetbrains.com/issue/CMP-10078/Compose-view-sometimes-not-rendered-in-LazyVStack

## Release Notes
N/A