### PR TITLE
Remove global snapshot workaround for focused-rect offset

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
@@ -231,11 +231,15 @@ private class OffsetToFocusedRectNode(
         animationJob?.cancel()
         startOffset = currentOffset
 
-        if (!animationDuration.isPositive() || startOffset == targetOffset()) {
+        if (!animationDuration.isPositive()) {
             offsetProgress = 1f
-            if (animationDuration.isPositive()) {
-                animationCompletion()
-            }
+            invalidateMeasurement()
+            return
+        }
+
+        if (startOffset == targetOffset()) {
+            offsetProgress = 1f
+            animationCompletion()
             invalidateMeasurement()
             return
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
@@ -17,18 +17,17 @@
 package androidx.compose.ui.layout
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateMeasurement
 import androidx.compose.ui.platform.PlatformInsets
-import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toOffset
@@ -40,6 +39,8 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.time.Duration
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun OffsetToFocusedRect(
@@ -49,74 +50,31 @@ internal fun OffsetToFocusedRect(
     animationDuration: Duration,
     animationCompletion: () -> Unit,
     content: @Composable () -> Unit,
-) {
-    var currentOffset by remember { mutableStateOf(IntOffset.Zero) }
-    var startOffset by remember { mutableStateOf(IntOffset.Zero) }
-    var offsetProgress by remember { mutableStateOf(1f) }
-    val density = LocalDensity.current
-
-    fun translatedFocusedRect(): Rect? {
-        // The current implementation of OffsetToFocusedRect assumes that the focus rectangle is
-        // either static or only changes during the animation.
-        // The [Snapshot.withoutReadObservation] function is used here to avoid side effects caused
-        // by the internal implementation of the [getFocusedRect] function.
-        val rect = Snapshot.withoutReadObservation { getFocusedRect() }
-        return rect?.translate(-currentOffset.toOffset())
-    }
-
-    LaunchedEffect(insets, animationDuration) {
-        startOffset = currentOffset
-        if (animationDuration.isPositive()) {
-            if (startOffset == density.adjustedToFocusedRectOffset(
-                    insets = insets,
-                    focusedRect = translatedFocusedRect(),
-                    size = size
-                )
-            ) {
-                offsetProgress = 1f
-            } else {
-                withAnimationProgress(animationDuration) {
-                    offsetProgress = it
-                }
-            }
-            animationCompletion()
-        } else {
-            offsetProgress = 1f
-        }
-    }
-
-    Layout(
-        content = content,
-        measurePolicy = { measurables, constraints ->
-            val endOffset = density.adjustedToFocusedRectOffset(
-                insets = insets,
-                focusedRect = translatedFocusedRect(),
-                size = size
-            )
-
-            // Intentionally update state within composition to trigger second measure and
-            // layout because focus rect may be miscalculated due to simultaneous offset and
-            // window insets changes.
-            //
-            // FIXME: this "second measure" only settles in-frame because BaseComposeScene.draw()
-            //  currently calls Snapshot.sendApplyNotifications() between the measure and draw phases -
-            //  a temporary, un-Android workaround kept solely for this code path.
-            currentOffset = startOffset + (endOffset - startOffset) * offsetProgress
-
-            val placeables = measurables.fastMap { it.measure(constraints) }
-            layout(
-                placeables.fastMaxOfOrDefault(constraints.minWidth) { it.width },
-                placeables.fastMaxOfOrDefault(constraints.minHeight) { it.height }
-            ) {
-                placeables.fastForEach {
-                    it.place(currentOffset)
-                }
+) = Layout(
+    modifier = Modifier.then(
+        OffsetToFocusedRectElement(
+            insets = insets,
+            getFocusedRect = getFocusedRect,
+            size = size,
+            animationDuration = animationDuration,
+            animationCompletion = animationCompletion,
+        )
+    ),
+    content = content,
+    measurePolicy = { measurables, constraints ->
+        val placeables = measurables.fastMap { it.measure(constraints) }
+        layout(
+            placeables.fastMaxOfOrDefault(constraints.minWidth) { it.width },
+            placeables.fastMaxOfOrDefault(constraints.minHeight) { it.height }
+        ) {
+            placeables.fastForEach {
+                it.place(IntOffset.Zero)
             }
         }
-    )
-}
+    }
+)
 
-internal fun Density.adjustedToFocusedRectOffset(
+internal fun adjustedToFocusedRectOffset(
     insets: PlatformInsets,
     focusedRect: Rect?,
     size: IntSize?
@@ -170,5 +128,144 @@ private fun directionalFocusOffset(
         max(0f, min(hiddenFromPart, -hiddenToPart)).roundToInt()
     } else {
         min(0f, max(hiddenFromPart, -hiddenToPart)).roundToInt()
+    }
+}
+
+private data class OffsetToFocusedRectElement(
+    val insets: PlatformInsets,
+    val getFocusedRect: () -> Rect?,
+    val size: IntSize?,
+    val animationDuration: Duration,
+    val animationCompletion: () -> Unit,
+) : ModifierNodeElement<OffsetToFocusedRectNode>() {
+    override fun create() = OffsetToFocusedRectNode(
+        insets = insets,
+        getFocusedRect = getFocusedRect,
+        size = size,
+        animationDuration = animationDuration,
+        animationCompletion = animationCompletion,
+    )
+
+    override fun update(node: OffsetToFocusedRectNode) {
+        node.update(
+            insets = insets,
+            getFocusedRect = getFocusedRect,
+            size = size,
+            animationDuration = animationDuration,
+            animationCompletion = animationCompletion,
+        )
+    }
+}
+
+private class OffsetToFocusedRectNode(
+    private var insets: PlatformInsets,
+    private var getFocusedRect: () -> Rect?,
+    private var size: IntSize?,
+    private var animationDuration: Duration,
+    private var animationCompletion: () -> Unit,
+) : Modifier.Node(), GlobalPositionAwareModifierNode, LayoutModifierNode {
+    private var currentOffset = IntOffset.Zero
+    private var startOffset = IntOffset.Zero
+    private var offsetProgress = 1f
+    private var animationJob: Job? = null
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    fun update(
+        insets: PlatformInsets,
+        getFocusedRect: () -> Rect?,
+        size: IntSize?,
+        animationDuration: Duration,
+        animationCompletion: () -> Unit,
+    ) {
+        val animationInputsChanged =
+            this.insets != insets || this.animationDuration != animationDuration
+        val needsRemeasure =
+            animationInputsChanged ||
+                this.getFocusedRect !== getFocusedRect ||
+                this.size != size
+
+        this.insets = insets
+        this.getFocusedRect = getFocusedRect
+        this.size = size
+        this.animationDuration = animationDuration
+        this.animationCompletion = animationCompletion
+
+        if (!isAttached) return
+        if (animationInputsChanged) {
+            restartAnimation()
+        } else if (needsRemeasure) {
+            invalidateMeasurement()
+        }
+    }
+
+    override fun onAttach() {
+        restartAnimation()
+    }
+
+    override fun onDetach() {
+        animationJob?.cancel()
+        animationJob = null
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        currentOffset = calculatedOffset()
+        return layout(placeable.width, placeable.height) {
+            placeable.place(currentOffset)
+        }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        // The first point at which the focus rect contains both the new offset and a  simultaneous
+        // child-layout change (e.g. imePadding). Settle only when that changes the offset.
+        val settledOffset = calculatedOffset()
+        if (settledOffset != currentOffset) {
+            currentOffset = settledOffset
+            invalidateMeasurement()
+        }
+    }
+
+    private fun restartAnimation() {
+        animationJob?.cancel()
+        startOffset = currentOffset
+
+        if (!animationDuration.isPositive() || startOffset == targetOffset()) {
+            offsetProgress = 1f
+            if (animationDuration.isPositive()) {
+                animationCompletion()
+            }
+            invalidateMeasurement()
+            return
+        }
+
+        animationJob = coroutineScope.launch {
+            withAnimationProgress(animationDuration) { progress ->
+                offsetProgress = progress
+                invalidateMeasurement()
+            }
+            animationCompletion()
+        }
+    }
+
+    private fun calculatedOffset(): IntOffset =
+        startOffset + (targetOffset() - startOffset) * offsetProgress
+
+    private fun targetOffset(): IntOffset {
+        // The current implementation of OffsetToFocusedRect assumes that the focus rectangle is
+        // either static or only changes during the animation.
+        // The [Snapshot.withoutReadObservation] function is used here to avoid side effects caused
+        // by the internal implementation of the [getFocusedRect] function.
+        val focusedRect = Snapshot.withoutReadObservation { getFocusedRect() }
+            ?.translate(-currentOffset.toOffset())
+
+        return adjustedToFocusedRectOffset(
+            insets = insets,
+            focusedRect = focusedRect,
+            size = size,
+        )
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
@@ -181,9 +181,7 @@ private class OffsetToFocusedRectNode(
         val animationInputsChanged =
             this.insets != insets || this.animationDuration != animationDuration
         val needsRemeasure =
-            animationInputsChanged ||
-                this.getFocusedRect !== getFocusedRect ||
-                this.size != size
+            animationInputsChanged || this.getFocusedRect !== getFocusedRect || this.size != size
 
         this.insets = insets
         this.getFocusedRect = getFocusedRect

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -174,13 +174,6 @@ internal abstract class BaseComposeScene(
         hasForcedDraw = false
 
         postponeInvalidation("BaseComposeScene:draw") {
-            // FIXME CMP-10291: Remove applying the global snapshot here.
-            //  Android never applies the snapshot *between* the layout and draw phases
-            //  (applies happen once per frame on the main looper, not between phases).
-            //  This between-phase apply is a temporary workaround kept only to preserve current
-            //  behavior for OffsetToFocusedRect (iOS FocusableAboveKeyboard).
-            Snapshot.sendApplyNotifications()
-
             // AndroidComposeView.dispatchDraw() begins with measureAndLayout() so layout changes
             // discovered after the host layout traversal are still settled before drawing. Keep
             // that trailing layout pass here even though measureAndLayout() is also a public phase.

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -35,12 +35,21 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateMeasurement
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -288,8 +297,9 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun measureAndLayoutRunsAgainBeforeDraw() = runSkikoComposeUiTest {
-        // Android runs measureAndLayout again right before drawing; validate this behavior.
+    fun stateWriteDuringLayoutDoesNotRemeasureBeforeDraw() = runSkikoComposeUiTest {
+        // A write made during layout updates this draw, but its measure invalidation is handled by
+        // a subsequent frame.
         val state = mutableStateOf(0)
         val events = mutableListOf<String>()
         setContent {
@@ -311,8 +321,62 @@ class RenderPhasesTest {
         }
 
         assertContentEquals(
-            expected = listOf("measure.0", "layout.0", "measure.1", "layout.1", "draw.1"),
-            actual = events
+            expected = listOf("measure.0", "layout.0", "draw.1", "measure.1", "layout.1"),
+            actual = events,
         )
+    }
+
+    @Test
+    fun measurementInvalidatedSettlesBeforeDraw() = runSkikoComposeUiTest {
+        val events = mutableListOf<String>()
+
+        setContent {
+            Layout(
+                modifier = Modifier
+                    .then(InvalidateMeasurementOnPositionedElement)
+                    .drawBehind { events += "draw" },
+                measurePolicy = { _, _ ->
+                    events += "measure"
+                    layout(100, 100) {
+                        events += "layout"
+                    }
+                },
+            )
+        }
+
+        // Positioning is dispatched after the layout pass, and this
+        // node's direct measurement invalidation must be settled before draw.
+        assertContentEquals(
+            expected = listOf("measure", "layout", "measure", "layout", "draw"),
+            actual = events,
+        )
+    }
+}
+
+private data object InvalidateMeasurementOnPositionedElement :
+    ModifierNodeElement<InvalidateMeasurementOnPositionedNode>() {
+    override fun create() = InvalidateMeasurementOnPositionedNode()
+    override fun update(node: InvalidateMeasurementOnPositionedNode) = Unit
+}
+
+private class InvalidateMeasurementOnPositionedNode :
+    Modifier.Node(), GlobalPositionAwareModifierNode, LayoutModifierNode {
+    private var shouldInvalidateMeasurement = true
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        if (shouldInvalidateMeasurement) {
+            shouldInvalidateMeasurement = false
+            invalidateMeasurement()
+        }
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.min
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -581,6 +582,57 @@ internal abstract class KeyboardInsetsTest(
             bottom = screenSize.height - keyboardHeight
         )
         assertEquals(expectedTextField, lastTextFieldFrame)
+    }
+
+    @Test
+    fun testFocusableAboveKeyboardWithIMEInsetsStaysAboveKeyboardDuringAnimation() = runUIKitInstrumentedTest {
+        var textFieldBottom = Int.MIN_VALUE
+        val drawnTextFieldFrames = mutableListOf<Pair<Int, Int>>()
+        val focusRequester = FocusRequester()
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            val imeInsets = WindowInsets.ime
+            BasicTextField(
+                value = "test Focusable AboveKeyboard Large Text Field".repeat(200),
+                onValueChange = {},
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .fillMaxSize()
+                    .imePadding()
+                    .onGloballyPositioned { coordinates ->
+                        textFieldBottom = coordinates.boundsInWindow().roundToIntRect().bottom
+                    }
+                    .drawWithContent {
+                        val visibleBottom = screenSize.height.roundToPx() - imeInsets.getBottom(Density(density))
+                        drawnTextFieldFrames += textFieldBottom to visibleBottom
+                        drawContent()
+                    }
+            )
+        }
+
+        drawnTextFieldFrames.clear()
+        focusRequester.requestFocus()
+        waitForIdle()
+
+        assertTrue(
+            drawnTextFieldFrames.size > 5,
+            "Animation should produce large number of frames"
+        )
+
+        assertEquals(
+            expected = with(density) { (screenSize.height - keyboardHeight).roundToPx() },
+            actual = drawnTextFieldFrames.last().second
+        )
+
+        drawnTextFieldFrames.forEach { frame ->
+            assertTrue(
+                actual = frame.first <= frame.second,
+                "Focused field must be settled above the keyboard in every drawn frame: " +
+                    "fieldBottom=${frame.first}, visibleBottom=${frame.second}",
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Refactor `OffsetToFocusedRect` from composition owned state updated during measure to a `Modifier.Node()`. 

The previous implementation depended on `Snapshot.sendApplyNotifications()` between layout and draw to settle measurement before rendering. The `Modifier.Node()` implementation removes this workaround and aligns the render pipeline with Android.

Fixes [CMP-10291](https://youtrack.jetbrains.com/issue/CMP-10291) `OffsetToFocusedRect` relies on inter-phase `Snapshot` apply between layout and draw

## Testing

##### `RenderPhasesTest.kt`
- Update the render-phase test to assert that a snapshot write during layout is
  drawn immediately but its measurement invalidation is processed after that draw
- Verify that `invalidateMeasurement()` during draw-time is settled before draw
##### `KeyboardInsetsTest.kt`
- On iOS test IME stays above keyboard during animation when IME padding and `FocusableAboveKeyboard` are used

## Release Notes
N/A
