### PR TITLE
Ensure canvas retains focus after backing HTML input removal

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -28,6 +28,10 @@ val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
     },
     Screen.Example("MagicMouse") {
         MagicMouse()
+    },
+    Screen.Example("Tab Focus") {
+        // https://youtrack.jetbrains.com/issue/CMP-9388
+        TabFocus()
     }
 ))
 

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TabFocus() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        BasicTextField(
+            state = rememberTextFieldState("TextField 1"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+        BasicTextField(
+            state = rememberTextFieldState("TextField 2"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+        Checkbox(checked = false, onCheckedChange = {})
+        BasicTextField(
+            state = rememberTextFieldState("TextField 3"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+        Checkbox(checked = false, onCheckedChange = {})
+        TextButton(onClick = {}) { Text("Button") }
+        Checkbox(checked = false, onCheckedChange = {})
+        BasicTextField(
+            state = rememberTextFieldState("TextField 4"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+        TextButton(onClick = {}) { Text("Button") }
+        BasicTextField(
+            state = rememberTextFieldState("TextField 5"),
+            lineLimits = TextFieldLineLimits.SingleLine
+        )
+        BasicTextField(
+            state = rememberTextFieldState("TextField 6"),
+            lineLimits = TextFieldLineLimits.SingleLine
+        )
+        Box(
+            modifier = Modifier.clickable(onClick = {}),
+        ) {
+            Text("clickable Box")
+        }
+        BasicTextField(
+            state = rememberTextFieldState("TextField 7"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+        BasicTextField(
+            state = rememberTextFieldState("TextField 8"),
+            lineLimits = TextFieldLineLimits.SingleLine,
+        )
+    }
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -334,6 +334,16 @@ internal class ComposeWindow(
                         //this@ComposeWindow.processKeyboardEvent(keyboardEvent)
                         return scene.sendKeyEvent(keyEvent)
                     }
+
+                    override fun stopInput() {
+                        // super.stopInput() will remove the focused backing html input.
+                        // Once a focused HTML element is removed, the browser moves focus to <body>.
+                        // Focus the canvas first so it retains focus after the backing input is removed:
+                        if (!canvas.isFocused()) {
+                            canvas.focus()
+                        }
+                        super.stopInput()
+                    }
                 }
             }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -288,6 +288,8 @@ private suspend fun awaitWithYield() {
 internal external class ExtendedShadowRoot : ShadowRoot {
 
     fun elementFromPoint(x: Double, y: Double): Element
+
+    val activeElement: Element?
 }
 
 // OnCanvasTests is an interface, so it can't have a backing field for composeWindow.

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextFieldFocusTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextFieldFocusTest.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.background
 import androidx.compose.ui.events.keyEvent
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.isClearFocusOnMouseDownEnabled
@@ -52,19 +54,19 @@ import org.w3c.dom.pointerevents.PointerEventInit
 
 class TextFieldFocusTest : OnCanvasTests {
 
+    private suspend fun waitForSingleLineHtmlInput(): HTMLSpanElement {
+        while (true) {
+            val element = getShadowRoot().querySelector("span.compose-backing-field")
+            if (element is HTMLSpanElement) {
+                return element
+            }
+            yield()
+        }
+    }
+
     @Test
     fun canMoveFocusForwardAndBackUsingTab() = runApplicationTest {
         val focusRequester = FocusRequester()
-
-        suspend fun waitForSingleLineHtmlInput(): HTMLSpanElement {
-            while (true) {
-                val element = getShadowRoot().querySelector("span.compose-backing-field")
-                if (element is HTMLSpanElement) {
-                    return element
-                }
-                yield()
-            }
-        }
 
         var firstTextFieldFocusState: FocusState? = null
         var secondTextFieldFocusState: FocusState? = null
@@ -226,5 +228,39 @@ class TextFieldFocusTest : OnCanvasTests {
         assertTrue(focusState!!.isFocused, "Expected to keep focus despite clicking outside")
     }
 
+    @Test
+    fun canvasRetainsFocusAfterTextFieldStopsInput() = runApplicationTest {
+        val focusRequester = FocusRequester()
+        var focusManager: FocusManager? = null
 
+        createComposeWindow {
+            Column {
+                focusManager = LocalFocusManager.current
+                BasicTextField(
+                    state = rememberTextFieldState("test"),
+                    modifier = Modifier.focusRequester(focusRequester),
+                    lineLimits = TextFieldLineLimits.SingleLine
+                )
+            }
+        }
+
+        val shadowRoot = getShadowRoot()
+
+        getCanvas().focus()
+        assertEquals(getCanvas(), shadowRoot.activeElement, "Canvas should be focused after explicit focus() call")
+
+        focusRequester.requestFocus()
+        awaitIdle()
+
+        // Wait for the backing HTML input to appear and be focused
+        val htmlInput = waitForSingleLineHtmlInput()
+        assertEquals(htmlInput, shadowRoot.activeElement, "Backing input should have DOM focus")
+
+        // Clear focus — this triggers stopInput() which removes the backing input
+        focusManager!!.clearFocus()
+        awaitIdle()
+
+        assertFalse(htmlInput.isConnected, "Backing input should be removed")
+        assertEquals(getCanvas(), shadowRoot.activeElement, "Canvas should retain focus after the html input is removed")
+    }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9388

**Description:**
Focus the canvas before the backing html input gets removed. When a focused HTML element gets removed, the browser will focus `<body>`. And the next "Tab" key event won't hit `<canvas>`, so Compose will miss it too. To avoid this, we focus `<canvas>` programmatically. 

## Testing
- Added a unit test
- This should be tested by QA

## Release Notes
### Fixes - Web
- Ensure canvas retains focus after backing HTML input removal

