### PR TITLE
Fix Tab focus order with interop elements 

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -32,6 +32,9 @@ val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
     Screen.Example("Tab Focus") {
         // https://youtrack.jetbrains.com/issue/CMP-9388
         TabFocus()
-    }
+    },
+    Screen.Example("Tab Focus With Interop") {
+        TabFocusWithInterop()
+    },
 ))
 

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
@@ -17,10 +17,15 @@
 package androidx.compose.mpp.demo.bugs
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -29,7 +34,15 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.HtmlElementView
+import kotlinx.browser.document
+import org.w3c.dom.HTMLButtonElement
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.HtmlElementView
+import kotlinx.browser.document
 
 @Composable
 fun TabFocus() {
@@ -79,6 +92,49 @@ fun TabFocus() {
         BasicTextField(
             state = rememberTextFieldState("TextField 8"),
             lineLimits = TextFieldLineLimits.SingleLine,
+        )
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun TabFocusWithInterop() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        TextButton(onClick = {}) { Text("Compose Button 1") }
+
+        HtmlElementView(
+            factory = {
+                (document.createElement("button") as HTMLButtonElement).apply {
+                    textContent = "HTML Button 1"
+                }
+            },
+            modifier = Modifier.width(200.dp).height(40.dp)
+        )
+
+        TextButton(onClick = {}) { Text("Compose Button 2") }
+
+        HtmlElementView(
+            factory = {
+                (document.createElement("button") as HTMLButtonElement).apply {
+                    textContent = "HTML Button 2"
+                }
+            },
+            modifier = Modifier.width(200.dp).height(40.dp)
+        )
+
+        TextButton(onClick = {}) { Text("Compose Button 3") }
+
+        HtmlElementView(
+            factory = {
+                (document.createElement("button") as HTMLButtonElement).apply {
+                    textContent = "HTML Button 3"
+                }
+            },
+            modifier = Modifier.width(200.dp).height(40.dp)
         )
     }
 }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
@@ -138,7 +138,7 @@ private fun ComplexInteropWidget() {
     HtmlElementView(
         factory = {
             (document.createElement("div") as HTMLDivElement).apply {
-                setAttribute("tabindex", "-1")
+                // setAttribute("tabindex", "0")
                 setAttribute("style", "display:flex; flex-direction:column; gap:8px; border:1px solid #ccc; padding:4px;")
 
                 appendChild(document.createElement("span")).apply {

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
@@ -17,13 +17,10 @@
 package androidx.compose.mpp.demo.bugs
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
@@ -38,11 +35,14 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.HtmlElementView
+import kotlin.let
 import kotlinx.browser.document
 import org.w3c.dom.HTMLButtonElement
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.HtmlElementView
-import kotlinx.browser.document
+import org.w3c.dom.HTMLDivElement
+import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.HTMLLabelElement
+import org.w3c.dom.HTMLSelectElement
+import org.w3c.dom.HTMLOptionElement
 
 @Composable
 fun TabFocus() {
@@ -117,14 +117,7 @@ fun TabFocusWithInterop() {
 
         TextButton(onClick = {}) { Text("Compose Button 2") }
 
-        HtmlElementView(
-            factory = {
-                (document.createElement("button") as HTMLButtonElement).apply {
-                    textContent = "HTML Button 2"
-                }
-            },
-            modifier = Modifier.width(200.dp).height(40.dp)
-        )
+        ComplexInteropWidget()
 
         TextButton(onClick = {}) { Text("Compose Button 3") }
 
@@ -137,4 +130,48 @@ fun TabFocusWithInterop() {
             modifier = Modifier.width(200.dp).height(40.dp)
         )
     }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun ComplexInteropWidget() {
+    HtmlElementView(
+        factory = {
+            (document.createElement("div") as HTMLDivElement).apply {
+                setAttribute("tabindex", "0")
+                setAttribute("style", "display:flex; flex-direction:column; gap:8px; border:1px solid #ccc; padding:4px;")
+
+                appendChild(document.createElement("span")).apply {
+                    textContent = "Complex HTML Interop Widget with focusable nested elements"
+                }
+
+                // Button 1
+                appendChild(document.createElement("button")).apply {
+                    textContent = "Click me 1"
+                }
+
+                appendChild(document.createElement("button")).apply {
+                    textContent = "Click me 2"
+                }
+
+                // Single-line text input
+                appendChild((document.createElement("input") as HTMLInputElement).also {
+                    it.setAttribute("type", "text")
+                    it.setAttribute("placeholder", "Type something...")
+                    it.setAttribute("style", "width:100%; box-sizing:border-box;")
+                })
+
+                // Checkbox
+                appendChild((document.createElement("input") as HTMLInputElement).also {
+                    it.setAttribute("type", "checkbox")
+                    it.setAttribute("id", "interop-checkbox")
+                })
+            }
+        },
+        update = { div ->
+            div.style.width = "93%"
+            div.style.height = "93%"
+        },
+        modifier = Modifier.width(220.dp).height(180.dp)
+    )
 }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TabFocus.kt
@@ -138,7 +138,7 @@ private fun ComplexInteropWidget() {
     HtmlElementView(
         factory = {
             (document.createElement("div") as HTMLDivElement).apply {
-                setAttribute("tabindex", "0")
+                setAttribute("tabindex", "-1")
                 setAttribute("style", "display:flex; flex-direction:column; gap:8px; border:1px solid #ccc; padding:4px;")
 
                 appendChild(document.createElement("span")).apply {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.node.visitLocalDescendants
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.window.LocalComposeWindow
+import kotlin.js.js
 import kotlinx.browser.window
 import org.w3c.dom.AddEventListenerOptions
 import org.w3c.dom.HTMLElement
@@ -69,15 +70,25 @@ private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetNode>(
 
 private class FocusTargetPropertiesNode : Modifier.Node(), FocusPropertiesModifierNode {
     override fun applyFocusProperties(focusProperties: FocusProperties) {
-        focusProperties.canFocus = node.isAttached
+        val hasFocusable = getFirstFocusable(getEmbeddedHtmlContainer()) != null
+        focusProperties.canFocus = node.isAttached && hasFocusable
     }
 }
 
 private class FocusGroupPropertiesNode :
     Modifier.Node(), FocusPropertiesModifierNode, CompositionLocalConsumerModifierNode {
 
+    private var lastTabKeyDown: KeyboardEvent? = null
+    private var htmlElement: HTMLElement? = null
+
     private val onEnter: FocusEnterExitScope.() -> Unit = {
-        htmlElement?.focus()
+        val focusTarget = when (requestedFocusDirection) {
+            FocusDirection.Previous,
+            FocusDirection.Up,
+            FocusDirection.Left -> getLastFocusable(getEmbeddedHtmlContainer())
+            else -> getFirstFocusable(getEmbeddedHtmlContainer())
+        }
+        focusTarget?.focus()
     }
 
     private val onExit: FocusEnterExitScope.() -> Unit = {
@@ -89,9 +100,6 @@ private class FocusGroupPropertiesNode :
         focusProperties.onEnter = onEnter
         focusProperties.onExit = onExit
     }
-
-    private var lastTabKeyDown: KeyboardEvent? = null
-    private var htmlElement: HTMLElement? = null
 
     private val tabKeyDownListener = { event: Event ->
         lastTabKeyDown = (event as? KeyboardEvent)?.takeIf {
@@ -159,7 +167,7 @@ private class FocusGroupPropertiesNode :
 
     override fun onAttach() {
         super.onAttach()
-        htmlElement = getEmbeddedHtmlElement()
+        htmlElement = getEmbeddedHtmlContainer()
         // capture=true to listen to focus/blur events on the children of the interop container
         htmlElement?.addEventListener("focus", onFocusEvent, AddEventListenerOptions(capture = true))
         htmlElement?.addEventListener("blur", onBlurEvent, AddEventListenerOptions(capture = true))
@@ -169,6 +177,7 @@ private class FocusGroupPropertiesNode :
         htmlElement?.removeEventListener("focus", onFocusEvent, AddEventListenerOptions(capture = true))
         htmlElement?.removeEventListener("blur", onBlurEvent, AddEventListenerOptions(capture = true))
         super.onDetach()
+        htmlElement = null
     }
 
     private fun getFocusTargetOfEmbeddedViewWrapper(): FocusTargetNode {
@@ -195,8 +204,99 @@ private object FocusTargetPropertiesElement : ModifierNodeElement<FocusTargetPro
     override fun equals(other: Any?) = other === this
 }
 
-private fun Modifier.Node.getEmbeddedHtmlElement(): HTMLElement {
-    return checkNotNull(node.requireLayoutNode().getInteropView()) {
-        "Could not fetch interop view"
-    } as HTMLElement
+private fun Modifier.Node.getEmbeddedHtmlContainer(): HTMLElement {
+    val interopView = node.requireLayoutNode().getInteropView() as? HTMLElement
+    checkNotNull(interopView) {"Could not fetch interop view" }
+    val interopContainer = interopView.parentElement as? HTMLElement
+    checkNotNull(interopContainer) {"Could not fetch interop container" }
+    return interopContainer
 }
+
+/**
+ * Gets the first focusable element inside [container].
+ * Uses TreeWalker for early-exit forward traversal.
+ */
+// language=js
+private fun getFirstFocusable(container: HTMLElement): HTMLElement? = js(
+    """
+    (() => {
+        if (!container) return null;
+
+        const selector = 'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, audio[controls], video[controls]';
+        
+        const isVisible = (node) => {
+            // 1. If checkVisibility exists and node is connected to DOM
+            if (typeof node.checkVisibility === 'function' && node.isConnected) {
+                return node.checkVisibility({ visibilityProperty: true, opacityProperty: true });
+            }
+            // 2. Fallback for detached nodes or browsers without checkVisibility
+            const style = window.getComputedStyle(node);
+            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+        };
+
+        const walker = document.createTreeWalker(
+            container,
+            NodeFilter.SHOW_ELEMENT,
+            {
+                acceptNode(node) {
+                    if (!node.matches(selector)) return NodeFilter.FILTER_SKIP;
+                    if (node.closest('[inert]')) return NodeFilter.FILTER_SKIP;
+                    return isVisible(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+                }
+            }
+        );
+
+        return walker.nextNode();
+    })()
+    """
+)
+
+/**
+ * Gets the last focusable element inside [container].
+ * Uses reverse depth-first traversal for instant early-exit from the end.
+ */
+// language=js
+private fun getLastFocusable(container: HTMLElement): HTMLElement? = js(
+    """
+    (() => {
+        if (!container) return null;
+
+        // 1. Jump directly to the deepest last leaf element
+        let lastLeaf = container;
+        while (lastLeaf.lastElementChild) {
+            lastLeaf = lastLeaf.lastElementChild;
+        }
+
+        // If the container has no child elements, return null
+        if (lastLeaf === container) return null;
+        
+        const selector = 'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, audio[controls], video[controls]';
+        
+        const isVisible = (node) => {
+            if (typeof node.checkVisibility === 'function' && node.isConnected) {
+                return node.checkVisibility({ visibilityProperty: true, opacityProperty: true });
+            }
+            const style = window.getComputedStyle(node);
+            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+        };
+
+        const filter = {
+            acceptNode(node) {
+                if (!node.matches(selector)) return NodeFilter.FILTER_SKIP;
+                if (node.closest('[inert]')) return NodeFilter.FILTER_SKIP;
+                return isVisible(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+            }
+        };
+
+        // 2. If the last leaf itself is focusable, return it immediately
+        if (filter.acceptNode(lastLeaf) === NodeFilter.FILTER_ACCEPT) {
+            return lastLeaf;
+        }
+
+        // 3. Otherwise, position TreeWalker at the leaf and walk BACKWARD natively!
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, filter);
+        walker.currentNode = lastLeaf;
+        return walker.previousNode();
+    })()
+    """
+)

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -230,7 +230,8 @@ internal fun getFocusableHtmlElement(container: HTMLElement, last: Boolean = fal
 (() => {
     if (!container) return null;
 
-    let skipClosestInertCheck = false; // its value is updated depending on the traversal direction
+    // A flag to avoid redundant closest(inert) checks during upwards traversal when no inert nested elements are present
+    const skipClosestInertCheck = last && !container.querySelector('[inert]');
 
     const selector = ':is(button, select, textarea, input:not([type="hidden"])):not([disabled]), [href], [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, :is(audio, video)[controls]';
     const filter = {
@@ -242,17 +243,9 @@ internal fun getFocusableHtmlElement(container: HTMLElement, last: Boolean = fal
     };
 
     if (!last) {
-        // Forward traversal:
-        // with forward traversal, we check the nested containers for inert,
-        // checking for closest(inert) is redundant.
-        skipClosestInertCheck = true;
         const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, filter);
         return walker.nextNode();
     }
-    
-    const hasAnyInert = container.querySelector('[inert]') !== null;
-    // Avoid redundant closest(inert) check when no inert nested elements are present
-    skipClosestInertCheck = !hasAnyInert;
 
     // Reverse traversal — jump to the deepest last leaf, then walk backward
     let lastLeaf = container;

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.viewinterop
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusDirection.Companion.Exit
+import androidx.compose.ui.focus.FocusEnterExitScope
+import androidx.compose.ui.focus.FocusProperties
+import androidx.compose.ui.focus.FocusPropertiesModifierNode
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.FocusTargetNode
+import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.focus.performRequestFocus
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.requireLayoutNode
+import androidx.compose.ui.node.requireOwner
+import androidx.compose.ui.node.visitLocalDescendants
+import androidx.compose.ui.node.Nodes
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.window.LocalComposeWindow
+import kotlin.js.js
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.FocusEvent
+import org.w3c.dom.events.KeyboardEvent
+
+/**
+ * Modifier that bridges HTML interop views into Compose's focus system.
+ *
+ * Applied automatically to [HtmlElementView] so that interop elements participate in
+ * Compose focus navigation (Tab / Shift+Tab).
+ *
+ * Mirrors [FocusGroupNode.android.kt] for Android.
+ */
+internal fun Modifier.focusInteropModifier(): Modifier = this
+    // Focus group to intercept focus enter/exit. Manages focus enter/exit events from the
+    // HTML element and observes the focus state inside the interop element.
+    .then(FocusGroupPropertiesElement)
+    .focusTarget()
+    // Focus target to make the embedded view focusable. This focusTarget becomes focused when
+    // the associated HTML element gains focus. It represents the focusability of the interop view.
+    .then(FocusTargetPropertiesElement)
+    .then(FocusTargetInteropElement)
+
+private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetInteropNode>() {
+    override fun create() = FocusTargetInteropNode()
+
+    override fun update(node: FocusTargetInteropNode) {}
+
+    override fun hashCode() = "focusTargetInterop".hashCode()
+
+    override fun equals(other: Any?) = other === this
+}
+
+/**
+ * The node that becomes focused on the Compose side when the associated HTML element gains focus.
+ */
+private class FocusTargetInteropNode :
+    DelegatingNode(), ObserverModifierNode, CompositionLocalConsumerModifierNode {
+
+    private val focusTargetNode =
+        delegate(FocusTargetNode(isInteropViewHost = true, onFocusChange = ::onFocusStateChange))
+
+    private fun onFocusStateChange(previousState: FocusState, currentState: FocusState) {
+        if (!isAttached) return
+        val isFocused = currentState.isFocused
+        val wasFocused = previousState.isFocused
+        // Ignore cases where we are initialized as unfocused, or moving between different
+        // unfocused states.
+        if (isFocused == wasFocused) return
+        // Pinning could be added here in the future if needed.
+    }
+
+    override fun onObservedReadsChanged() {}
+}
+
+private class FocusTargetPropertiesNode : Modifier.Node(), FocusPropertiesModifierNode {
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        val htmlElement = getEmbeddedHtmlElement()
+        focusProperties.canFocus = node.isAttached && true // htmlElement.isFocusable()
+//        htmlElement.getBoundingClientRect()?.let { rect ->
+//            focusProperties.focusRect = Rect(rect.left.toFloat(), rect.top.toFloat(),
+//                rect.right.toFloat(), rect.bottom.toFloat())
+//        }
+    }
+}
+
+/**
+ * Checks if an HTML element can receive focus.
+ */
+//private fun HTMLElement.isFocusable(): Boolean = js("this.tabIndex >= 0 || this.tagName === 'BUTTON' || this.tagName === 'INPUT' || " +
+//        "this.tagName === 'SELECT' || this.tagName === 'TEXTAREA' || this.tagName === 'A'")
+
+/**
+ * Gets the bounding client rect of an HTML element.
+ */
+//private fun HTMLElement.getBoundingClientRect(): Rect? {
+//    // language=javascript
+//    return js("var rect = this.getBoundingClientRect(); " +
+//        "if (rect.width === 0 && rect.height === 0) return null; " +
+//        "return new androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.right, rect.bottom);")
+//}
+
+private class FocusGroupPropertiesNode :
+    Modifier.Node(), FocusPropertiesModifierNode, CompositionLocalConsumerModifierNode {
+
+    var focusedChild: HTMLElement? = null
+
+    val onEnter: FocusEnterExitScope.() -> Unit = {
+        val htmlElement = getEmbeddedHtmlElement()
+        if (!htmlElement.isFocused()) {
+            htmlElement.focus()
+            // Try to focus the HTML element or its first focusable child.
+//            val target = (htmlElement.querySelector(":focusable") ?: htmlElement) as? HTMLElement
+//            target?.focus()
+        }
+    }
+
+    val onExit: FocusEnterExitScope.() -> Unit = {
+        val htmlElement = getEmbeddedHtmlElement()
+        if (htmlElement.isFocused()) {
+            htmlElement.blur()
+        }
+    }
+
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        focusProperties.canFocus = false
+        focusProperties.onEnter = onEnter
+        focusProperties.onExit = onExit
+    }
+
+    private var lastTabKeyDown: KeyboardEvent? = null
+
+    override fun onAttach() {
+        println("FocusGroupNode.onAttach")
+        super.onAttach()
+        val htmlElement = getEmbeddedHtmlElement()
+        println("htmlElement: $htmlElement")
+        val tabKeyDownListener = { event: Event ->
+            println("Tab keydown!!! - $event")
+
+            lastTabKeyDown = (event as? KeyboardEvent)?.takeIf { it.key == "Tab" }
+
+            window.requestAnimationFrame {
+                lastTabKeyDown = null
+            }
+
+            Unit
+        }
+        htmlElement.addEventListener("focus") {
+            htmlElement.addEventListener("keydown", tabKeyDownListener)
+        }
+        htmlElement.addEventListener("blur") {
+            htmlElement.removeEventListener("keydown", tabKeyDownListener)
+            if (lastTabKeyDown != null) {
+                val localComposeWindow = currentValueOf(LocalComposeWindow)
+                localComposeWindow?.focusCanvas()
+                val focusManager = currentValueOf(LocalFocusManager)
+                val direction = if (lastTabKeyDown?.shiftKey == true) FocusDirection.Previous else FocusDirection.Next
+                focusManager.moveFocus(direction)
+                lastTabKeyDown = null
+            }
+        }
+//        htmlElement.addEventListener("focusin") { onFocusIn(it)}
+//        htmlElement.addEventListener("focusout") { onFocusOut(it) }
+    }
+
+    override fun onDetach() {
+        println("FocusGroupNode.onDetach")
+        val htmlElement = getEmbeddedHtmlElement()
+//        htmlElement.removeEventListener("focusin", ::onFocusIn)
+//        htmlElement.removeEventListener("focusout", ::onFocusOut)
+        focusedChild = null
+        super.onDetach()
+    }
+
+    private val onFocusIn: (Event) -> Unit = { event ->
+    }
+
+    private val onFocusOut: (Event) -> Unit = { event ->
+    }
+
+    private fun getFocusTargetOfEmbeddedViewWrapper(): FocusTargetNode {
+        var foundFocusTargetOfFocusGroup = false
+        visitLocalDescendants(Nodes.FocusTarget) {
+            if (foundFocusTargetOfFocusGroup) return it
+            foundFocusTargetOfFocusGroup = true
+        }
+        error("Could not find focus target of embedded view wrapper")
+    }
+}
+
+private object FocusGroupPropertiesElement : ModifierNodeElement<FocusGroupPropertiesNode>() {
+    override fun create(): FocusGroupPropertiesNode = FocusGroupPropertiesNode()
+
+    override fun update(node: FocusGroupPropertiesNode) {}
+
+    override fun hashCode() = "FocusGroupProperties".hashCode()
+
+    override fun equals(other: Any?) = other === this
+}
+
+private object FocusTargetPropertiesElement : ModifierNodeElement<FocusTargetPropertiesNode>() {
+    override fun create(): FocusTargetPropertiesNode = FocusTargetPropertiesNode()
+
+    override fun update(node: FocusTargetPropertiesNode) {}
+
+    override fun hashCode() = "FocusTargetProperties".hashCode()
+
+    override fun equals(other: Any?) = other === this
+}
+
+private fun Modifier.Node.getEmbeddedHtmlElement(): HTMLElement {
+    return checkNotNull(node.requireLayoutNode().getInteropView()) {
+        "Could not fetch interop view"
+    } as HTMLElement
+}
+
+private fun HTMLElement.isFocused(): Boolean {
+    val root = getRootNode()
+    return false
+}
+
+private external interface DocumentOrShadowRootLike {
+    val activeElement: HTMLElement?
+}
+
+private fun getRootNode(): DocumentOrShadowRootLike = js("this.getRootNode()")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.node.visitLocalDescendants
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.window.LocalComposeWindow
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.JsString
 import kotlin.js.js
 import kotlinx.browser.window
 import org.w3c.dom.AddEventListenerOptions
@@ -69,10 +72,11 @@ private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetNode>(
 }
 
 private class FocusTargetPropertiesNode : Modifier.Node(), FocusPropertiesModifierNode {
+    @OptIn(ExperimentalWasmJsInterop::class)
     override fun applyFocusProperties(focusProperties: FocusProperties) {
         focusProperties.canFocus = node.isAttached
             // find at least one focusable element inside the interop container
-            && getFirstFocusable(getEmbeddedHtmlContainer()) != null
+            && getFocusableHtmlElement(getEmbeddedHtmlContainer()) != null
     }
 }
 
@@ -82,12 +86,13 @@ private class FocusGroupPropertiesNode :
     private var lastTabKeyDown: KeyboardEvent? = null
     private var htmlElement: HTMLElement? = null
 
+    @OptIn(ExperimentalWasmJsInterop::class)
     private val onEnter: FocusEnterExitScope.() -> Unit = {
         val focusTarget = when (requestedFocusDirection) {
             FocusDirection.Previous,
             FocusDirection.Up,
-            FocusDirection.Left -> getLastFocusable(getEmbeddedHtmlContainer())
-            else -> getFirstFocusable(getEmbeddedHtmlContainer())
+            FocusDirection.Left -> getFocusableHtmlElement(getEmbeddedHtmlContainer(), last = true)
+            else -> getFocusableHtmlElement(getEmbeddedHtmlContainer())
         }
         focusTarget?.focus()
     }
@@ -207,97 +212,53 @@ private object FocusTargetPropertiesElement : ModifierNodeElement<FocusTargetPro
 
 private fun Modifier.Node.getEmbeddedHtmlContainer(): HTMLElement {
     val interopView = node.requireLayoutNode().getInteropView() as? HTMLElement
-    checkNotNull(interopView) {"Could not fetch interop view" }
+    checkNotNull(interopView) { "Could not fetch interop view" }
     val interopContainer = interopView.parentElement as? HTMLElement
-    checkNotNull(interopContainer) {"Could not fetch interop container" }
+    checkNotNull(interopContainer) { "Could not fetch interop container" }
     return interopContainer
 }
 
 /**
- * Gets the first focusable element inside [container].
- * Uses TreeWalker for early-exit forward traversal.
+ * Gets the first or last focusable HTML element inside [container].
+ *
+ * When [last] is false (default), performs a forward TreeWalker traversal with early exit.
+ * When [last] is true, jumps to the deepest last leaf and walks backward for instant early exit.
  */
-// language=js
-private fun getFirstFocusable(container: HTMLElement): HTMLElement? = js(
-    """
-    (() => {
-        if (!container) return null;
+@OptIn(ExperimentalWasmJsInterop::class)
+//language=js
+internal fun getFocusableHtmlElement(container: HTMLElement, last: Boolean = false): HTMLElement? = js("""
+(() => {
+    if (!container) return null;
 
-        const selector = 'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, audio[controls], video[controls]';
-        
-        const isVisible = (node) => {
-            // 1. If checkVisibility exists and node is connected to DOM
-            if (typeof node.checkVisibility === 'function' && node.isConnected) {
-                return node.checkVisibility({ visibilityProperty: true, opacityProperty: true });
-            }
-            // 2. Fallback for detached nodes or browsers without checkVisibility
-            const style = window.getComputedStyle(node);
-            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
-        };
-
-        const walker = document.createTreeWalker(
-            container,
-            NodeFilter.SHOW_ELEMENT,
-            {
-                acceptNode(node) {
-                    if (!node.matches(selector)) return NodeFilter.FILTER_SKIP;
-                    if (node.closest('[inert]')) return NodeFilter.FILTER_SKIP;
-                    return isVisible(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
-                }
-            }
-        );
-
-        return walker.nextNode();
-    })()
-    """
-)
-
-/**
- * Gets the last focusable element inside [container].
- * Uses reverse depth-first traversal for instant early-exit from the end.
- */
-// language=js
-private fun getLastFocusable(container: HTMLElement): HTMLElement? = js(
-    """
-    (() => {
-        if (!container) return null;
-
-        // 1. Jump directly to the deepest last leaf element
-        let lastLeaf = container;
-        while (lastLeaf.lastElementChild) {
-            lastLeaf = lastLeaf.lastElementChild;
+    const selector = ':is(button, select, textarea, input:not([type="hidden"])):not([disabled]), [href], [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, :is(audio, video)[controls]';
+    const filter = {
+        acceptNode(node) {
+            return (node.matches(selector) && !node.closest('[inert]'))
+                ? NodeFilter.FILTER_ACCEPT
+                : NodeFilter.FILTER_SKIP;
         }
+    };
 
-        // If the container has no child elements, return null
-        if (lastLeaf === container) return null;
-        
-        const selector = 'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, audio[controls], video[controls]';
-        
-        const isVisible = (node) => {
-            if (typeof node.checkVisibility === 'function' && node.isConnected) {
-                return node.checkVisibility({ visibilityProperty: true, opacityProperty: true });
-            }
-            const style = window.getComputedStyle(node);
-            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
-        };
-
-        const filter = {
-            acceptNode(node) {
-                if (!node.matches(selector)) return NodeFilter.FILTER_SKIP;
-                if (node.closest('[inert]')) return NodeFilter.FILTER_SKIP;
-                return isVisible(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
-            }
-        };
-
-        // 2. If the last leaf itself is focusable, return it immediately
-        if (filter.acceptNode(lastLeaf) === NodeFilter.FILTER_ACCEPT) {
-            return lastLeaf;
-        }
-
-        // 3. Otherwise, position TreeWalker at the leaf and walk BACKWARD natively!
+    if (!last) {
+        // Forward traversal — TreeWalker naturally visits in document order
         const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, filter);
-        walker.currentNode = lastLeaf;
-        return walker.previousNode();
-    })()
-    """
-)
+        return walker.nextNode();
+    }
+
+    // Reverse traversal — jump to the deepest last leaf, then walk backward
+    let lastLeaf = container;
+    while (lastLeaf.lastElementChild) {
+        lastLeaf = lastLeaf.lastElementChild;
+    }
+    if (lastLeaf === container) return null;
+
+    // If the last leaf itself is focusable, return it immediately
+    if (filter.acceptNode(lastLeaf) === NodeFilter.FILTER_ACCEPT) {
+        return lastLeaf;
+    }
+
+    // Position TreeWalker at the leaf and walk backward natively
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, filter);
+    walker.currentNode = lastLeaf;
+    return walker.previousNode();
+})()""")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.focus.FocusTargetNode
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.performRequestFocus
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DelegatingNode
@@ -39,6 +40,7 @@ import androidx.compose.ui.node.visitLocalDescendants
 import androidx.compose.ui.node.Nodes
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.window.LocalComposeWindow
 import kotlin.js.js
 import kotlinx.browser.document
@@ -165,28 +167,40 @@ private class FocusGroupPropertiesNode :
 
             lastTabKeyDown = (event as? KeyboardEvent)?.takeIf { it.key == "Tab" }
 
-            window.requestAnimationFrame {
-                lastTabKeyDown = null
+
+            if (lastTabKeyDown != null) {
+                // This will ensure focus indication:
+                currentValueOf(LocalInputModeManager).requestInputMode(InputMode.Keyboard)
+                window.requestAnimationFrame {
+                    lastTabKeyDown = null
+                }
             }
 
             Unit
         }
         htmlElement.addEventListener("focus") {
+            println("focus::: HTML element gained focus")
             htmlElement.addEventListener("keydown", tabKeyDownListener)
+            // HTML element (or a child) gained focus. Sync Compose focus to the interop wrapper.
+            val focusTargetNode = getFocusTargetOfEmbeddedViewWrapper()
+            if (!focusTargetNode.focusState.hasFocus) {
+                focusTargetNode.performRequestFocus()
+            }
         }
         htmlElement.addEventListener("blur") {
+            println("blur::: HTML element lost focus")
             htmlElement.removeEventListener("keydown", tabKeyDownListener)
             if (lastTabKeyDown != null) {
+                println("blur::: Tab - $lastTabKeyDown")
                 val localComposeWindow = currentValueOf(LocalComposeWindow)
                 localComposeWindow?.focusCanvas()
                 val focusManager = currentValueOf(LocalFocusManager)
                 val direction = if (lastTabKeyDown?.shiftKey == true) FocusDirection.Previous else FocusDirection.Next
                 focusManager.moveFocus(direction)
+                println("blur::: Tab - direction: $direction")
                 lastTabKeyDown = null
             }
         }
-//        htmlElement.addEventListener("focusin") { onFocusIn(it)}
-//        htmlElement.addEventListener("focusout") { onFocusOut(it) }
     }
 
     override fun onDetach() {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -36,8 +36,10 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.window.LocalComposeWindow
 import kotlinx.browser.window
+import org.w3c.dom.AddEventListenerOptions
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
+import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 
 /**
@@ -107,7 +109,12 @@ private class FocusGroupPropertiesNode :
         }
     }
 
-    private val onFocusEvent = { _: Event ->
+    private var focusedInHtml = false
+
+    private val onFocusEvent = onFocusEvent@{ _: Event ->
+        if (focusedInHtml) return@onFocusEvent
+        focusedInHtml = true
+
         // Listen to Tab / Tab+Shift key down events to track where the focus moves.
         htmlElement?.addEventListener("keydown", tabKeyDownListener)
 
@@ -118,26 +125,33 @@ private class FocusGroupPropertiesNode :
         }
     }
 
-    private val onBlurEvent = { _: Event ->
-        htmlElement?.removeEventListener("keydown", tabKeyDownListener)
+    private val onBlurEvent = { event: Event ->
+        val blurEvent = event as FocusEvent
+        val isLeavingInteropContainer = blurEvent.relatedTarget == null
+            || htmlElement?.contains(blurEvent.relatedTarget as HTMLElement) != true
+
+      if (isLeavingInteropContainer) {
+          htmlElement?.removeEventListener("keydown", tabKeyDownListener)
+          focusedInHtml = false
+      }
 
         val composeWindow = currentValueOf(LocalComposeWindow)!!
         val isFocusInComposeContainer = composeWindow.isFocusInComposeContainer()
 
         // If the browser moved focus to a different element within the Compose-managed html-subtree,
         // then focus canvas again so it can handle key events.
-        if (isFocusInComposeContainer) {
+        if (isLeavingInteropContainer && isFocusInComposeContainer) {
             composeWindow.focusCanvas()
-        }
 
-        // Now let Compose move its own focus according to the earlier Tab keydown.
-        if (isFocusInComposeContainer && lastTabKeyDown != null) {
-            val direction = if (lastTabKeyDown?.shiftKey == true) {
-                FocusDirection.Previous
-            } else {
-                FocusDirection.Next
+            // Now let Compose move its own focus according to the earlier Tab keydown.
+            if (lastTabKeyDown != null) {
+                val direction = if (lastTabKeyDown?.shiftKey == true) {
+                    FocusDirection.Previous
+                } else {
+                    FocusDirection.Next
+                }
+                currentValueOf(LocalFocusManager).moveFocus(direction)
             }
-            currentValueOf(LocalFocusManager).moveFocus(direction)
         }
 
         lastTabKeyDown = null
@@ -146,13 +160,14 @@ private class FocusGroupPropertiesNode :
     override fun onAttach() {
         super.onAttach()
         htmlElement = getEmbeddedHtmlElement()
-        htmlElement?.addEventListener("focus", onFocusEvent)
-        htmlElement?.addEventListener("blur", onBlurEvent)
+        // capture=true to listen to focus/blur events on the children of the interop container
+        htmlElement?.addEventListener("focus", onFocusEvent, AddEventListenerOptions(capture = true))
+        htmlElement?.addEventListener("blur", onBlurEvent, AddEventListenerOptions(capture = true))
     }
 
     override fun onDetach() {
-        htmlElement?.removeEventListener("focus", onFocusEvent)
-        htmlElement?.removeEventListener("blur", onBlurEvent)
+        htmlElement?.removeEventListener("focus", onFocusEvent, AddEventListenerOptions(capture = true))
+        htmlElement?.removeEventListener("blur", onBlurEvent, AddEventListenerOptions(capture = true))
         super.onDetach()
     }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -16,38 +16,28 @@
 
 package androidx.compose.ui.viewinterop
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.FocusDirection.Companion.Exit
 import androidx.compose.ui.focus.FocusEnterExitScope
 import androidx.compose.ui.focus.FocusProperties
 import androidx.compose.ui.focus.FocusPropertiesModifierNode
-import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.FocusTargetNode
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.performRequestFocus
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.InputMode
-import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
-import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
-import androidx.compose.ui.node.ObserverModifierNode
-import androidx.compose.ui.node.requireLayoutNode
-import androidx.compose.ui.node.requireOwner
-import androidx.compose.ui.node.visitLocalDescendants
 import androidx.compose.ui.node.Nodes
 import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.requireLayoutNode
+import androidx.compose.ui.node.visitLocalDescendants
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.window.LocalComposeWindow
-import kotlin.js.js
-import kotlinx.browser.document
 import kotlinx.browser.window
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
-import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 
 /**
@@ -68,85 +58,28 @@ internal fun Modifier.focusInteropModifier(): Modifier = this
     .then(FocusTargetPropertiesElement)
     .then(FocusTargetInteropElement)
 
-private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetInteropNode>() {
-    override fun create() = FocusTargetInteropNode()
-
-    override fun update(node: FocusTargetInteropNode) {}
-
+private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetNode>() {
+    override fun create() = FocusTargetNode(isInteropViewHost = true, onFocusChange = { _, _, -> })
+    override fun update(node: FocusTargetNode) {}
     override fun hashCode() = "focusTargetInterop".hashCode()
-
     override fun equals(other: Any?) = other === this
-}
-
-/**
- * The node that becomes focused on the Compose side when the associated HTML element gains focus.
- */
-private class FocusTargetInteropNode :
-    DelegatingNode(), ObserverModifierNode, CompositionLocalConsumerModifierNode {
-
-    private val focusTargetNode =
-        delegate(FocusTargetNode(isInteropViewHost = true, onFocusChange = ::onFocusStateChange))
-
-    private fun onFocusStateChange(previousState: FocusState, currentState: FocusState) {
-        if (!isAttached) return
-        val isFocused = currentState.isFocused
-        val wasFocused = previousState.isFocused
-        // Ignore cases where we are initialized as unfocused, or moving between different
-        // unfocused states.
-        if (isFocused == wasFocused) return
-        // Pinning could be added here in the future if needed.
-    }
-
-    override fun onObservedReadsChanged() {}
 }
 
 private class FocusTargetPropertiesNode : Modifier.Node(), FocusPropertiesModifierNode {
     override fun applyFocusProperties(focusProperties: FocusProperties) {
-        val htmlElement = getEmbeddedHtmlElement()
-        focusProperties.canFocus = node.isAttached && true // htmlElement.isFocusable()
-//        htmlElement.getBoundingClientRect()?.let { rect ->
-//            focusProperties.focusRect = Rect(rect.left.toFloat(), rect.top.toFloat(),
-//                rect.right.toFloat(), rect.bottom.toFloat())
-//        }
+        focusProperties.canFocus = node.isAttached
     }
 }
-
-/**
- * Checks if an HTML element can receive focus.
- */
-//private fun HTMLElement.isFocusable(): Boolean = js("this.tabIndex >= 0 || this.tagName === 'BUTTON' || this.tagName === 'INPUT' || " +
-//        "this.tagName === 'SELECT' || this.tagName === 'TEXTAREA' || this.tagName === 'A'")
-
-/**
- * Gets the bounding client rect of an HTML element.
- */
-//private fun HTMLElement.getBoundingClientRect(): Rect? {
-//    // language=javascript
-//    return js("var rect = this.getBoundingClientRect(); " +
-//        "if (rect.width === 0 && rect.height === 0) return null; " +
-//        "return new androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.right, rect.bottom);")
-//}
 
 private class FocusGroupPropertiesNode :
     Modifier.Node(), FocusPropertiesModifierNode, CompositionLocalConsumerModifierNode {
 
-    var focusedChild: HTMLElement? = null
-
-    val onEnter: FocusEnterExitScope.() -> Unit = {
-        val htmlElement = getEmbeddedHtmlElement()
-        if (!htmlElement.isFocused()) {
-            htmlElement.focus()
-            // Try to focus the HTML element or its first focusable child.
-//            val target = (htmlElement.querySelector(":focusable") ?: htmlElement) as? HTMLElement
-//            target?.focus()
-        }
+    private val onEnter: FocusEnterExitScope.() -> Unit = {
+        getEmbeddedHtmlElement().focus()
     }
 
-    val onExit: FocusEnterExitScope.() -> Unit = {
-        val htmlElement = getEmbeddedHtmlElement()
-        if (htmlElement.isFocused()) {
-            htmlElement.blur()
-        }
+    private val onExit: FocusEnterExitScope.() -> Unit = {
+        getEmbeddedHtmlElement().blur()
     }
 
     override fun applyFocusProperties(focusProperties: FocusProperties) {
@@ -156,66 +89,71 @@ private class FocusGroupPropertiesNode :
     }
 
     private var lastTabKeyDown: KeyboardEvent? = null
+    private var htmlElement: HTMLElement? = null
 
-    override fun onAttach() {
-        println("FocusGroupNode.onAttach")
-        super.onAttach()
-        val htmlElement = getEmbeddedHtmlElement()
-        println("htmlElement: $htmlElement")
-        val tabKeyDownListener = { event: Event ->
-            println("Tab keydown!!! - $event")
-
-            lastTabKeyDown = (event as? KeyboardEvent)?.takeIf { it.key == "Tab" }
-
-
-            if (lastTabKeyDown != null) {
-                // This will ensure focus indication:
-                currentValueOf(LocalInputModeManager).requestInputMode(InputMode.Keyboard)
-                window.requestAnimationFrame {
-                    lastTabKeyDown = null
-                }
-            }
-
-            Unit
+    private val tabKeyDownListener = { event: Event ->
+        lastTabKeyDown = (event as? KeyboardEvent)?.takeIf {
+            it.keyCode == Key.Tab.keyCode.toInt()
         }
-        htmlElement.addEventListener("focus") {
-            println("focus::: HTML element gained focus")
-            htmlElement.addEventListener("keydown", tabKeyDownListener)
-            // HTML element (or a child) gained focus. Sync Compose focus to the interop wrapper.
-            val focusTargetNode = getFocusTargetOfEmbeddedViewWrapper()
-            if (!focusTargetNode.focusState.hasFocus) {
-                focusTargetNode.performRequestFocus()
-            }
-        }
-        htmlElement.addEventListener("blur") {
-            println("blur::: HTML element lost focus")
-            htmlElement.removeEventListener("keydown", tabKeyDownListener)
-            if (lastTabKeyDown != null) {
-                println("blur::: Tab - $lastTabKeyDown")
-                val localComposeWindow = currentValueOf(LocalComposeWindow)
-                localComposeWindow?.focusCanvas()
-                val focusManager = currentValueOf(LocalFocusManager)
-                val direction = if (lastTabKeyDown?.shiftKey == true) FocusDirection.Previous else FocusDirection.Next
-                focusManager.moveFocus(direction)
-                println("blur::: Tab - direction: $direction")
+
+        if (lastTabKeyDown != null) {
+            // This will ensure focus indication:
+            currentValueOf(LocalInputModeManager).requestInputMode(InputMode.Keyboard)
+
+            // Reset in case no downstream events occur.
+            window.requestAnimationFrame {
                 lastTabKeyDown = null
             }
         }
     }
 
+    private val onFocusEvent = { _: Event ->
+        // Listen to Tab / Tab+Shift key down events to track where the focus moves.
+        htmlElement?.addEventListener("keydown", tabKeyDownListener)
+
+        // HTML element (or a child) gained focus. Update Compose focus too.
+        val focusTargetNode = getFocusTargetOfEmbeddedViewWrapper()
+        if (!focusTargetNode.focusState.hasFocus) {
+            focusTargetNode.performRequestFocus()
+        }
+    }
+
+    private val onBlurEvent = { _: Event ->
+        htmlElement?.removeEventListener("keydown", tabKeyDownListener)
+
+        val composeWindow = currentValueOf(LocalComposeWindow)!!
+        val isFocusInComposeContainer = composeWindow.isFocusInComposeContainer()
+
+        // If the browser moved focus to a different element within the Compose-managed html-subtree,
+        // then focus canvas again so it can handle key events.
+        if (isFocusInComposeContainer) {
+            composeWindow.focusCanvas()
+        }
+
+        // Now let Compose move its own focus according to the earlier Tab keydown.
+        if (isFocusInComposeContainer && lastTabKeyDown != null) {
+            val direction = if (lastTabKeyDown?.shiftKey == true) {
+                FocusDirection.Previous
+            } else {
+                FocusDirection.Next
+            }
+            currentValueOf(LocalFocusManager).moveFocus(direction)
+        }
+
+        lastTabKeyDown = null
+    }
+
+    override fun onAttach() {
+        super.onAttach()
+        htmlElement = getEmbeddedHtmlElement()
+        htmlElement?.addEventListener("focus", onFocusEvent)
+        htmlElement?.addEventListener("blur", onBlurEvent)
+    }
+
     override fun onDetach() {
-        println("FocusGroupNode.onDetach")
-        val htmlElement = getEmbeddedHtmlElement()
-//        htmlElement.removeEventListener("focusin", ::onFocusIn)
-//        htmlElement.removeEventListener("focusout", ::onFocusOut)
-        focusedChild = null
+        htmlElement?.removeEventListener("focus", onFocusEvent)
+        htmlElement?.removeEventListener("blur", onBlurEvent)
         super.onDetach()
-    }
-
-    private val onFocusIn: (Event) -> Unit = { event ->
-    }
-
-    private val onFocusOut: (Event) -> Unit = { event ->
     }
 
     private fun getFocusTargetOfEmbeddedViewWrapper(): FocusTargetNode {
@@ -230,21 +168,15 @@ private class FocusGroupPropertiesNode :
 
 private object FocusGroupPropertiesElement : ModifierNodeElement<FocusGroupPropertiesNode>() {
     override fun create(): FocusGroupPropertiesNode = FocusGroupPropertiesNode()
-
     override fun update(node: FocusGroupPropertiesNode) {}
-
     override fun hashCode() = "FocusGroupProperties".hashCode()
-
     override fun equals(other: Any?) = other === this
 }
 
 private object FocusTargetPropertiesElement : ModifierNodeElement<FocusTargetPropertiesNode>() {
     override fun create(): FocusTargetPropertiesNode = FocusTargetPropertiesNode()
-
     override fun update(node: FocusTargetPropertiesNode) {}
-
     override fun hashCode() = "FocusTargetProperties".hashCode()
-
     override fun equals(other: Any?) = other === this
 }
 
@@ -253,14 +185,3 @@ private fun Modifier.Node.getEmbeddedHtmlElement(): HTMLElement {
         "Could not fetch interop view"
     } as HTMLElement
 }
-
-private fun HTMLElement.isFocused(): Boolean {
-    val root = getRootNode()
-    return false
-}
-
-private external interface DocumentOrShadowRootLike {
-    val activeElement: HTMLElement?
-}
-
-private fun getRootNode(): DocumentOrShadowRootLike = js("this.getRootNode()")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -77,11 +77,11 @@ private class FocusGroupPropertiesNode :
     Modifier.Node(), FocusPropertiesModifierNode, CompositionLocalConsumerModifierNode {
 
     private val onEnter: FocusEnterExitScope.() -> Unit = {
-        getEmbeddedHtmlElement().focus()
+        htmlElement?.focus()
     }
 
     private val onExit: FocusEnterExitScope.() -> Unit = {
-        getEmbeddedHtmlElement().blur()
+        htmlElement?.blur()
     }
 
     override fun applyFocusProperties(focusProperties: FocusProperties) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -70,8 +70,9 @@ private object FocusTargetInteropElement : ModifierNodeElement<FocusTargetNode>(
 
 private class FocusTargetPropertiesNode : Modifier.Node(), FocusPropertiesModifierNode {
     override fun applyFocusProperties(focusProperties: FocusProperties) {
-        val hasFocusable = getFirstFocusable(getEmbeddedHtmlContainer()) != null
-        focusProperties.canFocus = node.isAttached && hasFocusable
+        focusProperties.canFocus = node.isAttached
+            // find at least one focusable element inside the interop container
+            && getFirstFocusable(getEmbeddedHtmlContainer()) != null
     }
 }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.web.kt
@@ -230,20 +230,29 @@ internal fun getFocusableHtmlElement(container: HTMLElement, last: Boolean = fal
 (() => {
     if (!container) return null;
 
+    let skipClosestInertCheck = false; // its value is updated depending on the traversal direction
+
     const selector = ':is(button, select, textarea, input:not([type="hidden"])):not([disabled]), [href], [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, :is(audio, video)[controls]';
     const filter = {
         acceptNode(node) {
-            return (node.matches(selector) && !node.closest('[inert]'))
-                ? NodeFilter.FILTER_ACCEPT
-                : NodeFilter.FILTER_SKIP;
+            if (node.inert) return NodeFilter.FILTER_REJECT; // completely skip an inert subtree
+            if (node.matches(selector) && (skipClosestInertCheck || !node.closest('[inert]'))) return NodeFilter.FILTER_ACCEPT;
+            return NodeFilter.FILTER_SKIP;
         }
     };
 
     if (!last) {
-        // Forward traversal — TreeWalker naturally visits in document order
+        // Forward traversal:
+        // with forward traversal, we check the nested containers for inert,
+        // checking for closest(inert) is redundant.
+        skipClosestInertCheck = true;
         const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, filter);
         return walker.nextNode();
     }
+    
+    const hasAnyInert = container.querySelector('[inert]') !== null;
+    // Avoid redundant closest(inert) check when no inert nested elements are present
+    skipClosestInertCheck = !hasAnyInert;
 
     // Reverse traversal — jump to the deepest last leaf, then walk backward
     let lastLeaf = container;

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
@@ -124,7 +124,7 @@ internal fun <T : HTMLElement> InternalHtmlElementView(
                 compositeKeyHash
             )
         },
-        modifier,
+        modifier.focusInteropModifier(),
         onReset,
         onRelease,
         update = {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.web.kt
@@ -53,6 +53,7 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
             (document.createElement("div") as HTMLDivElement)
                 .apply {
                     style.position = "absolute"
+                    tabIndex = -1
                     // hide it until it's properly positioned,
                     // otherwise it can briefly flash at 0,0
                     toggleVisibility(this, isHidden = true)

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.web.kt
@@ -53,7 +53,6 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
             (document.createElement("div") as HTMLDivElement)
                 .apply {
                     style.position = "absolute"
-                    tabIndex = -1
                     // hide it until it's properly positioned,
                     // otherwise it can briefly flash at 0,0
                     toggleVisibility(this, isHidden = true)

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -199,12 +199,13 @@ fun ComposeViewport(
     }
     positioningContainer.appendChild(interopContainerElement)
 
-    // To keep DOM focus in the canvas:
+    // To keep DOM focus on the canvas after Tabbing out of the interop container:
     positioningContainer.appendChild(createHtmlFocusDecoy(canvas))
 
     val composeWindow = ComposeWindow(
         canvas = canvas,
         rootNode = shadowRoot,
+        viewportContainer = viewportContainer,
         layerRoot = appContainer,
         interopContainerElement = interopContainerElement,
         a11yContainerElement = a11yContainerElement,

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -244,13 +244,13 @@ private fun isWebGL2Supported(): Boolean =
 private fun createHtmlFocusDecoy(canvas: HTMLCanvasElement): HTMLDivElement =
     (document.createElement("div") as HTMLDivElement).apply {
         tabIndex = 0
+        setAttribute("aria-hidden", "true") // Usually it's an antipattern for a focusable element, but it's okay for a decoy element.
         style.apply {
-            position = "absolute"
-            top = "-9999px"
-            left = "-9999px"
-            width = "1px"
-            height = "1px"
-            clip = "rect(0 0 0 0)"
+            position = "absolute" // to remove the decoy completely out of the document layout tree
+            width = "0"
+            height = "0"
+            outline = "none"
+            setProperty("pointer-events", "none")
         }
         addEventListener("focus") {
             canvas.focus()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -27,6 +27,7 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.OPEN
 import org.w3c.dom.ShadowRootInit
 import org.w3c.dom.ShadowRootMode
+
 /**
  * EXPERIMENTAL! Might be deleted or changed in the future!
  *
@@ -172,8 +173,6 @@ fun ComposeViewport(
     canvas.style.setProperty("touch-action", "pan-x pan-y") // allow the browser to scroll when compose is not scrolling
     appContainer.appendChild(canvas)
 
-
-
     //a11y container
     val configuration = ComposeViewportConfiguration().apply(configure)
     val a11yContainerElement = if (configuration.isA11YEnabled) {
@@ -199,6 +198,9 @@ fun ComposeViewport(
         left = "0"
     }
     positioningContainer.appendChild(interopContainerElement)
+
+    // To keep DOM focus in the canvas:
+    positioningContainer.appendChild(createHtmlFocusDecoy(canvas))
 
     val composeWindow = ComposeWindow(
         canvas = canvas,
@@ -229,3 +231,27 @@ private const val WEBGL2_NOT_SUPPORTED_MSG = "This application requires WebGL2. 
     "Please ensure your browser is updated and hardware acceleration is enabled in the browser settings."
 private fun isWebGL2Supported(): Boolean =
     js("!!document.createElement('canvas').getContext('webgl2')")
+
+/**
+ * Creates a hidden focusable decoy element to be placed after the interop container in DOM order.
+ *
+ * When Tab is pressed on the last HTML interop element, the browser would normally
+ * move focus to the address bar since no further focusable elements exist.
+ * This decoy intercepts that focus and immediately redirects it to the canvas,
+ * allowing Compose's focus manager to continue navigation to the next Compose element.
+ */
+private fun createHtmlFocusDecoy(canvas: HTMLCanvasElement): HTMLDivElement =
+    (document.createElement("div") as HTMLDivElement).apply {
+        tabIndex = 0
+        style.apply {
+            position = "absolute"
+            top = "-9999px"
+            left = "-9999px"
+            width = "1px"
+            height = "1px"
+            clip = "rect(0 0 0 0)"
+        }
+        addEventListener("focus") {
+            canvas.focus()
+        }
+    }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -202,6 +202,7 @@ internal class ComposeWindow(
     private val canvas: HTMLCanvasElement,
     private val rootNode: Node,
     private val layerRoot: HTMLElement,
+    private val viewportContainer: Element,
     private val interopContainerElement: HTMLDivElement,
     private val a11yContainerElement: HTMLDivElement?,
     private val configuration: ComposeViewportConfiguration,
@@ -938,6 +939,11 @@ internal class ComposeWindow(
         canvas.focus()
     }
 
+    internal fun isFocusInComposeContainer(): Boolean {
+        return document.activeElement != null && viewportContainer.contains(document.activeElement)
+            || rootNode.activeElement != null
+    }
+
     companion object {
         private val DomDisposableRegistry = WeakMap<JsAny>()
 
@@ -1113,7 +1119,7 @@ private fun Element.isFocused(): Boolean {
     return activeElement == this
 }
 
-private external interface ShadowRootExt {
+internal external interface ShadowRootExt {
     val activeElement: Element?
 }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -934,6 +934,10 @@ internal class ComposeWindow(
             y = offsetY.toFloat() * density.density
         )
 
+    internal fun focusCanvas() {
+        canvas.focus()
+    }
+
     companion object {
         private val DomDisposableRegistry = WeakMap<JsAny>()
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -1119,7 +1119,7 @@ private fun Element.isFocused(): Boolean {
     return activeElement == this
 }
 
-internal external interface ShadowRootExt {
+private external interface ShadowRootExt {
     val activeElement: Element?
 }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -941,7 +941,7 @@ internal class ComposeWindow(
 
     internal fun isFocusInComposeContainer(): Boolean {
         return document.activeElement != null && viewportContainer.contains(document.activeElement)
-            || rootNode.activeElement != null
+            || (rootNode as ShadowRootExt).activeElement != null
     }
 
     companion object {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/GetFocusableHtmlElementTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/GetFocusableHtmlElementTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.viewinterop
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
+
+class GetFocusableHtmlElementTest {
+
+    @BeforeTest
+    fun setup() {
+        document.body!!.innerHTML = ""
+    }
+
+    private fun createContainer(html: String): HTMLElement {
+        val div = document.createElement("div") as HTMLElement
+        div.innerHTML = html
+        document.body!!.appendChild(div)
+        return div
+    }
+
+    @Test
+    fun noFocusableElements() {
+        val container = createContainer("<div><span>text</span><div>more</div></div>")
+        assertNull(getFocusableHtmlElement(container), "expected no first focusable")
+        assertNull(getFocusableHtmlElement(container, last = true), "expected no last focusable")
+    }
+
+    @Test
+    fun singleFocusableElement() {
+        val container = createContainer("<div><button id='btn'>Click</button></div>")
+        val first = getFocusableHtmlElement(container)
+        val last = getFocusableHtmlElement(container, last = true)
+
+        assertEquals(first, last, "first and last should be the same element")
+        assertEquals("btn", first?.id)
+    }
+
+    @Test
+    fun flatListOfFocusableElements() {
+        val container = createContainer("""
+            <div>
+                <button id='a'>A</button>
+                <button id='b'>B</button>
+                <button id='c'>C</button>
+            </div>
+        """.trimIndent())
+        assertEquals("a", getFocusableHtmlElement(container)?.id, "button 'a' is the first focusable")
+        assertEquals("c", getFocusableHtmlElement(container, last = true)?.id, "button 'c' is the last focusable")
+    }
+
+    @Test
+    fun lastFocusableDiffersFromLastLeaf() {
+        val container = createContainer("""
+            <div>
+                <button id='first'>First</button>
+                <button id='middle'>Middle</button>
+                <div><div><span>non-focusable leaf</span></div></div>
+            </div>
+        """.trimIndent())
+        assertEquals("first", getFocusableHtmlElement(container)?.id)
+        // the last leaf is the <span>, but the last focusable is <button id='middle'>
+        assertEquals("middle", getFocusableHtmlElement(container, last = true)?.id)
+    }
+
+    @Test
+    fun selectorRespectsFocusabilityRules() {
+        val container = createContainer("""
+            <div>
+                <button id='disabled' disabled>Disabled</button>
+                <input type="hidden" id="hidden" />
+                <span tabindex="-1" id="negative">Negative tabindex</span>
+                <div inert><button id='inert'>Inert</button></div>
+                <a href="#" id="link">Link</a>
+                <button id="btn">Button</button>
+                <input type="hidden" id="inputHiddenLast" />
+            </div>
+        """.trimIndent())
+        // The first focusable is the link
+        assertEquals("link", getFocusableHtmlElement(container)?.id, "first focusable")
+        // The last focusable is the button
+        assertEquals("btn", getFocusableHtmlElement(container, last = true)?.id, "last focusable")
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/GetFocusableHtmlElementTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/GetFocusableHtmlElementTest.kt
@@ -99,4 +99,20 @@ class GetFocusableHtmlElementTest {
         // The last focusable is the button
         assertEquals("btn", getFocusableHtmlElement(container, last = true)?.id, "last focusable")
     }
+
+    @Test
+    fun rejectsInertContainers() {
+        val container = createContainer("""
+            <div>
+                <div inert><button id='a'>A</button></div>
+                <button id='b'>B</button>
+                <button id='c'>C</button>
+                <div inert><button id='d'>D</button></div>
+            </div>
+        """.trimIndent())
+        // button 'a' is inside an inert container and should be rejected
+        assertEquals("b", getFocusableHtmlElement(container)?.id, "button 'b' is the first focusable")
+        // button 'd' is inside an inert container and should be rejected
+        assertEquals("c", getFocusableHtmlElement(container, last = true)?.id, "button 'c' is the last focusable")
+    }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -42,6 +42,7 @@ class ComposeWindowLifecycleTest : OnCanvasTests {
         val composeWindow = ComposeWindow(
             canvas = canvas,
             rootNode = getShadowRoot(),
+            viewportContainer = document.body!!,
             layerRoot = document.createElement("div") as HTMLElement,
             interopContainerElement = document.createElement("div") as HTMLDivElement,
             a11yContainerElement = null,


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10554/Tab-doesnt-move-focus-to-HTML-interop-views

Introduce an internal `Modifier.focusInteropModifier()` responsible for Focus synchronization between Compose and HTML interop elements. 

**Supported cases:**
- Navigating using Tab/Tab+Shift throug a sequence of Compose and Html interop elements
- Compose focus update after clicking an Html interop element

**Implementation details:**
- Added focus and blur listeners on the html interop container - so Compose can register when focus comes/leaves the interop element or its children
- Added a keydown listener on the html interop container to listen to Tab/Tab+Shift to register the direction of the upcoming focus change

**Known issues:**
Safari: https://bugs.webkit.org/show_bug.cgi?id=22261
> Mac users expect the focus to remain in the text field if you click on a button. That’s what happens everywhere else on their computer in all the Mac applications.

That's why clickin on an say html button in the interop element won't trigger a `focus` event. 

**Demo after the fix:**

https://github.com/user-attachments/assets/6b873a21-ff9f-485d-a697-0d45435478e3




## Testing
- This should be tested by QA
- Our unit tests can't reliably verify this, because the html elements will ignore "untrusted" focus/keydown events which we usually create in our tests (we'll consider a Selenium test for this)

## Release Notes
### Fixes - Web
- Fix Tab focus order with interop elements

