### PR TITLE
Fix SelectionContainer crashing when starting a selection beyond the last selectable [isMouseSelectionBetweenTextEnabled=true]

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionLayout.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionLayout.kt
@@ -510,7 +510,7 @@ internal class SelectionLayoutBuilder(
      * @return the [SelectionLayout] or null if no [SelectableInfo]s were added.
      */
     fun build(): SelectionLayout? {
-        val lastSlot = currentSlot + 1
+        val lastSlot = currentSlot
         return when (infoList.size) {
             0 -> {
                 null

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
@@ -19,28 +19,35 @@ package androidx.compose.foundation.text.selection
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.animateMoveTo
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.dragAndDrop
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -184,6 +191,105 @@ class SelectionContainerTest {
             assertEquals(7, it.end.offset)
         }
     }
+
+    @Composable
+    private fun SelectionContainerWithGaps(selectionState: SelectionState) {
+        SelectionContainer(selectionState) {
+            Column(Modifier.testTag("column")) {
+                Spacer(Modifier.size(20.dp).testTag("gap_before"))
+                BasicText("Text1", Modifier.testTag("text1"))
+                Spacer(Modifier.size(20.dp).testTag("gap_between"))
+                BasicText("Text2", Modifier.testTag("text2"))
+                Spacer(Modifier.size(20.dp).testTag("gap_after"))
+            }
+        }
+    }
+
+    @Test
+    fun selectWithMouseFromGapBefore() = androidx.compose.ui.test.v2.runComposeUiTest {
+        val selectionState = SelectionState()
+        setContent {
+            SelectionContainerWithGaps(selectionState)
+        }
+
+        val column = onNodeWithTag("column")
+        val gapBefore = onNodeWithTag("gap_before").fetchSemanticsNode()
+        val gapBetween = onNodeWithTag("gap_between").fetchSemanticsNode()
+        val gapAfter = onNodeWithTag("gap_after").fetchSemanticsNode()
+
+        column.performMouseInput {
+            updatePointerTo(gapBefore.boundsInRoot.center)
+            press()
+            moveTo(gapBetween.boundsInRoot.center)
+        }
+        assertEquals("Text1", selectionState.selectedText)
+        assertFalse(selectionState.selection!!.handlesCrossed)
+
+        column.performMouseInput {
+            moveTo(gapAfter.boundsInRoot.center)
+        }
+        assertEquals("Text1Text2", selectionState.selectedText)
+        assertFalse(selectionState.selection!!.handlesCrossed)
+    }
+
+    @Test
+    fun selectWithMouseFromGapBetween() = androidx.compose.ui.test.v2.runComposeUiTest {
+        val selectionState = SelectionState()
+        setContent {
+            SelectionContainerWithGaps(selectionState)
+        }
+
+        val column = onNodeWithTag("column")
+        val gapBefore = onNodeWithTag("gap_before").fetchSemanticsNode()
+        val gapBetween = onNodeWithTag("gap_between").fetchSemanticsNode()
+        val gapAfter = onNodeWithTag("gap_after").fetchSemanticsNode()
+
+        column.performMouseInput {
+            updatePointerTo(gapBetween.boundsInRoot.center)
+            press()
+            moveTo(gapBefore.boundsInRoot.center)
+        }
+        assertEquals("Text1", selectionState.selectedText)
+        assertTrue(selectionState.selection!!.handlesCrossed)
+
+        column.performMouseInput {
+            moveTo(gapAfter.boundsInRoot.center)
+        }
+
+        assertEquals("Text2", selectionState.selectedText)
+        assertFalse(selectionState.selection!!.handlesCrossed)
+    }
+
+    @Test
+    fun selectWithMouseFromGapAfter() = androidx.compose.ui.test.v2.runComposeUiTest {
+        val selectionState = SelectionState()
+        setContent {
+            SelectionContainerWithGaps(selectionState)
+        }
+
+        val column = onNodeWithTag("column")
+        val gapBefore = onNodeWithTag("gap_before").fetchSemanticsNode()
+        val gapBetween = onNodeWithTag("gap_between").fetchSemanticsNode()
+        val gapAfter = onNodeWithTag("gap_after").fetchSemanticsNode()
+
+        column.performMouseInput {
+            updatePointerTo(gapAfter.boundsInRoot.center)
+            press()
+            moveTo(gapBetween.boundsInRoot.center)
+        }
+        assertEquals("Text2", selectionState.selectedText)
+        assertTrue(selectionState.selection!!.handlesCrossed)
+
+        column.performMouseInput {
+            moveTo(gapBefore.boundsInRoot.center)
+        }
+
+        assertEquals("Text1Text2", selectionState.selectedText)
+        assertTrue(selectionState.selection!!.handlesCrossed)
+    }
 }
 
 private fun Selection?.exists() = (this != null) && !this.toTextRange().collapsed
+
+private val SelectionState.selectedText
+    get() = selectedTexts.joinToString(separator = "")


### PR DESCRIPTION
Fix `SelectionContainer` crashing when trying to start selection from beyond the last selectable with `isMouseSelectionBetweenTextEnabled = true`.

I will also submit this upstream, but I want to get a fix into `jb-main` (and 1.12 branch) ASAP.

Fixes https://youtrack.jetbrains.com/issue/CMP-10573

## Testing
Tested manually and with a unit test.

```
const val LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

@OptIn(ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication(
    state = WindowState(size = DpSize(600.dp, 400.dp))
) {
    SelectionContainer(Modifier.background(Color.LightGray)) {
        Column(
            Modifier.fillMaxSize().padding(32.dp).verticalScroll(rememberScrollState()),
            verticalArrangement = Arrangement.spacedBy(24.dp)
        ) {
            repeat(2) { row ->
                Text(LoremIpsum)
            }
        }
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix crash when starting a selection beyond the last text in a `SelectionContainer`.
