### PR TITLE
Update demo project to use separate skiko-skottie dependencies

### DIFF
--- a/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
+++ b/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
@@ -106,7 +106,7 @@ fun <T: KotlinTarget> AndroidXMultiplatformExtension.configureForkWebTarget(
                 it.from(skikoWasm.map { artifact ->
                     project.zipTree(artifact)
                         .matching { pattern ->
-                            pattern.include("skiko.wasm", "skiko.mjs", "js-reexport-symbols.mjs")
+                            pattern.include("skiko.wasm", "skiko.mjs", "js-skiko-reexport-symbols.mjs")
                         }
                 })
             }

--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(libs.kotlinSerializationCore)
+                implementation(libs.skiko.skottie)
 
                 implementation(project(":compose:foundation:foundation"))
                 implementation(project(":compose:foundation:foundation-layout"))
@@ -157,6 +158,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinCoroutinesSwing)
                 implementation(libs.skikoAwtRuntime)
+                implementation(libs.skikoSkottieAwtRuntime)
             }
         }
 
@@ -293,6 +295,7 @@ private fun configureSkikoWebRuntime(
 
     val unpackRuntime = project.tasks.register("unpackSkikoRuntimeFor$titledTargetName", Copy::class.java) {
         destinationDir = project.file(unpackedRuntimeDir)
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         from(
             skikoWebRuntimeJarFiles.map { artifact -> project.zipTree(artifact) }
         )

--- a/gradle/libs-fork.versions.toml
+++ b/gradle/libs-fork.versions.toml
@@ -78,7 +78,7 @@ protobuf = "4.28.2"
 paparazzi = "1.0.0"
 paparazziNative = "2022.1.1-canary-f5f9f71"
 shadow = "8.1.1"
-skiko = "0.151.0-alpha02"
+skiko = "0.151.0-alpha03"
 spdxGradlePlugin = "0.6.0"
 sqldelight = "1.3.0"
 retrofit = "2.12.0"
@@ -303,6 +303,8 @@ skikoAwtRuntimeLinuxX64 = { module = "org.jetbrains.skiko:skiko-awt-runtime-linu
 skikoAwtRuntimeLinuxArm64 = { module = "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64", version.ref = "skiko" }
 skikoAwtRuntime = { module = "org.jetbrains.skiko:skiko-awt-runtime-all", version.ref = "skiko" }
 skikoWasmJs = { module = "org.jetbrains.skiko:skiko-wasm-js", version.ref = "skiko" }
+skiko-skottie = { module = "org.jetbrains.skiko:skiko-skottie", version.ref = "skiko" }
+skikoSkottieAwtRuntime = { module = "org.jetbrains.skiko:skiko-skottie-awt-runtime-all", version.ref = "skiko" }
 spdxGradlePluginz = { module = "org.spdx:spdx-gradle-plugin", version.ref = "spdxGradlePlugin" }
 sqldelightAndroid = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelightCoroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqldelight" }

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -76,13 +76,13 @@ config.frameworks.push("webpack-output");
 config.files.push(
     {pattern: path.resolve(basePath, "kotlin", "skiko.wasm"), included: false, served: true, watched: false},
     {pattern: path.resolve(basePath, "kotlin", "skiko.mjs"), included: true, served: true, watched: false, type: 'module'},
-    {pattern: path.resolve(basePath, "kotlin", "js-reexport-symbols.mjs"), included: false, served: true, watched: false, type: 'module'},
+    {pattern: path.resolve(basePath, "kotlin", "js-skiko-reexport-symbols.mjs"), included: false, served: true, watched: false, type: 'module'},
 );
 
 config.proxies = {
     "/skiko.mjs": path.resolve(basePath, "kotlin", "skiko.mjs"),
     "/skiko.wasm": path.resolve(basePath, "kotlin", "skiko.wasm"),
-    "/js-reexport-symbols.mjs": path.resolve(basePath, "kotlin", "js-reexport-symbols.mjs"),
+    "/js-skiko-reexport-symbols.mjs": path.resolve(basePath, "kotlin", "js-skiko-reexport-symbols.mjs"),
 }
 
 

--- a/mpp/karma.config.d/js/static/compose_context.html
+++ b/mpp/karma.config.d/js/static/compose_context.html
@@ -40,7 +40,7 @@ Reloaded before every execution run.
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script type="module">
-    import {api} from "/base/kotlin/js-reexport-symbols.mjs"
+    import {api} from "/base/kotlin/js-skiko-reexport-symbols.mjs"
 
     // Load the wasm module and start Karma after it's loaded
     api.awaitSkiko.then(() => {


### PR DESCRIPTION
This PR updates skiko to the newest alpha version and updates demo project to use separate skiko-skottie dependencies

## Release Notes
### Migration Notes - Multiple Platforms
- Skottie is no longer included in the Skiko core binary and is no longer bundled with Compose Multiplatform. To continue using Skottie, add `org.jetbrains.skiko:skiko-skottie` to `commonMain`. If your project targets desktop, also add `org.jetbrains.skiko:skiko-skottie-awt-runtime-all` to `desktopMain`.