### PR TITLE
navigation-testing - redirect to published artifacts

### DIFF
--- a/buildSrc-fork/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
+++ b/buildSrc-fork/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
@@ -55,7 +55,7 @@ fun Project.configureMavenArtifactUpload(
     androidXKmpExtension: AndroidXMultiplatformExtension,
     afterConfigure: () -> Unit,
 ) {
-    if (isJetBrainsFork(project) && JetBrainsPublication.shouldPublish(this)) return
+    if (isJetBrainsFork(project)) return
     apply(mapOf("plugin" to "maven-publish"))
     var registered = false
     fun registerOnFirstPublishableArtifact(component: SoftwareComponent) {

--- a/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsMavenCoordinatesChanger.kt
+++ b/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsMavenCoordinatesChanger.kt
@@ -20,12 +20,11 @@ import androidx.build.Version
 import org.gradle.api.Project
 
 fun Project.changeMavenCoordinatesToJetBrains() {
-    // we are interested in changing coordinates only for what we publish
-    val component = JetBrainsPublication.projectPathToComponent[path] ?: return
+    val component = JetBrainsPublication.projectPathToComponent[path]
     val versions = JetBrainsVersionsService.versions(project)
 
     val group = JetBrainsPublication.mavenGroupFor(path)
-    val version = Version(versions.versionOf(component.library()))
+    val version = Version(versions.versionOf(component?.library()))
     this.group = group
     this.version = version
 

--- a/buildSrc-fork/public/src/main/kotlin/androidx/build/AndroidXExtension.kt
+++ b/buildSrc-fork/public/src/main/kotlin/androidx/build/AndroidXExtension.kt
@@ -54,10 +54,7 @@ abstract class AndroidXExtension(
     val deviceTests = DeviceTests.register(project.extensions)
 
     init {
-        // Always set a known default based on project path. see: b/302183954
-        setDefaultGroupFromProjectPath()
         mavenGroup = chooseLibraryGroup()
-        chooseProjectVersion()
     }
 
     @get:Inject abstract val buildFeatures: BuildFeatures

--- a/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
+++ b/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
@@ -202,8 +202,8 @@ class JetBrainsVersions(val libraryToVersion: Map<String, String>) : Serializabl
         }
     }
 
-    fun versionOf(libraryName: String): String {
-        return libraryToVersion[libraryName] ?: "9999.0.0-SNAPSHOT"
+    fun versionOf(libraryName: String?): String {
+        return libraryName?.let(libraryToVersion::get) ?: "9999.0.0-SNAPSHOT"
     }
 }
 

--- a/navigation/navigation-testing/build-fork.gradle
+++ b/navigation/navigation-testing/build-fork.gradle
@@ -23,96 +23,28 @@
 
 import androidx.build.PlatformIdentifier
 import androidx.build.SoftwareType
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
     id("AndroidXPlugin")
     id("JetBrainsAndroidXPlugin")
-    alias(libs.plugins.kotlinSerialization)
 }
 
 androidXMultiplatform {
-    androidLibrary {
-        namespace = "androidx.navigation.testing"
-        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
+    redirect("androidx.navigation") {
+        androidLibrary {
+            namespace = "org.jetbrains.androidx.navigation.testing"
+        }
+        desktop()
+        linux()
+        mac()
+        watchos()
+        tvos()
+        ios()
+        js()
+        wasmJs()
     }
-    desktop()
-    linux()
-    mac()
-    watchos()
-    tvos()
-    ios()
-    js()
-    wasmJs()
 
     defaultPlatform(PlatformIdentifier.ANDROID)
-
-    sourceSets {
-        configureEach {
-            languageSettings.optIn("kotlin.contracts.ExperimentalContracts")
-        }
-
-        commonMain.dependencies {
-            api(project(":navigation:navigation-runtime"))
-            api("androidx.lifecycle:lifecycle-runtime-testing:2.10.0")
-
-            implementation(libs.kotlinCoroutinesCore)
-            implementation(libs.kotlinSerializationCore)
-            implementation(project(":navigation:navigation-common"))
-            implementation("androidx.lifecycle:lifecycle-common:2.10.0")
-            implementation("androidx.lifecycle:lifecycle-viewmodel:2.10.0")
-            implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.10.0")
-        }
-
-        commonTest.dependencies {
-            implementation(libs.kotlinTest)
-            implementation(libs.kotlinCoroutinesTest)
-            implementation(project(":kruth:kruth"))
-        }
-
-        jvmAndAndroidTest.dependencies {
-            runtimeOnly(libs.kotlinTestJunit)
-            implementation(libs.junit)
-        }
-
-        androidMain.dependencies {
-            api("androidx.lifecycle:lifecycle-runtime:2.10.0")
-            api("androidx.lifecycle:lifecycle-viewmodel:2.10.0")
-            api("androidx.savedstate:savedstate-ktx:1.4.0")
-            implementation("androidx.core:core-ktx:1.1.0")
-            implementation("androidx.profileinstaller:profileinstaller:1.4.0")
-        }
-
-        androidHostTest.dependencies {
-            runtimeOnly(libs.testCore)
-            runtimeOnly(libs.kotlinTestJunit)
-            implementation(libs.junit)
-            implementation(libs.testRunner)
-        }
-
-        androidDeviceTest.dependencies {
-            implementation(project(":internal-testutils-navigation"))
-            implementation("androidx.lifecycle:lifecycle-runtime:2.6.2")
-            implementation(libs.testExtJunit)
-            implementation(libs.testExtTruth)
-            implementation(libs.testRules)
-
-            runtimeOnly(libs.testCore)
-            runtimeOnly(libs.kotlinTestJunit)
-            implementation(libs.junit)
-            implementation(libs.testRunner)
-        }
-
-        create("nonAndroidMain").dependsOn(commonMain)
-        desktopMain.dependsOn(nonAndroidMain)
-        nativeMain.dependsOn(nonAndroidMain)
-        webMain.dependsOn(nonAndroidMain)
-
-        create("nonAndroidTest").dependsOn(commonTest)
-        desktopTest.dependsOn(nonAndroidTest)
-        nativeTest.dependsOn(nonAndroidTest)
-        webTest.dependsOn(nonAndroidTest)
-    }
 }
 
 androidx {


### PR DESCRIPTION
Part of https://youtrack.jetbrains.com/issue/CMP-10569/Setup-GitHub-action-in-integration-branch

Requirement for https://github.com/JetBrains/compose-multiplatform-core/pull/3256

Reason:
- `navigation-testing` doesn't redirect currently to anything
- it depends on `navigation-runtime`, which redirects all the targets
- there was an incompatible change between `navigation-runtime` and `navigation-testing` (remove/add methods in interface)
- this change leaded to compilation error, because `navigation-testing` uses the new interface, but it depends on an interface from the old redirected `navigation-runtime`
- it works in AOSP because they built both modules from sources and they don't have to preserve compatibility because it is one group

## Release Notes
N/A