### PR TITLE
Dispose Compose application automatically on its DOM container detached

### DIFF
--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
@@ -63,6 +63,12 @@ fun <T> AndroidXMultiplatformExtension.configureForkWebTarget(
         val target = createTarget {
             block?.execute(this)
             project.configurePinnedKotlinLibraries(platform)
+            if (platform == PlatformIdentifier.JS) {
+                compilerOptions {
+                    target.set("es2015")
+                    useEsClasses.set(true)
+                }
+            }
             browser {
                 testTask {
                     it.testLogging.showStandardStreams = true

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXForkTargetsExtensions.kt
@@ -63,12 +63,6 @@ fun <T> AndroidXMultiplatformExtension.configureForkWebTarget(
         val target = createTarget {
             block?.execute(this)
             project.configurePinnedKotlinLibraries(platform)
-            if (platform == PlatformIdentifier.JS) {
-                compilerOptions {
-                    target.set("es2015")
-                    useEsClasses.set(true)
-                }
-            }
             browser {
                 testTask {
                     it.testLogging.showStandardStreams = true

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
+import kotlin.js.js
 import kotlinx.browser.document
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
@@ -26,7 +27,6 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.OPEN
 import org.w3c.dom.ShadowRootInit
 import org.w3c.dom.ShadowRootMode
-
 /**
  * EXPERIMENTAL! Might be deleted or changed in the future!
  *
@@ -96,7 +96,7 @@ fun ComposeViewport(
     // Create a common positioning container (parent html element) for shadow and the interop containers
     // to position at the same place - the interop container is position at 0,0 relative to the shadow.
     // It simplifies the positioning of the interop views in the container.
-    val positioningContainer = document.createElement("div") as HTMLDivElement
+    val positioningContainer = ComposeWindow.createComposeComponent()
     positioningContainer.style.apply {
         position = "relative"
     }
@@ -172,6 +172,8 @@ fun ComposeViewport(
     canvas.style.setProperty("touch-action", "pan-x pan-y") // allow the browser to scroll when compose is not scrolling
     appContainer.appendChild(canvas)
 
+
+
     //a11y container
     val configuration = ComposeViewportConfiguration().apply(configure)
     val a11yContainerElement = if (configuration.isA11YEnabled) {
@@ -198,7 +200,7 @@ fun ComposeViewport(
     }
     positioningContainer.appendChild(interopContainerElement)
 
-    ComposeWindow(
+    val composeWindow = ComposeWindow(
         canvas = canvas,
         rootNode = shadowRoot,
         layerRoot = appContainer,
@@ -208,6 +210,10 @@ fun ComposeViewport(
         configuration = configuration,
         state = DefaultWindowState(viewportContainer)
     )
+
+    ComposeWindow.registerDisposableFor(positioningContainer) {
+        composeWindow.dispose()
+    }
 }
 
 private fun clearNodeChildren(node: Element): Unit =

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -1105,8 +1105,17 @@ private external interface ShadowRootExt {
 // the Kotlin/js `js(...)` intrinsic uses a restricted JS parser that does not
 // accept ES6 `class` declarations directly in the code string.
 @OptIn(ExperimentalWasmJsInterop::class)
-private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny =
-    js("(new Function('weakMap', 'return class ComposeComponentElement extends HTMLElement { disconnectedCallback() { const cb = weakMap.get(this); if (cb) cb(); }};'))(weakMap)")
+private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny = js("""
+    (() => {
+        class ComposeComponentElement extends HTMLElement {
+            disconnectedCallback() {
+                const cb = weakMap.get(this);
+                if (cb) cb();
+            }
+        }
+        return ComposeComponentElement;
+    })()
+""")
 
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -111,7 +111,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoRenderDelegate
 import org.jetbrains.skiko.hostOs
-import org.w3c.dom.CustomElementRegistry
 import org.w3c.dom.DocumentReadyState
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
@@ -932,7 +931,8 @@ internal class ComposeWindow(
 
         fun createComposeComponent(): HTMLElement {
             if (customElements.get("compose-component") == null) {
-                defineCustomElement("compose-component",
+                customElements.define(
+                    "compose-component",
                     composeComponentElementCtor(DomDisposableRegistry)
                 )
             }
@@ -1100,7 +1100,8 @@ private external interface ShadowRootExt {
 
 // A real ES6 `class extends HTMLElement` is required by `customElements.define`.
 // Kotlin/Wasm does not emit Kotlin classes as JS constructors, so we create the
-// constructor in JS and register it via a JS helper
+// constructor in JS and return it as a JS function so it can be passed directly
+// to `customElements.define`.
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny = js("""
     (() => {
@@ -1116,9 +1117,8 @@ private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny = js("""
 
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
-// Note: `V` is intentionally not a type parameter because Kotlin/Wasm JS interop
-// only allows type parameters with an upper bound of `JsAny` or its subtypes,
-// while the value stored here is a Kotlin function type `() -> Unit`.
+// Kotlin/Wasm JS interop  only allows type parameters with an upper bound of `JsAny` or its subtypes,
+// while the actual value stored here is a Kotlin function type `() -> Unit`.
 @OptIn(ExperimentalWasmJsInterop::class)
 private external class WeakMap<K : JsAny>(): JsAny {
     fun get(key: K): (() -> Unit)?
@@ -1127,8 +1127,9 @@ private external class WeakMap<K : JsAny>(): JsAny {
     fun delete(key: K): Boolean
 }
 
-private external val customElements: CustomElementRegistry
+private external interface CustomElementRegistry : JsAny {
+    fun get(name: String): JsAny?
+    fun define(name: String, constructor: JsAny)
+}
 
-@OptIn(ExperimentalWasmJsInterop::class)
-private fun defineCustomElement(name: String, ctor: JsAny): Unit =
-    js("customElements.define(name, ctor)")
+private external val customElements: CustomElementRegistry

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -640,7 +640,7 @@ internal class ComposeWindow(
         insetsManager?.onCanvasResized(canvas)
     }
 
-    // TODO: need to call .dispose() on window close.
+    // This is called automatically on destroying the corresponding DOM container
     fun dispose() {
         // dispose() can be called both explicitly and via the DOM disconnectedCallback
         // when the container element is removed from the document. Make it idempotent so
@@ -1100,10 +1100,7 @@ private external interface ShadowRootExt {
 
 // A real ES6 `class extends HTMLElement` is required by `customElements.define`.
 // Kotlin/Wasm does not emit Kotlin classes as JS constructors, so we create the
-// constructor in JS and register it via a JS helper.
-// Note: the class source is built at runtime through `new Function(...)` because
-// the Kotlin/js `js(...)` intrinsic uses a restricted JS parser that does not
-// accept ES6 `class` declarations directly in the code string.
+// constructor in JS and register it via a JS helper
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny = js("""
     (() => {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -98,6 +98,7 @@ import androidx.compose.ui.viewinterop.WebInteropContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.enableSavedStateHandles
 import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
 import kotlin.js.js
 import kotlinx.browser.document
 import kotlinx.browser.window
@@ -110,6 +111,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoRenderDelegate
 import org.jetbrains.skiko.hostOs
+import org.w3c.dom.CustomElementRegistry
 import org.w3c.dom.DocumentReadyState
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
@@ -126,7 +128,6 @@ import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
 import org.w3c.dom.pointerevents.PointerEvent
-import androidx.compose.ui.window.MediaQueryListener
 
 private val actualDensity
     get() = window.devicePixelRatio
@@ -915,6 +916,27 @@ internal class ComposeWindow(
             x = offsetX.toFloat() * density.density,
             y = offsetY.toFloat() * density.density
         )
+
+    companion object {
+        private val DomDisposableRegistry = WeakMap<JsAny>()
+
+        fun registerDisposableFor(element: HTMLElement, handler: () -> Unit) {
+            DomDisposableRegistry.set(element, {
+                handler()
+                DomDisposableRegistry.delete(element)
+            })
+        }
+
+        fun createComposeComponent(): HTMLElement {
+            if (customElements.get("compose-component") == null) {
+                defineCustomElement("compose-component",
+                    composeComponentElementCtor(DomDisposableRegistry)
+                )
+            }
+
+            return document.createElement("compose-component") as HTMLElement
+        }
+    }
 }
 
 //https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
@@ -1072,3 +1094,32 @@ private fun Element.isFocused(): Boolean {
 private external interface ShadowRootExt {
     val activeElement: Element?
 }
+
+// A real ES6 `class extends HTMLElement` is required by `customElements.define`.
+// Kotlin/Wasm does not emit Kotlin classes as JS constructors, so we create the
+// constructor in JS and register it via a JS helper.
+// Note: the class source is built at runtime through `new Function(...)` because
+// the Kotlin/js `js(...)` intrinsic uses a restricted JS parser that does not
+// accept ES6 `class` declarations directly in the code string.
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun composeComponentElementCtor(weakMap: WeakMap<JsAny>): JsAny =
+    js("(new Function('weakMap', 'return class ComposeComponentElement extends HTMLElement { disconnectedCallback() { const cb = weakMap.get(this); if (cb) cb(); }};'))(weakMap)")
+
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+// Note: `V` is intentionally not a type parameter because Kotlin/Wasm JS interop
+// only allows type parameters with an upper bound of `JsAny` or its subtypes,
+// while the value stored here is a Kotlin function type `() -> Unit`.
+@OptIn(ExperimentalWasmJsInterop::class)
+private external class WeakMap<K : JsAny>(): JsAny {
+    fun get(key: K): (() -> Unit)?
+    fun set(key: K, value: () -> Unit): WeakMap<K>
+    fun has(key: K): Boolean
+    fun delete(key: K): Boolean
+}
+
+private external val customElements: CustomElementRegistry
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun defineCustomElement(name: String, ctor: JsAny): Unit =
+    js("customElements.define(name, ctor)")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -642,7 +642,10 @@ internal class ComposeWindow(
 
     // TODO: need to call .dispose() on window close.
     fun dispose() {
-        check(!isDisposed)
+        // dispose() can be called both explicitly and via the DOM disconnectedCallback
+        // when the container element is removed from the document. Make it idempotent so
+        // the auto-dispose fallback doesn't fail after an explicit dispose.
+        if (isDisposed) return
         (platformContext.prefetchScheduler as? WebPrefetchScheduler)?.dispose()
         archComponentsOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         archComponentsOwner.viewModelStore.clear()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -108,6 +108,21 @@ internal interface OnCanvasTests {
             storeComposeWindow(getContainer(), jsReference)
         }
 
+    /**
+     * Test-only accessor for the currently stored [ComposeWindow], if any.
+     * Returns `null` if the compose window has not been created yet or has already been cleared.
+     */
+    fun getComposeWindowOrNull(): ComposeWindow? = composeWindow
+
+    /**
+     * Clears the stored reference to the [ComposeWindow] without calling `dispose()`.
+     * Use this in tests that intentionally trigger disposal via DOM removal to prevent
+     * [afterTest] from disposing an already-disposed window.
+     */
+    fun clearComposeWindowReference() {
+        composeWindow = null
+    }
+
     /*
     <container>
       <positioning_container>

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowDisposeOnDomRemovalTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowDisposeOnDomRemovalTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.sendFromScope
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.channels.Channel
+import org.w3c.dom.get
+
+/**
+ * Verifies the disposal contract implemented in `ComposeWindow.web.kt`:
+ * removing the `<compose-component>` custom element from the DOM must trigger
+ * `ComposeWindow.dispose()` via the custom element's `disconnectedCallback`.
+ *
+ * See the WeakMap-based wiring in `ComposeViewport(...)` and the
+ * `disconnectedCallback` in `composeComponentElementCtor(...)`.
+ */
+class ComposeWindowDisposeOnDomRemovalTest : OnCanvasTests {
+
+    /**
+     * Primary case: clearing the user-provided container removes the
+     * `<compose-component>` child and must dispose the `ComposeWindow`.
+     */
+    @Test
+    fun disposeIsCalledWhenComposeComponentIsDetachedFromDom() = runApplicationTest {
+        val destroyEvents = Channel<Lifecycle.Event>(4)
+        val onDisposeSignals = Channel<Unit>(1)
+
+        createComposeWindow {
+            DisposableEffect(Unit) {
+                onDispose { onDisposeSignals.sendFromScope(Unit) }
+            }
+        }
+
+        val window = assertNotNull(
+            getComposeWindowOrNull(),
+            "ComposeWindow was not created"
+        )
+        window.archComponentsOwner.lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    destroyEvents.sendFromScope(event)
+                }
+            }
+        )
+
+        // Sanity: not disposed yet.
+        assertNotEquals(
+            Lifecycle.State.DESTROYED,
+            window.archComponentsOwner.lifecycle.currentState,
+            "ComposeWindow must not be disposed before DOM removal"
+        )
+
+        // Trigger DOM destruction WITHOUT calling dispose() manually.
+        // replaceChildren() clears the container, which detaches the
+        // <compose-component> child and fires disconnectedCallback.
+        (getContainer() as CanReplaceChildren).replaceChildren()
+
+        // Give the browser a frame to fire disconnectedCallback.
+        awaitAnimationFrame()
+
+        // Assert dispose actually happened:
+        assertEquals(
+            Lifecycle.Event.ON_DESTROY,
+            destroyEvents.receiveWithTimeout(),
+            "ON_DESTROY was not delivered after DOM removal"
+        )
+
+        // The composition itself was torn down:
+        onDisposeSignals.receiveWithTimeout()
+
+        assertEquals(
+            Lifecycle.State.DESTROYED,
+            window.archComponentsOwner.lifecycle.currentState
+        )
+
+        // Prevent afterTest from disposing an already-disposed window.
+        clearComposeWindowReference()
+    }
+
+    /**
+     * Removing only the `<compose-component>` element must dispose the window as well.
+     * This proves that the mechanism relies on the custom element being disconnected,
+     * not on the outer container being cleared.
+     */
+    @Test
+    fun disposeIsCalledWhenPositioningContainerIsRemovedDirectly() = runApplicationTest {
+        val destroyEvents = Channel<Lifecycle.Event>(4)
+
+        createComposeWindow {}
+
+        val window = assertNotNull(
+            getComposeWindowOrNull(),
+            "ComposeWindow was not created"
+        )
+        window.archComponentsOwner.lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    destroyEvents.sendFromScope(event)
+                }
+            }
+        )
+
+        val positioningContainer = getContainer().children[0]
+            ?: error("positioning container not found")
+        (positioningContainer as RemovableElement).remove()
+
+        awaitAnimationFrame()
+
+        assertEquals(
+            Lifecycle.Event.ON_DESTROY,
+            destroyEvents.receiveWithTimeout(),
+            "ON_DESTROY was not delivered after removing <compose-component>"
+        )
+        assertEquals(
+            Lifecycle.State.DESTROYED,
+            window.archComponentsOwner.lifecycle.currentState
+        )
+
+        clearComposeWindowReference()
+    }
+
+    /**
+     * Removing the outer container (the whole subtree) from the document must also
+     * trigger disposal, because the `<compose-component>` child gets disconnected.
+     */
+    @Test
+    fun disposeIsCalledWhenContainerIsRemovedFromDocument() = runApplicationTest {
+        val destroyEvents = Channel<Lifecycle.Event>(4)
+
+        createComposeWindow {}
+
+        val window = assertNotNull(
+            getComposeWindowOrNull(),
+            "ComposeWindow was not created"
+        )
+        window.archComponentsOwner.lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    destroyEvents.sendFromScope(event)
+                }
+            }
+        )
+
+        // Note: the container itself is required by afterTest to reset the canvas,
+        // so we re-attach an empty replacement with the same id right away.
+        val container = getContainer()
+        val parent = container.parentNode ?: error("container has no parent")
+        (container as RemovableElement).remove()
+
+        awaitAnimationFrame()
+
+        assertEquals(
+            Lifecycle.Event.ON_DESTROY,
+            destroyEvents.receiveWithTimeout(),
+            "ON_DESTROY was not delivered after removing the container from document"
+        )
+        assertEquals(
+            Lifecycle.State.DESTROYED,
+            window.archComponentsOwner.lifecycle.currentState
+        )
+
+        // Restore a fresh container so that afterTest's resetCanvas() can find it.
+        val restored = kotlinx.browser.document.createElement("div")
+        restored.id = "canvasApp"
+        parent.appendChild(restored)
+    }
+}
+
+private external interface RemovableElement {
+    fun remove()
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren
+private external interface CanReplaceChildren {
+    fun replaceChildren()
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowDisposeOnDomRemovalTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowDisposeOnDomRemovalTest.kt
@@ -106,7 +106,7 @@ class ComposeWindowDisposeOnDomRemovalTest : OnCanvasTests {
      */
     @Test
     fun disposeIsCalledWhenPositioningContainerIsRemovedDirectly() = runApplicationTest {
-        val destroyEvents = Channel<Lifecycle.Event>(4)
+        val destroyEvents = Channel<Lifecycle.Event>(1)
 
         createComposeWindow {}
 


### PR DESCRIPTION
The goal of this PR is to enforce Compose  application disposal if DOM container that removed

Fixes:
https://youtrack.jetbrains.com/issue/CMP-9090
https://youtrack.jetbrains.com/issue/CMP-10507

## Testing
./gradlew testWeb

## Release Notes
### Features - Web
Disposing Compose application automatically if parent container is destroyed