### PR TITLE
Fix portable Swift runtime linking in UIKit klibs

### DIFF
--- a/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.FileCollection
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.androidx.build.configureSwiftCompatibilityLinking
 import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
@@ -42,6 +43,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 /** Plugin to apply common configuration for Compose projects. */
 class AndroidXComposeImplPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        project.configureSwiftCompatibilityLinking()
+
         project.plugins.configureEach { plugin ->
             when (plugin) {
                 is AppPlugin,

--- a/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/SwiftCompatibilityLinking.kt
+++ b/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/SwiftCompatibilityLinking.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.androidx.build
+
+import java.io.File
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+fun Project.configureSwiftCompatibilityLinking() {
+    plugins.withId("org.jetbrains.kotlin.multiplatform") {
+        extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .withType(KotlinNativeTarget::class.java)
+            .all { target -> target.configureSwiftCompatibilityLinking() }
+    }
+}
+
+private fun KotlinNativeTarget.configureSwiftCompatibilityLinking() {
+    if (System.getProperty("os.name") != "Mac OS X") return
+
+    val sdkName =
+        when (konanTarget) {
+            KonanTarget.IOS_ARM64 -> "iphoneos"
+            KonanTarget.IOS_X64,
+            KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
+            else -> return
+        }
+    val swiftCompatibilityLibraryDir =
+        project.providers
+            .exec { spec -> spec.commandLine("xcrun", "--find", "swiftc") }
+            .standardOutput
+            .asText
+            .map { swiftcPath ->
+                File(swiftcPath.trim())
+                    .parentFile
+                    .parentFile
+                    .parentFile
+                    .resolve("usr/lib/swift/$sdkName")
+                    .absolutePath
+            }
+
+    binaries.all { binary ->
+        binary.linkTaskProvider.configure { linkTask ->
+            linkTask.toolOptions.freeCompilerArgs.addAll(
+                swiftCompatibilityLibraryDir.map { libraryDir ->
+                    listOf("-linker-option", "-L$libraryDir")
+                }
+            )
+        }
+    }
+}

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.FileCollection
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.androidx.build.configureSwiftCompatibilityLinking
 import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
@@ -42,6 +43,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 /** Plugin to apply common configuration for Compose projects. */
 class AndroidXComposeImplPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        project.configureSwiftCompatibilityLinking()
+
         project.plugins.configureEach { plugin ->
             when (plugin) {
                 is AppPlugin,

--- a/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/SwiftCompatibilityLinking.kt
+++ b/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/SwiftCompatibilityLinking.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.androidx.build
+
+import java.io.File
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+fun Project.configureSwiftCompatibilityLinking() {
+    plugins.withId("org.jetbrains.kotlin.multiplatform") {
+        extensions
+            .getByType(KotlinMultiplatformExtension::class.java)
+            .targets
+            .withType(KotlinNativeTarget::class.java)
+            .all { target -> target.configureSwiftCompatibilityLinking() }
+    }
+}
+
+private fun KotlinNativeTarget.configureSwiftCompatibilityLinking() {
+    if (System.getProperty("os.name") != "Mac OS X") return
+
+    val sdkName =
+        when (konanTarget) {
+            KonanTarget.IOS_ARM64 -> "iphoneos"
+            KonanTarget.IOS_X64,
+            KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
+            else -> return
+        }
+    val swiftCompatibilityLibraryDir =
+        project.providers
+            .exec { spec -> spec.commandLine("xcrun", "--find", "swiftc") }
+            .standardOutput
+            .asText
+            .map { swiftcPath ->
+                File(swiftcPath.trim())
+                    .parentFile
+                    .parentFile
+                    .parentFile
+                    .resolve("usr/lib/swift/$sdkName")
+                    .absolutePath
+            }
+
+    binaries.all { binary ->
+        binary.linkTaskProvider.configure { linkTask ->
+            linkTask.toolOptions.freeCompilerArgs.addAll(
+                swiftCompatibilityLibraryDir.map { libraryDir ->
+                    listOf("-linker-option", "-L$libraryDir")
+                }
+            )
+        }
+    }
+}

--- a/compose/ui/ui-uikit/build.gradle
+++ b/compose/ui/ui-uikit/build.gradle
@@ -179,12 +179,6 @@ private def configureSwiftUtils(target, xcodeProjectDir, sdkName, destination, a
     def headersPath = new File(buildDir, "/Products/usr/local/include/${libraryName}")
     def generatedHeaderPath = new File(headersPath, "${libraryName}-Swift.h")
     def sourceDefPath = new File(project.projectDir, "src/nativeInterop/cinterop/swiftUtils.def")
-    def generatedDefPath = new File(project.buildDir, "generated/nativeInterop/cinterop/${libraryName}-${sdkName}/swiftUtils.def")
-    def swiftcPathProvider = providers.exec {
-        commandLine("xcrun", "--find", "swiftc")
-    }.standardOutput.asText.map {
-        it.trim()
-    }
     def compilerArgs = [
             "-include-binary", libraryPath.toString(),
     ]
@@ -223,71 +217,18 @@ private def configureSwiftUtils(target, xcodeProjectDir, sdkName, destination, a
             ))
         }
 
-        def defTaskName = "${compileTaskProvider.name}UIKitSwiftUtilsDef"
-
-        // cinterop persists linkerOpts only when they come from a .def file. Generate one because
-        // Swift compatibility libraries live under the selected Xcode toolchain path.
-        def defTask = project.tasks.register(defTaskName) {
-            inputs.file(sourceDefPath)
-                    .withPropertyName("${libraryName}-${sdkName}-source-def")
-                    .withPathSensitivity(PathSensitivity.RELATIVE)
-            inputs.property("sdkName", sdkName)
-            inputs.property("swiftcPath", swiftcPathProvider)
-            outputs.file(generatedDefPath)
-                    .withPropertyName("${libraryName}-${sdkName}-def")
-            outputs.upToDateWhen { false }
-
-            doLast {
-                // Resolve the selected Xcode toolchain only when this iOS task runs.
-                def swiftcPath = swiftcPathProvider.get()
-                def swiftToolchainDir = new File(swiftcPath).parentFile.parentFile.parentFile
-                def swiftToolchainLibPath = new File(swiftToolchainDir, "usr/lib/swift/${sdkName}")
-                def swiftLinkerOpts = [
-                        "-ObjC",
-
-                        "-L${swiftToolchainLibPath}",
-
-                        "-rpath",
-                        "/usr/lib/swift",
-
-                        "-framework",
-                        "Foundation",
-
-                        "-lc++",
-
-                        "-lswiftCore",
-                        "-lswiftFoundation",
-                        "-lswiftCoreFoundation",
-                        "-lswiftDispatch",
-                        "-lswiftObjectiveC",
-                        "-lswiftXPC",
-                        "-lswift_Builtin_float",
-                        "-lswift_Concurrency",
-
-                        "-lswiftCompatibility51",
-                        "-lswiftCompatibility56",
-                        "-lswiftCompatibilityConcurrency",
-                        "-lswiftCompatibilityPacks",
-                ]
-
-                generatedDefPath.parentFile.mkdirs()
-                generatedDefPath.text = "${sourceDefPath.text.trim()}\nlinkerOpts = ${swiftLinkerOpts.join(" ")}\n"
-            }
-        }
-
         tasks[compileTaskProvider.name].dependsOn(libTask)
 
-        // Generate Kotlin bindings from the installed Swift ObjC header and use the generated .def
-        // so downstream Kotlin/Native binaries receive the Swift linker options transitively.
+        // Generate Kotlin bindings from the installed Swift ObjC header. The consuming iOS build
+        // supplies the compatibility-library search path.
         cinterops {
             swiftUtils {
                 def cinteropTask = tasks[interopProcessingTaskName]
                 cinteropTask.dependsOn(libTask)
-                cinteropTask.dependsOn(defTask)
                 cinteropTask.inputs.file(generatedHeaderPath)
                 extraOpts("-header", generatedHeaderPath.name)
                 compilerOpts("-I${headersPath}")
-                defFile(generatedDefPath)
+                defFile(sourceDefPath)
             }
         }
     }

--- a/compose/ui/ui-uikit/src/nativeInterop/cinterop/swiftUtils.def
+++ b/compose/ui/ui-uikit/src/nativeInterop/cinterop/swiftUtils.def
@@ -1,10 +1,21 @@
 #
-# The Gradle build copies these stable cinterop settings to a generated .def
-# file and appends target-specific Swift linker options resolved from the
-# selected Xcode toolchain. See configureUIKitSwiftUtils in build.gradle.
+# Copyright 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 package = androidx.compose.ui.uikit.utils
 language = Objective-C
 compilerOpts = -D_Float16=short
 headerFilter = CMP*
+linkerOpts = -ObjC -rpath /usr/lib/swift -framework Foundation -lc++ -lswiftCore -lswiftFoundation -lswiftCoreFoundation -lswiftDispatch -lswiftObjectiveC -lswiftXPC -lswift_Builtin_float -lswift_Concurrency -lswiftCompatibility51 -lswiftCompatibility56 -lswiftCompatibilityConcurrency -lswiftCompatibilityPacks


### PR DESCRIPTION
Avoid publishing Xcode path in the UIKit swiftUtils KLib metadata.
The Swift runtime library names remain portable linker requirements in `swiftUtils.def`. And the active Xcode toolchain's Swift compatibility library directory is resolved lazily at final iOS link time.

Fixes [CMP-10607](https://youtrack.jetbrains.com/issue/CMP-10607) Resolve Swift compatibility libraries from the consumer’s active Xcode during iOS linking

## Release Notes
N/A
