### PR TITLE
Configure karma to wait for skiko.wasm initialization before running the tests

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -164,7 +164,7 @@ internal interface OnCanvasTests {
 
         fun skipFramesUntil(condition: () -> Boolean, onTrue: () -> Unit) {
             val currentTime = currentTimeMillis()
-            assertTrue(currentTime - startTime < timeout.inWholeMilliseconds, "awaitA11YChanges timed out after $timeout")
+            assertTrue(currentTime - startTime < timeout.inWholeMilliseconds, "awaitA11YChanges timed out after $timeout.\ninnerHtml = ${a11yContainer.innerHTML}")
             window.requestAnimationFrame {
                 if (!condition()) {
                     skipFramesUntil(condition, onTrue)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yContainerSizingTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yContainerSizingTest.kt
@@ -48,7 +48,7 @@ class A11yContainerSizingTest : OnCanvasTests {
     private val epsilon = 1.0
 
     @Test
-    fun a11yContainerHasNonZeroRenderedSizeAfterInit() = runTest {
+    fun a11yContainerHasNonZeroRenderedSizeAfterInit() = runApplicationTest {
         createComposeWindow {
             Text("a11y sizing regression")
         }
@@ -77,7 +77,7 @@ class A11yContainerSizingTest : OnCanvasTests {
      * size, so this comparison would fail.
      */
     @Test
-    fun a11yContainerCoversCanvasForHitTesting() = runTest {
+    fun a11yContainerCoversCanvasForHitTesting() = runApplicationTest {
         createComposeWindow {
             Text("a11y hit region regression")
         }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yContainerSizingTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yContainerSizingTest.kt
@@ -18,6 +18,9 @@ package androidx.compose.ui.platform.a11y
 
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.OnCanvasTests
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -126,14 +129,19 @@ class A11yContainerSizingTest : OnCanvasTests {
      */
     @Test
     fun semanticNodeLiesWithinA11yHitRegion() = runApplicationTest {
+        var showButton by mutableStateOf(false)
+
         createComposeWindow {
-            Button(onClick = {}) {
-                Text("Hittable")
+            if (showButton) {
+                Button(onClick = {}) {
+                    Text("Hittable")
+                }
             }
         }
 
         val a11yContainer = assertNotNull(getA11YContainer())
 
+        showButton = true
         awaitA11YChanges()
 
         val button = a11yContainer.children[0]?.children[0] as? HTMLElement

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -60,6 +60,16 @@ const KarmaWebpackOutputPlugin = {
 config.plugins.push(KarmaWebpackOutputPlugin);
 config.frameworks.push("webpack-output");
 
+config.files.push(
+    {pattern: path.resolve(basePath, "kotlin", "skiko.wasm"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "skiko.mjs"), included: false, served: true, watched: false, type: 'module'},
+);
+
+config.proxies = {
+    "/skiko.mjs": path.resolve(basePath, "kotlin", "skiko.mjs"),
+    "/skiko.wasm": path.resolve(basePath, "kotlin", "skiko.wasm"),
+}
+
 configLaunchers(config);
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540

--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -44,6 +44,11 @@ window.addEventListener("rejectionhandled", (event) => {
 
 const awaitAnimationFrame = () => new Promise(resolve => requestAnimationFrame(resolve));
 
+before(async function() {
+    const {awaitSkiko} = await import('/base/kotlin/skiko.mjs');
+    await awaitSkiko;
+});
+
 beforeEach(async function() {
     // Wait for skiko.wasm to be ready before each test
     await awaitAnimationFrame;


### PR DESCRIPTION
This change should reduce tests flakiness. 

## Release Notes
N/A
