### PR TITLE
Fixed "Testing Started" at the end of iOS instrumented tests

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -165,6 +165,9 @@ jobs:
         timeout-minutes: 30
         shell: bash
         working-directory: compose/ui/ui/src/uikitInstrumentedTest/launcher
+        env:
+          # Keep xcodebuild's stdout unbuffered so its log lines stay in order.
+          NSUnbufferedIO: "YES"
         run: |
           xcodebuild test \
             -resultBundlePath TestResults.xcresult \


### PR DESCRIPTION
Set `NSUnbufferedIO` environment variable to ensure ordered xcodebuild logs in iOS tests

## Release Notes
N/A

