### PR TITLE
Move skiko awt runtime to ui skiko

### DIFF
--- a/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
+++ b/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
@@ -79,7 +79,6 @@ object JetBrainsPublication {
                     "Jvmmacos-arm64",
                     "Jvmwindows-x64",
                     "Jvmwindows-arm64",
-                    "Jvmall",
                 )
             ),
         ),

--- a/compose/desktop/desktop/build.gradle
+++ b/compose/desktop/desktop/build.gradle
@@ -74,14 +74,12 @@ androidx {
     legacyDisableKotlinStrictApiMode = true
 }
 
-def jvmOs(container, name, skikoDep) {
+def jvmOs(container, name) {
     container.create("jvm$name", MavenPublication) {
         artifactId = "${project.name}-jvm-$name"
         def projectGroup = project.group
         def projectName = project.name
         def composeVersion = project.version
-        def skikoModule = skikoDep.module
-        def skikoVersion = skikoDep.versionConstraint.requiredVersion
         pom {
             withXml {
                 def dependenciesNode = asNode().appendNode("dependencies")
@@ -90,12 +88,6 @@ def jvmOs(container, name, skikoDep) {
                 desktopDependency.appendNode("artifactId", projectName)
                 desktopDependency.appendNode("version", composeVersion)
                 desktopDependency.appendNode("scope", "compile")
-
-                def skikoDependency = dependenciesNode.appendNode("dependency")
-                skikoDependency.appendNode("groupId", skikoModule.group)
-                skikoDependency.appendNode("artifactId", skikoModule.name)
-                skikoDependency.appendNode("version", skikoVersion)
-                skikoDependency.appendNode("scope", "runtime")
             }
         }
     }
@@ -104,13 +96,12 @@ def jvmOs(container, name, skikoDep) {
 afterEvaluate {
     publishing {
         publications {
-            jvmOs(it, "linux-x64", libs.skikoAwtRuntimeLinuxX64.get())
-            jvmOs(it, "linux-arm64", libs.skikoAwtRuntimeLinuxArm64.get())
-            jvmOs(it, "macos-x64", libs.skikoAwtRuntimeMacOsX64.get())
-            jvmOs(it, "macos-arm64", libs.skikoAwtRuntimeMacOsArm64.get())
-            jvmOs(it, "windows-x64", libs.skikoAwtRuntimeWindowsX64.get())
-            jvmOs(it, "windows-arm64", libs.skikoAwtRuntimeWindowsArm64.get())
-            jvmOs(it, "all", libs.skikoAwtRuntime.get())
+            jvmOs(it, "linux-x64")
+            jvmOs(it, "linux-arm64")
+            jvmOs(it, "macos-x64")
+            jvmOs(it, "macos-arm64")
+            jvmOs(it, "windows-x64")
+            jvmOs(it, "windows-arm64")
         }
     }
 }

--- a/compose/ui/ui-skiko/build.gradle
+++ b/compose/ui/ui-skiko/build.gradle
@@ -71,6 +71,9 @@ androidXMultiplatform {
         desktopMain {
             dependsOn(nonAndroidMain)
             dependsOn(nonAndroidExcludingWebMain)
+            dependencies {
+                runtimeOnly(libs.skikoAwtRuntime)
+            }
         }
 
         desktopTest {


### PR DESCRIPTION
This PR moves the JVM Skiko runtime to ui-skiko while keeping the desktop-specific publications for backward compatibility. It also removes the previously introduced `desktop-jvm-all` publication as it will be no longer needed

## Release Notes
N/A