### PR TITLE
Support opening AOSP project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+gradlew merge=ours
+gradle.properties merge=ours
+gradle/wrapper/gradle-wrapper.properties merge=ours

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,9 @@
+# This config is not applied automatically. Currently it is only needed for AOSP merges
+#
+# Run once after cloning:
+#   git config --local include.path ../.gitconfig
+
+# A custom no-op merge driver that is used to solve conflicts
+[merge "ours"]
+    # "true" is a just a command that does nothing during a merge resolution
+	driver = true

--- a/aospComposeProject.sh
+++ b/aospComposeProject.sh
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script runs the project in the original AOSP mode that uses the original build files
+# instead of the fork mode build files (settings-fork, etc)
+#
+# Note that it is supported only in "integration" branch,
+# because "jb-main" contains different copied parts that might not compile together
+
+export PROJECT_MODE=AOSP
+export ANDROIDX_PROJECTS=COMPOSE
+./gradlew studio

--- a/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
+++ b/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
@@ -163,28 +163,6 @@ fun Project.isValidateProjectStructureEnabled(): Boolean =
     findBooleanProperty(VALIDATE_PROJECT_STRUCTURE) ?: true
 
 /**
- * Validates that all properties passed by the user of the form "-Pandroidx.*" are not misspelled
- */
-fun Project.validateAllAndroidxArgumentsAreRecognized() {
-    for (propertyName in project.properties.keys) {
-        if (propertyName.startsWith("androidx")) {
-            if (!ALL_ANDROIDX_PROPERTIES.contains(propertyName)) {
-                val message =
-                    "Unrecognized Androidx property '$propertyName'.\n" +
-                        "\n" +
-                        "Is this a misspelling? All recognized Androidx properties:\n" +
-                        ALL_ANDROIDX_PROPERTIES.joinToString("\n") +
-                        "\n" +
-                        "\n" +
-                        "See AndroidXGradleProperties.kt if you need to add this property to " +
-                        "the list of known properties."
-                throw GradleException(message)
-            }
-        }
-    }
-}
-
-/**
  * Returns whether tests in the project should display output. Build server scripts generally set
  * displayTestOutput to false so that their failing test results aren't considered build failures,
  * and instead pass their test failures on via build artifacts to be tracked and displayed on test
@@ -200,8 +178,9 @@ fun Project.isDisplayTestOutput(): Boolean = findBooleanProperty(DISPLAY_TEST_OU
  * and `<version>.txt`. When set to `false`, only `current.txt` will be written. The default value
  * is `true`.
  */
+@Suppress("UnusedReceiverParameter")
 fun Project.isWriteVersionedApiFilesEnabled(): Boolean =
-    findBooleanProperty(WRITE_VERSIONED_API_FILES) ?: true
+    false
 
 /** Returns whether the build is for checking forward compatibility across projects */
 fun Project.usingMaxDepVersions(): Provider<Boolean> {

--- a/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
+++ b/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
@@ -62,7 +62,6 @@ abstract class AndroidXRootImplPlugin : Plugin<Project> {
     }
 
     private fun Project.configureRootProject() {
-        project.validateAllAndroidxArgumentsAreRecognized()
         tasks.register("listAndroidXProperties", ListAndroidXPropertiesTask::class.java)
         tasks.register("createProject", ProjectCreatorTask::class.java)
         configureKtfmtCheckFile()

--- a/buildSrc-fork/public/src/main/kotlin/androidx/build/AndroidXConfig.kt
+++ b/buildSrc-fork/public/src/main/kotlin/androidx/build/AndroidXConfig.kt
@@ -46,9 +46,9 @@ abstract class AndroidConfigImpl(private val project: Project) : AndroidConfig {
     }
 
     companion object {
-        private const val COMPILE_SDK = "androidx.compileSdk"
-        private const val LATEST_STABLE_COMPILE_SDK = "androidx.latestStableCompileSdk"
-        private const val TARGET_SDK_VERSION = "androidx.targetSdkVersion"
+        private const val COMPILE_SDK = "jetbrains.androidx.android.compileSdk"
+        private const val LATEST_STABLE_COMPILE_SDK = "jetbrains.androidx.android.latestStableCompileSdk"
+        private const val TARGET_SDK_VERSION = "jetbrains.androidx.android.targetSdkVersion"
 
         /**
          * Implementation detail. This should only be used by AndroidXGradleProperties for property

--- a/buildSrc-fork/public/src/main/kotlin/androidx/build/ProjectLayoutType.kt
+++ b/buildSrc-fork/public/src/main/kotlin/androidx/build/ProjectLayoutType.kt
@@ -19,6 +19,7 @@ package androidx.build
 import androidx.build.gradle.extraPropertyOrNull
 import org.gradle.api.Project
 
+// TODO remove, there is only one type of the project for buildSrc-fork
 enum class ProjectLayoutType {
     ANDROIDX,
     PLAYGROUND,
@@ -26,16 +27,10 @@ enum class ProjectLayoutType {
 
     companion object {
         /** Returns the project layout type for the project (PLAYGROUND or ANDROIDX) */
+        @Suppress("unused")
         @JvmStatic
         fun from(project: Project): ProjectLayoutType {
-            val value = project.extraPropertyOrNull(STUDIO_TYPE)
-            return when (value) {
-                "playground" -> PLAYGROUND
-                null,
-                "androidx" -> ANDROIDX
-                "jetbrains-fork" -> JETBRAINS_FORK
-                else -> error("Invalid project type $value")
-            }
+            return JETBRAINS_FORK
         }
 
         /** @return `true` if running in a Playground (Github) setup, `false` otherwise. */

--- a/buildSrc/settings-fork.gradle
+++ b/buildSrc/settings-fork.gradle
@@ -37,14 +37,9 @@ apply from: "../buildSrc-fork/settingsScripts/out-setup.groovy"
 getGradle().beforeProject { project ->
     def checkoutRoot = new File("${buildscript.sourceFile.parent}/..")
     init.chooseBuildDirectory(checkoutRoot, rootProject.name, project)
-
-    /*
-    Could not set unknown property 'kotlin.project.persistent.dir' for project ':buildSrc' of type org.gradle.api.Project.
-
     // https://youtrack.jetbrains.com/issue/KT-58223
-    def kotlinDir = new File(System.env.OUT_DIR ?: checkoutRoot, ".kotlinBuildSrc")
+    def kotlinDir = new File("${checkoutRoot}/out", ".kotlinBuildSrc")
     project.setProperty("kotlin.project.persistent.dir", kotlinDir.absolutePath)
-    */
 }
 
 include ":jetpad-integration"

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-def isRunFromGradlewStudio = System.getenv().get("EXPECTED_AGP_VERSION")
-if (!isRunFromGradlewStudio) {
+def isForkModeEnabled = System.getenv().get("PROJECT_MODE") != "AOSP"
+if (isForkModeEnabled) {
     apply from: "settings-fork.gradle"
     return
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
+# This file should contain properties that work both in the fork project, and in the original
+# AOSP project opened via aospComposeProject.sh
+#
+# Conflicts in this file should be solved as "ours"
+
 org.gradle.jvmargs=-Xmx12g \
   -XX:+HeapDumpOnOutOfMemoryError \
   -XX:+UseParallelGC \
@@ -9,6 +14,8 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.welcome=never
+kotlin.project.persistent.dir=./placeholder
+kotlin.user.home=./placeholder
 # Disabled due to https://github.com/gradle/gradle/issues/18626
 # org.gradle.vfs.watch=true
 # Reenabled in gradlew, but disabled in Studio until these errors become shown (b/268380971) or computed more quickly (https://github.com/gradle/gradle/issues/23272)
@@ -29,7 +36,6 @@ android.enableAppCompileTimeRClass=true
 # TODO(aurimas): flip the rest of these flags, they fail right now
 android.newDsl=false
 android.compatibility.enableLegacyApi=true
-android.builtInKotlin=false
 android.disallowKotlinSourceSets=false
 # -------------------------------------------------------------------
 
@@ -48,7 +54,7 @@ android.experimental.lint.reservedMemoryPerTask=1g
 android.prefabVersion=2.1.0
 
 # Don't generate versioned API files
-androidx.writeVersionedApiFiles=false
+androidx.writeVersionedApiFiles=true
 
 # Don't run the CheckAarMetadata task
 android.experimental.disableCompileSdkChecks=false
@@ -112,14 +118,15 @@ kapt.use.k2=true
 
 # JetBrains fork only properties
 
-# jetbrains-fork in jb-main branch
-androidx.studio.type=jetbrains-fork
-
 # In which browsers run web tests
 jetbrains.androidx.web.tests.enableChrome=true
 jetbrains.androidx.web.tests.enableChromium=false
 jetbrains.androidx.web.tests.enableFirefox=false
 jetbrains.androidx.web.tests.enableSafari=false
+
+jetbrains.androidx.android.compileSdk=34
+jetbrains.androidx.android.latestStableCompileSdk=36
+jetbrains.androidx.android.targetSdkVersion=36
 
 kotlinx.atomicfu.enableJsIrTransformation=true
 kotlinx.atomicfu.enableJvmIrTransformation=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,8 @@
+# Conflicts in this file should be solved as "ours"
+#
+# If AOSP updated Gradle to a newer version and AOSP is needed to be working,
+# migrate the fork to the same version
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Conflicts in this file should be solved as "ours"
+
 #
 # Copyright © 2015 the original authors.
 #
@@ -63,6 +65,40 @@
 #       You can find Gradle at https://github.com/gradle/gradle/.
 #
 ##############################################################################
+
+# --------- androidx specific code needed for build server. ------------------
+if [ "$PROJECT_MODE" == "AOSP" ]; then
+    SCRIPT_PATH="$(cd $(dirname $0) && pwd -P)"
+    if [ -n "$OUT_DIR" ] ; then
+        mkdir -p "$OUT_DIR"
+        OUT_DIR="$(cd $OUT_DIR && pwd -P)"
+        export TMPDIR="$OUT_DIR/tmp"
+    elif [[ $SCRIPT_PATH == /google/cog/* ]] ; then
+        export OUT_DIR="$HOME/androidxout"
+    else
+        CHECKOUT_ROOT="$(cd $SCRIPT_PATH/../.. && pwd -P)"
+        export OUT_DIR="$CHECKOUT_ROOT/out"
+    fi
+    export GRADLE_USER_HOME="$OUT_DIR/.gradle"
+    export KONAN_DATA_DIR="$OUT_DIR/.konan"
+
+    ORG_GRADLE_JVMARGS="$(cd $SCRIPT_PATH && grep org.gradle.jvmargs gradle.properties | sed 's/^/-D/')"
+    if [ -n "$DIST_DIR" ]; then
+        mkdir -p "$DIST_DIR"
+        DIST_DIR="$(cd $DIST_DIR && pwd -P)"
+
+        # tell Gradle where to put a heap dump on failure
+        ORG_GRADLE_JVMARGS="$(echo $ORG_GRADLE_JVMARGS | sed "s|$| -XX:HeapDumpPath=$DIST_DIR|")"
+
+        # We don't set a default DIST_DIR in an else clause here because Studio doesn't use gradlew
+        # and doesn't set DIST_DIR and we want gradlew and Studio to match
+    fi
+
+    # unset ANDROID_BUILD_TOP so that Lint doesn't think we're building the platform itself
+    unset ANDROID_BUILD_TOP
+fi
+
+# ----------------------------------------------------------------------------
 
 # Attempt to set APP_HOME
 

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -53,14 +53,10 @@ getGradle().beforeProject { project ->
     def checkoutRoot = new File("${buildscript.sourceFile.parent}")
     init.chooseBuildDirectory(checkoutRoot, rootProject.name, project)
 
-    /*
-    Could not set unknown property 'kotlin.project.persistent.dir' for project ':buildSrc' of type org.gradle.api.Project.
-
     // https://youtrack.jetbrains.com/issue/KT-58223
-    def kotlinDir = new File(System.env.OUT_DIR ?: checkoutRoot, ".kotlin")
+    def kotlinDir = new File("${checkoutRoot}/out", ".kotlin")
     project.setProperty("kotlin.project.persistent.dir", kotlinDir.absolutePath)
     project.setProperty("kotlin.user.home", kotlinDir.absolutePath)
-    */
 }
 
 apply(plugin: "com.gradle.develocity")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
 import groovy.transform.Field
 
 pluginManagement {
-    def isRunFromGradlewStudio = System.getenv().get("EXPECTED_AGP_VERSION")
-    if (!isRunFromGradlewStudio) {
+    def isForkModeEnabled = System.getenv().get("PROJECT_MODE") != "AOSP"
+    if (isForkModeEnabled) {
         apply from: "settings-plugin-management-fork.gradle"
         this.ext.configureForkPluginManagement.call(delegate)
         return
@@ -29,8 +29,8 @@ pluginManagement {
 }
 
 buildscript {
-    def isRunFromGradlewStudio = System.getenv().get("EXPECTED_AGP_VERSION")
-    if (!isRunFromGradlewStudio) {
+    def isForkModeEnabled = System.getenv().get("PROJECT_MODE") != "AOSP"
+    if (isForkModeEnabled) {
         apply from: "settings-buildscript-fork.gradle"
         this.ext.configureForkBuildscript.call(delegate)
         return
@@ -61,8 +61,8 @@ buildscript {
     }
 }
 
-def isRunFromGradlewStudio = System.getenv().get("EXPECTED_AGP_VERSION")
-if (!isRunFromGradlewStudio) {
+def isForkModeEnabled = System.getenv().get("PROJECT_MODE") != "AOSP"
+if (isForkModeEnabled) {
     apply from: "settings-fork.gradle"
     return
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10492/Support-opening-project-in-AOSP-mode

Add `aospComposeProject.sh` that runs a project fully in AOSP mode, with original build files

## Testing
- [TeamCity](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/6343269)
- open project in IDEA (fork mode) in `jb-main`
- open project via `./aospComposeProject.sh` (AOSP mode) in `integration-2026-07-03`

## Release Notes
N/A