### PR TITLE
Add integration branch to GitHub workflow triggers

### DIFF
--- a/.github/workflows/check-project-sync.yml
+++ b/.github/workflows/check-project-sync.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - jb-main
+      - integration
     paths: *gradle-paths
 
 jobs:

--- a/.github/workflows/check-public-api.yml
+++ b/.github/workflows/check-public-api.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - jb-main
+      - integration
 
 jobs:
   check-public-api:

--- a/.github/workflows/compose-publish-dry-run.yml
+++ b/.github/workflows/compose-publish-dry-run.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - jb-main
+      - integration
 
 jobs:
   compose-native-publish:

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - jb-main
+      - integration
 
 env:
   # TODO: https://youtrack.jetbrains.com/issue/CMP-9497/Investgate-CfW-tests-flakiness-with-enabled-gradle-configuration-cache-on-CI


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10569/Setup-GitHub-action-in-integration-branch

Run GitHub Actions workflows on pushes to the integration branch.

## Testing
1. go to integration branch
2. cherry pick:
  - https://github.com/JetBrains/compose-multiplatform-core/pull/3263
  - https://github.com/JetBrains/compose-multiplatform-core/pull/3264
  - https://github.com/JetBrains/compose-multiplatform-core/pull/3256
3. update API dump
4. run GitHub actions

## Release Notes
N/A