### PR TITLE
Call preventDefault on touch events when Compose consumed corresponding pointer events

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -450,22 +450,50 @@ internal class ComposeWindow(
             actualActivePointerButtons = null
         }
 
-        addTypedEvent<TouchEvent>("touchstart") { evt ->
-            // in most cases we don't care about touches since in Compose we do not process them at all
-            // there's one case however when we need to cancel them - it's when we are focussed in a DOM backing field
-            // see https://youtrack.jetbrains.com/issue/CMP-10079
-
-            val backingInput = (platformContext.textInputService as WebTextInputService).getBackingInput()
-            if (backingInput?.isFocused() == true) {
-                evt.preventDefault()
-            }
+        addTypedEvent<TouchEvent>("touchstart", passive = true) { _ ->
+            // We deliberately never preventDefault() touchstart, even though Compose consumes
+            // the corresponding pointerdown on interactive areas. Per the Touch Events spec,
+            // canceling touchstart suppresses the browser's default actions for the entire
+            // touch sequence: scrolling, back gesture, pull-to-refresh, AND the compatibility
+            // mouse events - and at touchstart time we can't yet know whether Compose will
+            // actually handle the gesture. The decision is deferred to where it can be made
+            // correctly: touchmove (move-based gestures) and touchend (tap-based defaults).
+            // The listener is passive and empty; it exists to document this decision.
         }
 
-        // While we don't pass touchmove(s) to Compose, we need to track them to prevent the browser from taking over the gestures.
+        addTypedEvent<TouchEvent>("touchend", passive = false) { evt ->
+            // Browsers dispatch pointerup before the corresponding touchend (de facto true in
+            // all engines, though the specs don't mandate the relative order), so at this
+            // point we already know whether Compose consumed the release - see onPointerEvent.
+            //
+            // If it did, we cancel touchend to suppress the tap's remaining default actions,
+            // primarily the "compatibility mouse events" - https://w3c.github.io/touch-events/#mouse-events
+            //
+            // Suppressing the synthetic mouse events prevents:
+            // - a duplicate click reaching the page for a tap Compose already handled;
+            // - the synthetic mousedown moving DOM focus, e.g. blurring the backing input of
+            //   a focused Compose text field and hiding the virtual keyboard
+            //   (https://youtrack.jetbrains.com/issue/CMP-10079).
+            //
+            // Move-based gestures (scroll, back gesture, pull-to-refresh) are NOT affected:
+            // those are decided earlier, in the touchmove handler and by the canvas
+            // touch-action style.
+            if (lastPointerReleaseConsumed && evt.cancelable) {
+                evt.preventDefault()
+            }
+            lastPointerReleaseConsumed = false // reset
+        }
+
+        // While we don't pass touchmove(s) to Compose (it processes pointermove instead), only
+        // touchmove's preventDefault() can stop the browser from taking over a move-based
+        // gesture (scroll, back gesture, pull-to-refresh): per the Pointer Events spec,
+        // canceling pointer events has no effect on the browser's direct manipulation
+        // behaviors - only touch-action and canceling touch events do.
         // https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/touch-action
         // > Applications using Touch events disable the browser handling of gestures by calling preventDefault()
-        addTypedEvent<TouchEvent>("touchmove") { evt ->
-            // This event happens after pointermove. Here we decide if the browser should take over the gesture.
+        addTypedEvent<TouchEvent>("touchmove", passive = false) { evt ->
+            // This event happens after the corresponding pointermove, so Compose has already
+            // processed the move. Here we decide if the browser should take over the gesture.
             val shouldPreventDefault = when {
                 // First case: Scrolling happened in Compose, so the browser shouldn't take over the gesture.
                 rootScrollObserver.consumedAnyScroll() -> true
@@ -475,7 +503,7 @@ internal class ComposeWindow(
                 // so they were not consumed by Compose. We let the browser handle this gesture.
                 else -> false
             }
-            if (shouldPreventDefault) {
+            if (shouldPreventDefault && evt.cancelable) {
                 evt.preventDefault()
             }
         }
@@ -659,6 +687,14 @@ internal class ComposeWindow(
 
     private val activeTouchPointers = mutableIntObjectMapOf<TouchEventWithContainerOffset>()
 
+    // Whether Compose consumed the most recent touch pointerup. Read (and then reset) by the
+    // touchend handler, which the browser dispatches right after pointerup, to decide whether
+    // to suppress the compatibility mouse events. A single flag suffices because every
+    // touchend is immediately preceded by its own pointerup; in the rare case where several
+    // simultaneously lifted fingers are coalesced into one touchend, the flag reflects only
+    // the last release.
+    private var lastPointerReleaseConsumed = false
+
     // Pointer IDs whose move events were consumed during the active touch sequence.
     // It's a part of touch events preventDefault logic.
     private val activeTouchPointersConsumedMoves = mutableIntSetOf()
@@ -677,6 +713,7 @@ internal class ComposeWindow(
                 activeTouchPointers.clear()
                 activeTouchPointersConsumedMoves.remove(event.pointerId)
                 activeTouchOffset = null
+                lastPointerReleaseConsumed = false
             } else {
                 actualActivePointerButtons = null
             }
@@ -808,10 +845,13 @@ internal class ComposeWindow(
             activeTouchOffset = null
 
             if (eventType == PointerEventType.Release) {
+                lastPointerReleaseConsumed = anyChangeConsumed
                 activeTouchPointers.remove(event.pointerId)
                 activeTouchPointersConsumedMoves.remove(event.pointerId)
             }
 
+            // Canceling a pointer event does not block scrolling or other native gestures
+            // (per the Pointer Events spec, only touch-action / canceling touch events do);
             if (anyChangeConsumed && event.cancelable) {
                 event.preventDefault()
                 if (eventType == PointerEventType.Move) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/synthethicEvents.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/synthethicEvents.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.ui.events
 
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
 import org.w3c.dom.events.CompositionEvent
 import org.w3c.dom.events.CompositionEventInit
 import org.w3c.dom.events.Event
@@ -86,6 +88,25 @@ internal fun compositionEnd(data: String) =
 internal fun createMouseEvent(type: String): MouseEvent {
     return MouseEvent(type)
 }
+
+/**
+ * Creates a synthetic TouchEvent ("touchstart"/"touchmove"/"touchend"/"touchcancel").
+ *
+ * The Touch lists are left empty: the ComposeWindow touch handlers read only [Event.cancelable].
+ * [cancelable] defaults to true; pass false to emulate an event dispatched while the browser is
+ * already performing a default action (e.g. touchmove/touchend during an ongoing pan).
+ *
+ * Desktop Firefox exposes the TouchEvent constructor only when dom.w3c_touch_events.enabled
+ * is set - the test browser is launched with that pref, see
+ * mpp/karma.config.d/web/commonKarmaConfig.js (FirefoxForComposeTests).
+ */
+internal fun touchEvent(type: String, cancelable: Boolean = true): Event =
+    createTouchEvent(type, cancelable)
+
+@OptIn(ExperimentalWasmJsInterop::class)
+// language=js
+private fun createTouchEvent(type: String, cancelable: Boolean): Event =
+    js("new TouchEvent(type, { cancelable: cancelable, bubbles: true })")
 
 
 internal interface EventsSequence {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/TouchPreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/TouchPreventDefaultTest.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.events.touchEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.w3c.dom.pointerevents.PointerEvent as WebPointerEvent
+import org.w3c.dom.pointerevents.PointerEventInit
+
+/**
+ * Verifies the preventDefault() decisions ComposeWindow makes on the touch event stream
+ * (see the touchstart/touchmove/touchend handlers in ComposeWindowInternal.web.kt).
+ *
+ * The browser's dispatch ordering contract is emulated manually: for each touch, the pointer
+ * event is dispatched before its touch counterpart (pointerdown -> touchstart,
+ * pointermove -> touchmove, pointerup -> touchend), matching de facto browser behavior.
+ *
+ * Limitations: synthetic events are untrusted, so the browser never performs real default
+ * actions for them. These tests pin down that we make the right preventDefault() calls for a
+ * given event stream; whether the browser then honors them (click suppression, focus
+ * retention, gesture handover) can only be verified end-to-end on real devices.
+ */
+class TouchPreventDefaultTest : OnCanvasTests {
+
+    private fun touch(id: Int, x: Int, y: Int) = PointerEventInit(
+        pointerId = id,
+        clientX = x,
+        clientY = y,
+        pointerType = "touch",
+        // Trusted touch-derived pointer events are cancelable; the EventInit default is false,
+        // and ComposeWindow's consume logic checks event.cancelable before preventDefault().
+        cancelable = true,
+    )
+
+    @Test
+    fun touchstartIsNotPrevented() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize().clickable { })
+        }
+
+        // Even though Compose consumes the pointerdown of an interactive area, touchstart must
+        // never be canceled - it would block system gestures (scroll, back, pull-to-refresh)
+        // before we know whether Compose handles the sequence.
+        dispatchEvents(WebPointerEvent("pointerdown", touch(0, 50, 50)))
+        val touchstart = touchEvent("touchstart")
+        dispatchEvents(touchstart)
+
+        assertFalse(touchstart.defaultPrevented)
+    }
+
+    @Test
+    fun touchendPreventedWhenReleaseConsumed() = runApplicationTest {
+        var clicksCount = 0
+        createComposeWindow {
+            Box(Modifier.fillMaxSize().clickable { clicksCount++ })
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 50)),
+            WebPointerEvent("pointerup", touch(0, 50, 50)),
+        )
+        val touchend = touchEvent("touchend")
+        dispatchEvents(touchend)
+
+        // The tap was consumed, so the synthetic mouse events (incl. click) must be suppressed.
+        assertTrue(touchend.defaultPrevented)
+
+        awaitIdle()
+        assertEquals(1, clicksCount)
+
+        // The flag is single-use: a touchend with no fresh pointerup must stay untouched.
+        val strayTouchend = touchEvent("touchend")
+        dispatchEvents(strayTouchend)
+        assertFalse(strayTouchend.defaultPrevented)
+    }
+
+    @Test
+    fun touchendNotPreventedWhenReleaseNotConsumed() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize()) // nothing consumes the tap
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 50)),
+            WebPointerEvent("pointerup", touch(0, 50, 50)),
+        )
+        val touchend = touchEvent("touchend")
+        dispatchEvents(touchend)
+
+        // The browser keeps its default actions (compatibility mouse events, click).
+        assertFalse(touchend.defaultPrevented)
+    }
+
+    @Test
+    fun nonCancelableTouchendStillResetsTheFlag() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize().clickable { })
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 50)),
+            WebPointerEvent("pointerup", touch(0, 50, 50)),
+        )
+
+        // The browser dispatches touchend with cancelable = false when it is already
+        // performing a default action; preventDefault() must not be attempted then.
+        val nonCancelable = touchEvent("touchend", cancelable = false)
+        dispatchEvents(nonCancelable)
+        assertFalse(nonCancelable.defaultPrevented)
+
+        // The consumed-release flag must be reset even on that path: a later touchend
+        // must not be canceled based on stale state.
+        val nextTouchend = touchEvent("touchend")
+        dispatchEvents(nextTouchend)
+        assertFalse(nextTouchend.defaultPrevented)
+    }
+
+    @Test
+    fun pointercancelResetsTheReleaseFlag() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize().clickable { })
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 50)),
+            WebPointerEvent("pointerup", touch(0, 50, 50)),
+            WebPointerEvent("pointercancel", touch(1, 50, 50)),
+        )
+        val touchend = touchEvent("touchend")
+        dispatchEvents(touchend)
+
+        assertFalse(touchend.defaultPrevented)
+    }
+
+    @Test
+    fun touchmovePreventedWhenComposeScrolls() = runTest {
+        createComposeWindow {
+            Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                repeat(50) {
+                    Box(Modifier.fillMaxWidth().height(100.dp))
+                }
+            }
+        }
+
+        // Drag upwards: the scrollable consumes the scroll (content scrolls forward).
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 80)),
+            // first move exceeds the touch slop
+            WebPointerEvent("pointermove", touch(0, 50, 60)),
+            WebPointerEvent("pointermove", touch(0, 50, 30)),
+        )
+        val touchmove = touchEvent("touchmove")
+        dispatchEvents(touchmove)
+
+        // Scrolling happened in Compose - the browser must not take over the gesture.
+        assertTrue(touchmove.defaultPrevented)
+    }
+
+    @Test
+    fun touchmovePreventedWhenDragConsumesMovesWithoutScroll() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize().pointerInput(Unit) {
+                detectTransformGestures { _, _, _, _ -> }
+            })
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 80)),
+            // first move exceeds the touch slop
+            WebPointerEvent("pointermove", touch(0, 50, 60)),
+            WebPointerEvent("pointermove", touch(0, 50, 30)),
+        )
+        val touchmove = touchEvent("touchmove")
+        dispatchEvents(touchmove)
+
+        // No scroll happened, but a component (drag) consumed the moves -
+        // the browser must not take over the gesture.
+        assertTrue(touchmove.defaultPrevented)
+    }
+
+    @Test
+    fun touchmoveNotPreventedWhenNothingConsumesMoves() = runTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize()) // nothing consumes the moves
+        }
+
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 80)),
+            WebPointerEvent("pointermove", touch(0, 50, 60)),
+            WebPointerEvent("pointermove", touch(0, 50, 30)),
+        )
+        val touchmove = touchEvent("touchmove")
+        dispatchEvents(touchmove)
+
+        // The browser is free to handle the gesture.
+        assertFalse(touchmove.defaultPrevented)
+    }
+
+    @Test
+    fun touchmoveNotPreventedWhenScrollingAtTheEdge() = runTest {
+        createComposeWindow {
+            Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                repeat(50) {
+                    Box(Modifier.fillMaxWidth().height(100.dp))
+                }
+            }
+        }
+
+        // Drag downwards while already scrolled to the top: the drag is tracked by the
+        // scrollable, but no scroll distance can be consumed (nowhere to scroll).
+        dispatchEvents(
+            WebPointerEvent("pointerdown", touch(0, 50, 30)),
+            // first move exceeds the touch slop
+            WebPointerEvent("pointermove", touch(0, 50, 60)),
+            WebPointerEvent("pointermove", touch(0, 50, 90)),
+        )
+        val touchmove = touchEvent("touchmove")
+        dispatchEvents(touchmove)
+
+        // The gesture hit the scroll edge - the browser should take it over
+        // (e.g. scroll of an outer html container, pull-to-refresh).
+        assertFalse(touchmove.defaultPrevented)
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/TouchPreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/TouchPreventDefaultTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.events.touchEvent
@@ -66,7 +68,7 @@ class TouchPreventDefaultTest : OnCanvasTests {
     @Test
     fun touchstartIsNotPrevented() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize().clickable { })
+            Box(Modifier.fillMaxSize().background(Color.LightGray).clickable { })
         }
 
         // Even though Compose consumes the pointerdown of an interactive area, touchstart must
@@ -76,14 +78,14 @@ class TouchPreventDefaultTest : OnCanvasTests {
         val touchstart = touchEvent("touchstart")
         dispatchEvents(touchstart)
 
-        assertFalse(touchstart.defaultPrevented)
+        assertFalse(touchstart.defaultPrevented, "touchstart should not be prevented")
     }
 
     @Test
     fun touchendPreventedWhenReleaseConsumed() = runApplicationTest {
         var clicksCount = 0
         createComposeWindow {
-            Box(Modifier.fillMaxSize().clickable { clicksCount++ })
+            Box(Modifier.fillMaxSize().background(Color.LightGray).clickable { clicksCount++ })
         }
 
         dispatchEvents(
@@ -94,21 +96,21 @@ class TouchPreventDefaultTest : OnCanvasTests {
         dispatchEvents(touchend)
 
         // The tap was consumed, so the synthetic mouse events (incl. click) must be suppressed.
-        assertTrue(touchend.defaultPrevented)
+        assertTrue(touchend.defaultPrevented, "touchend should be prevented when release is consumed")
 
         awaitIdle()
-        assertEquals(1, clicksCount)
+        assertEquals(1, clicksCount, "click should have been registered")
 
         // The flag is single-use: a touchend with no fresh pointerup must stay untouched.
         val strayTouchend = touchEvent("touchend")
         dispatchEvents(strayTouchend)
-        assertFalse(strayTouchend.defaultPrevented)
+        assertFalse(strayTouchend.defaultPrevented, "stray touchend without fresh pointerup should not be prevented")
     }
 
     @Test
     fun touchendNotPreventedWhenReleaseNotConsumed() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize()) // nothing consumes the tap
+            Box(Modifier.fillMaxSize().background(Color.LightGray)) // nothing consumes the tap
         }
 
         dispatchEvents(
@@ -119,13 +121,13 @@ class TouchPreventDefaultTest : OnCanvasTests {
         dispatchEvents(touchend)
 
         // The browser keeps its default actions (compatibility mouse events, click).
-        assertFalse(touchend.defaultPrevented)
+        assertFalse(touchend.defaultPrevented, "touchend should not be prevented when nothing consumes the tap")
     }
 
     @Test
     fun nonCancelableTouchendStillResetsTheFlag() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize().clickable { })
+            Box(Modifier.fillMaxSize().background(Color.LightGray).clickable { })
         }
 
         dispatchEvents(
@@ -137,19 +139,19 @@ class TouchPreventDefaultTest : OnCanvasTests {
         // performing a default action; preventDefault() must not be attempted then.
         val nonCancelable = touchEvent("touchend", cancelable = false)
         dispatchEvents(nonCancelable)
-        assertFalse(nonCancelable.defaultPrevented)
+        assertFalse(nonCancelable.defaultPrevented, "non-cancelable touchend should not be prevented")
 
         // The consumed-release flag must be reset even on that path: a later touchend
         // must not be canceled based on stale state.
         val nextTouchend = touchEvent("touchend")
         dispatchEvents(nextTouchend)
-        assertFalse(nextTouchend.defaultPrevented)
+        assertFalse(nextTouchend.defaultPrevented, "subsequent touchend should not be prevented after flag reset")
     }
 
     @Test
     fun pointercancelResetsTheReleaseFlag() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize().clickable { })
+            Box(Modifier.fillMaxSize().background(Color.LightGray).clickable { })
         }
 
         dispatchEvents(
@@ -160,7 +162,7 @@ class TouchPreventDefaultTest : OnCanvasTests {
         val touchend = touchEvent("touchend")
         dispatchEvents(touchend)
 
-        assertFalse(touchend.defaultPrevented)
+        assertFalse(touchend.defaultPrevented, "touchend should not be prevented after pointercancel resets the flag")
     }
 
     @Test
@@ -168,7 +170,7 @@ class TouchPreventDefaultTest : OnCanvasTests {
         createComposeWindow {
             Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
                 repeat(50) {
-                    Box(Modifier.fillMaxWidth().height(100.dp))
+                    Box(Modifier.fillMaxWidth().height(100.dp).background(Color.LightGray))
                 }
             }
         }
@@ -184,13 +186,13 @@ class TouchPreventDefaultTest : OnCanvasTests {
         dispatchEvents(touchmove)
 
         // Scrolling happened in Compose - the browser must not take over the gesture.
-        assertTrue(touchmove.defaultPrevented)
+        assertTrue(touchmove.defaultPrevented, "touchmove should be prevented when Compose scrolls")
     }
 
     @Test
     fun touchmovePreventedWhenDragConsumesMovesWithoutScroll() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize().pointerInput(Unit) {
+            Box(Modifier.fillMaxSize().background(Color.LightGray).pointerInput(Unit) {
                 detectTransformGestures { _, _, _, _ -> }
             })
         }
@@ -206,13 +208,13 @@ class TouchPreventDefaultTest : OnCanvasTests {
 
         // No scroll happened, but a component (drag) consumed the moves -
         // the browser must not take over the gesture.
-        assertTrue(touchmove.defaultPrevented)
+        assertTrue(touchmove.defaultPrevented, "touchmove should be prevented when drag consumes moves")
     }
 
     @Test
     fun touchmoveNotPreventedWhenNothingConsumesMoves() = runTest {
         createComposeWindow {
-            Box(Modifier.fillMaxSize()) // nothing consumes the moves
+            Box(Modifier.fillMaxSize().background(Color.LightGray)) // nothing consumes the moves
         }
 
         dispatchEvents(
@@ -224,7 +226,7 @@ class TouchPreventDefaultTest : OnCanvasTests {
         dispatchEvents(touchmove)
 
         // The browser is free to handle the gesture.
-        assertFalse(touchmove.defaultPrevented)
+        assertFalse(touchmove.defaultPrevented, "touchmove should not be prevented when nothing consumes moves")
     }
 
     @Test
@@ -232,7 +234,7 @@ class TouchPreventDefaultTest : OnCanvasTests {
         createComposeWindow {
             Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
                 repeat(50) {
-                    Box(Modifier.fillMaxWidth().height(100.dp))
+                    Box(Modifier.fillMaxWidth().height(100.dp).background(Color.LightGray))
                 }
             }
         }
@@ -250,6 +252,6 @@ class TouchPreventDefaultTest : OnCanvasTests {
 
         // The gesture hit the scroll edge - the browser should take it over
         // (e.g. scroll of an outer html container, pull-to-refresh).
-        assertFalse(touchmove.defaultPrevented)
+        assertFalse(touchmove.defaultPrevented, "touchmove should not be prevented when scrolling at the edge")
     }
 }


### PR DESCRIPTION
This PR rests on the specification of pointer events -> touch events relationship.
Calling `preventDefault` on pointer events doesn't prevent the touch events. 
Unless we preventDefault the touch events when it's necessary (according to Compose events handling) the browser will handle the gestures or even manipulate the focus. 
Such focus changes lead to unexpected software keyboard behaviour in mobile browsers. 
This PR introduces conditional preventDefault in touchend event handler (more info in the code comments).
We already had preventDefault in touchmove handler.

Fixes https://youtrack.jetbrains.com/issue/CMP-10438/Web-mobile-Android.-Software-keyboard-wont-open-after-a-context-menu

Updates the fix for https://youtrack.jetbrains.com/issue/CMP-10079/Web-Mobile.-iOS-26.4-only.-The-virtual-keyboard-jumps-after-each-tap

## Testing
Added new tests simulating the browser's events sequence.
Tested manually on Android Chrome and iOS Safary 26.5
This should be tested by QA

## Release Notes
### Fixes - Web
- Fixed the hidden software keyboard in mobile browsers in focused text fields

