### PR TITLE
Eliminating inconsistencies between BTF1, BTF2 and native iOS tap behavior

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
@@ -67,6 +67,7 @@ internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
 ) {
     pointerInputScope.detectTapAndPress(
         onTap = { offset ->
+            val wasFocused = isWindowAndTextFieldFocused
             requestFocus()
 
             if (enabled && isWindowAndTextFieldFocused) {
@@ -86,7 +87,7 @@ internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
                 )
 
                 // TODO: It should be toggleable
-                if (!cursorMoved) {
+                if (!cursorMoved && wasFocused) {
                     updateTextToolbarState(Cursor)
                 }
             }
@@ -132,14 +133,13 @@ private fun TextFieldSelectionState.placeCursorAtDesiredOffset(offset: Offset): 
     if (proposedIndex == -1) return false
 
     // Second step: adjust proposed cursor position as iOS does
-    val previousIndex = layoutResult.getOffsetForPosition(handleDragPosition)
     val currentText = textFieldState.untransformedText.text as String
     val index = if (textFieldState.untransformedText != textFieldState.visualText) {
         // BTF1 on iOS doesn't apply custom cursor positioning in case of any transformation,
         // so BTF2 should handle cursor positioning the same
         proposedIndex
     } else {
-        determineCursorDesiredOffset(proposedIndex, previousIndex, layoutResult, currentText)
+        determineCursorDesiredOffset(proposedIndex, layoutResult, currentText)
     }
 
     // Third step: if a transformation is applied, determine if the proposed cursor position

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -50,49 +50,35 @@ internal fun Modifier.cupertinoTextFieldPointer(
     this
         .updateSelectionTouchMode { state.isInTouchMode = it }
         .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
-            if (state.hasFocus) {
-                // To show keyboard if it was hidden. Even in selection mode (like native)
-                requestFocusAndShowKeyboardIfNeeded(
-                    state,
-                    focusRequester,
-                    !readOnly
-                )
-                if (state.handleState != HandleState.Selection) {
-                    state.layoutResult?.let { layoutResult ->
-                        TextFieldDelegate.cupertinoSetCursorOffsetFocused(
-                            position = offset,
-                            textLayoutResult = layoutResult,
-                            editProcessor = state.processor,
-                            offsetMapping = offsetMapping,
-                            showContextMenu = { show ->
-                                // it shouldn't be selection, but this is a way to call a context menu in BasicTextField
-                                if (show) {
-                                    manager.enterSelectionMode()
-                                } else {
-                                    manager.exitSelectionMode()
-                                }
-                            },
-                            onValueChange = state.onValueChange
-                        )
-                    }
-                } else {
-                    manager.deselect(offset)
-                }
-            } else {
-                requestFocusAndShowKeyboardIfNeeded(
-                    state,
-                    focusRequester,
-                    !readOnly
-                )
+            val wasFocused = state.hasFocus
+
+            // To show keyboard if it was hidden. Even in selection mode (like native)
+            requestFocusAndShowKeyboardIfNeeded(
+                state,
+                focusRequester,
+                !readOnly
+            )
+
+            if (state.handleState != HandleState.Selection) {
                 state.layoutResult?.let { layoutResult ->
-                    TextFieldDelegate.setCursorOffset(
-                        offset,
-                        layoutResult,
-                        state.processor,
-                        offsetMapping,
-                        state.onValueChange
+                    TextFieldDelegate.cupertinoSetCursorOffsetFocused(
+                        position = offset,
+                        textLayoutResult = layoutResult,
+                        editProcessor = state.processor,
+                        offsetMapping = offsetMapping,
+                        showContextMenu = { show ->
+                            // it shouldn't be selection, but this is a way to call a context menu in BasicTextField
+                            if (show && wasFocused) {
+                                manager.enterSelectionMode()
+                            } else {
+                                manager.exitSelectionMode()
+                            }
+                        },
+                        onValueChange = state.onValueChange
                     )
                 }
+            } else {
+                manager.deselect(offset)
             }
             if (state.textDelegate.text.isNotEmpty()) {
                 state.handleState = HandleState.Cursor

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
@@ -50,10 +50,9 @@ internal fun TextFieldDelegate.Companion.cupertinoSetCursorOffsetFocused(
     val previousOffset = currentValue.selection.start
 
     val cursorDesiredOffset = determineCursorDesiredOffset(
-        offset,
-        previousOffset,
-        textLayoutResult.value,
-        currentText
+        offset = offset,
+        textLayoutResult = textLayoutResult.value,
+        currentText = currentText
     )
 
     showContextMenu(cursorDesiredOffset == offset && cursorDesiredOffset == previousOffset)
@@ -74,19 +73,16 @@ internal fun TextFieldDelegate.Companion.cupertinoSetCursorOffsetFocused(
  * - If you tap on the left edge of the TextField, the caret is placed before the first word on this line. The same is for the right edge.
  * - If you tap at the caret placed in the middle of the word, it will jump to the end of the word.
  * @param offset The current offset position.
- * @param previousOffset The previous offset position (where caret was before incoming tap).
  * @param textLayoutResult The TextLayoutResult representing the layout of the text.
  * @param currentText The current text in the TextField.
  * @return The desired cursor position after evaluating the given parameters.
  */
 internal fun determineCursorDesiredOffset(
     offset: Int,
-    previousOffset: Int,
     textLayoutResult: TextLayoutResult,
     currentText: String
 ): Int {
     val caretOffsetPosition = when {
-        offset == previousOffset -> offset
         isLeftEdgeTapped(textLayoutResult, offset) -> {
             val lineNumber = textLayoutResult.getLineForOffset(offset)
             textLayoutResult.getLineStart(lineNumber)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
@@ -20,10 +20,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.MultiParagraph
 import androidx.compose.ui.text.TextLayoutInput
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.createFontFamilyResolver
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
@@ -46,12 +44,10 @@ class CupertinoTextFieldDelegateTest {
     fun testDetermineCursorDesiredOffset(
         givenOffset: Int,
         expected: Int,
-        sampleString: String,
-        cursorOffset: Int? = null
+        sampleString: String
     ) {
         val actual = determineCursorDesiredOffset(
             offset = givenOffset,
-            createSimpleTextFieldValue(text = sampleText, cursorOffset = cursorOffset).selection.start,
             textLayoutResult = createSimpleTextLayoutResult(sampleText),
             currentText = sampleText
         )
@@ -156,11 +152,11 @@ class CupertinoTextFieldDelegateTest {
     }
 
     @Test
-    fun determineCursorDesiredOffset_tap_on_the_caret_at_the_same_position() {
+    fun determineCursorDesiredOffset_tap_in_the_second_half_of_word() {
         val givenOffset = 24
-        val desiredOffset = 24
+        val desiredOffset = 28
 
-        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText, 24)
+        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText)
     }
 
     @Test
@@ -168,7 +164,7 @@ class CupertinoTextFieldDelegateTest {
         val givenOffset = 218
         val desiredOffset = 218
 
-        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText, 24)
+        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText)
     }
 
     // TODO: remove ignore after fix two compound emojis considered as one whole word
@@ -178,11 +174,8 @@ class CupertinoTextFieldDelegateTest {
         val givenOffset = 96
         val desiredOffset = 96
 
-        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText, 24)
+        testDetermineCursorDesiredOffset(givenOffset, desiredOffset, sampleText)
     }
-
-    private fun createSimpleTextFieldValue(text: String, cursorOffset: Int?) =
-        TextFieldValue(text, selection = TextRange(cursorOffset ?: 0))
 
     private fun createSimpleTextLayoutResult(text: String) = TextLayoutResult(
         layoutInput = simpleTextLayoutInput(text),

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -144,6 +144,7 @@ internal open class ComposeTextInputConnection(
         onSelectAllRequested: (() -> Unit)?
     ) {
         showMenuOrUpdatePosition = {
+            syncTextFieldValueFromRequestSnapshot()
             val density = view.density
             val offset = textInputView.frame.useContents { origin.toDpOffset().toOffset(density) }
             val target = rect.translate(-offset).toDpRect(density).toCGRect()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -124,6 +124,16 @@ internal abstract class TextInputConnection(
     protected abstract fun stateWillChange(textChanged: Boolean, selectionChanged: Boolean)
     protected abstract fun stateDidChange(textChanged: Boolean, selectionChanged: Boolean)
 
+    /**
+     * Refreshes [currentTextFieldValue] from the latest request snapshot. The snapshot flow can lag
+     * behind, so call this where the most up-to-date state matters — e.g. when building the context
+     * menu contents.
+     */
+    protected fun syncTextFieldValueFromRequestSnapshot() {
+        if (postponeSelectionUpdate) return
+        currentTextFieldValue = currentRequest?.stateSnapshot() ?: return
+    }
+
     abstract fun onViewGeometryUpdated()
 
     fun onPreviewKeyEvent(event: KeyEvent): Boolean {


### PR DESCRIPTION
Aligns tap/caret/context-menu behavior across `BasicTextField(TextFieldValue)` (BTF1), `BasicTextField(TextFieldState)` (BTF2) and native iOS.

Fixes:
https://youtrack.jetbrains.com/issue/CMP-10493


### What has been aligned

**BTF1 tap handling** 
- The iOS caret snap (`cupertinoSetCursorOffsetFocused`) now runs on every tap outside selection, including the focusing tap

**Context menu on tap** (BTF1 + BTF2)
- The menu now appears only on a tap into an already-focused field, the first tap in the unfocused field should not show the menu
- The menu by tap appears only if after the tap caret does not move to another position in the text

**iOS edit-menu freshness**
- The edit menu is now built from the latest request snapshot, so `Select` / `Select All` gating reads the current selection instead of a value the snapshot flow lagged behind on (fixed `Select` wrongly appearing after a double-tap word selection).

## Testing
Manual. This should be tested by QA

## Release Notes
### Fixes - iOS
- Fixed the caret not snapping to the nearest word boundary when tapping inside a word in an unfocused `BasicTextField(TextFieldValue)`
- Fixed the context menu appearing incorrectly after a tap in `BasicTextField(TextFieldValue)` and `BasicTextField(TextFieldState)`
