### PR TITLE
Fix incorrect event listener target for selection change in Firefox and Safari

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -152,11 +152,17 @@ internal class DomInputStrategy(
                 composeSender.sendEditCommand(SetSelectionCommand(normalizedStart, normalizedEnd))
             }
         }
+        // In Chrome, we need to listen to the selection change on the document
         document.addEventListener("selectionchange", selectionChangeListener)
+        // In Firefox and Safari we listen to the selection change on the input element.
+        // Chrome is expected to dispatch this event too (https://chromium-review.googlesource.com/c/chromium/src/+/5598393),
+        // but it doesn't: https://issuetracker.google.com/issues/518751607
+        htmlInput.addEventListener("selectionchange", selectionChangeListener)
     }
 
     fun dispose() {
         document.removeEventListener("selectionchange", selectionChangeListener)
+        htmlInput.removeEventListener("selectionchange", selectionChangeListener)
         selectionChangeListener = null
     }
 


### PR DESCRIPTION
This reverts the revert https://github.com/JetBrains/compose-multiplatform-core/pull/3102

WHY:
- We won't cherry-pick this change to release/1.12 where this change causes a bug with cursor position when deleting text.
- But in jb-main (in progress 1.13 state) this change doesn't trigger cursor position bugs thanks to other changes related to text input


Fixes https://youtrack.jetbrains.com/issue/CMP-9803/Web-Mobile.-Android.-Firefox.-Moving-cursor-with-spacebar-doesnt-work

## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fix cursor control using spacebar sliding gesture in Firefox mobile
