### PR TITLE
Add GitHub check for running project sync

### DIFF
--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -2,9 +2,21 @@ name: IDEA Sync
 on:
   workflow_dispatch:
   pull_request:
+    paths: &gradle-paths
+      - '**/*.gradle'
+      - '**/*.gradle.kts'
+      - '**/*.toml'
+      - '**/gradle.properties'
+      - 'gradle/**'
+      - 'buildSrc/**'
+      - 'buildSrc-fork/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '.github/workflows/check-project-sync.yml'
   push:
     branches:
       - jb-main
+    paths: *gradle-paths
 
 jobs:
   sync-project:

--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -13,14 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-26-xlarge, windows-latest ]
-        include:
-          - os: ubuntu-24.04
-            name: Linux
-          - os: macos-26-xlarge
-            name: macOS
-          - os: windows-latest
-            name: Windows
-    name: ${{ matrix.name }}
+    name: ${{ matrix.os }}
     steps:
       - name: Enable Long Paths
         if: runner.os == 'Windows'

--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -12,8 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, macos-26-xlarge, windows-latest ]
-    name: ${{ matrix.os }}
+        include:
+          - os: ubuntu-24.04
+            name: Linux
+          - os: macos-26-xlarge
+            name: macOS
+          - os: windows-latest
+            name: Windows
+    name: ${{ matrix.name }}
     steps:
       - name: Enable Long Paths
         if: runner.os == 'Windows'

--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -13,7 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-26-xlarge, windows-latest ]
-    name: ${{ matrix.os }}
+        include:
+          - os: ubuntu-24.04
+            name: Linux
+          - os: macos-26-xlarge
+            name: macOS
+          - os: windows-latest
+            name: Windows
+    name: ${{ matrix.name }}
     steps:
       - name: Enable Long Paths
         if: runner.os == 'Windows'

--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -1,0 +1,35 @@
+name: IDEA Sync
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - jb-main
+
+jobs:
+  sync-project:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-24.04, macos-26-xlarge, windows-latest ]
+    name: ${{ matrix.os }}
+    steps:
+      - name: Enable Long Paths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup Prerequisites
+        uses: ./.github/actions/setup-prerequisites
+
+      - name: Setup Xcode
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/setup-xcode
+
+      - name: Sync Project
+        shell: bash
+        run: |
+          ./gradlew prepareKotlinIdeaImport --no-daemon --stacktrace


### PR DESCRIPTION
Runs `prepareKotlinIdeaImport` on Linux, macOS, and Windows to catch sync errors.

A precedent of breaking Linux/Windows: [JetBrains/compose-multiplatform-core#3233](https://github.com/JetBrains/compose-multiplatform-core/pull/3233)

## Release Notes
N/A