### PR TITLE
preventDefault touchstart event when it hits an active text input (#3271)

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -52,6 +52,12 @@ internal abstract class WebTextInputService :
         }
 
     /**
+     * Active [PlatformTextInputMethodRequest] provides the geometry of the text input,
+     * which we use for hit-testing for better handling of touch events.
+     */
+    private var activeTextInputMethodRequest: PlatformTextInputMethodRequest? = null
+
+    /**
      * It's used for the initial positioning of the backing HTML input.
      * It's rather a workaround for the problem that startInput doesn't know the correct position yet.
      * To solve it properly, we need to change the common code.
@@ -69,6 +75,7 @@ internal abstract class WebTextInputService :
         request: PlatformTextInputMethodRequest,
         onEditCommand: (List<EditCommand>) -> Unit,
     ) {
+        activeTextInputMethodRequest = request
         backingDomInput = BackingDomInput(
             imeOptions = request.imeOptions,
             composeCommunicator = object : ComposeCommandCommunicator {
@@ -113,6 +120,7 @@ internal abstract class WebTextInputService :
     override fun stopInput() {
         backingDomInput?.dispose()
         backingDomInput = null
+        activeTextInputMethodRequest = null
     }
 
     override fun showSoftwareKeyboard() {
@@ -130,5 +138,10 @@ internal abstract class WebTextInputService :
     override fun notifyFocusedRect(rect: Rect) {
         val newRect = getNewGeometryForBackingInput(rect)
         backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)
+    }
+
+    fun hitTest(offset: Offset): Boolean {
+        if (offset == Offset.Unspecified) return false
+        return activeTextInputMethodRequest?.textClippingRectInRoot()?.contains(offset) ?: false
     }
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -117,6 +117,7 @@ import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
+import org.w3c.dom.get
 import org.w3c.dom.pointerevents.PointerEvent
 
 private val actualDensity
@@ -427,15 +428,31 @@ internal class ComposeWindow(
             actualActivePointerButtons = null
         }
 
-        addTypedEvent<TouchEvent>("touchstart", passive = true) { _ ->
-            // We deliberately never preventDefault() touchstart, even though Compose consumes
+        val webTextInputService = platformContext.textInputService as WebTextInputService
+
+        addTypedEvent<TouchEvent>("touchstart", passive = false) { evt ->
+            // preventDefault the touchstart if the corresponding pointerdown hits the active text input.
+            // Pros: a long press (touchstart + ~500ms delay after it) triggers focus changes in iOS Safari,
+            // and this is the only chance (the only event we have) to prevent that behavior,
+            // since we want the focus to remain in the active text input.
+            // Cons: the browser's gestures (e.g., pull-to-refresh) become suppressed while
+            // the pointer is in the active text input.
+            val isTextFieldActive = webTextInputService.getBackingInput()?.isFocused() ?: false
+            if (isTextFieldActive) {
+                val position = activeTouchPointers[lastPointerDownId]?.composePointer?.position
+                if (webTextInputService.hitTest(position ?: Offset.Unspecified)) {
+                    evt.preventDefault()
+                }
+            }
+            lastPointerDownId = -1
+
+            // In other cases, we never preventDefault() touchstart, even though Compose consumes
             // the corresponding pointerdown on interactive areas. Per the Touch Events spec,
             // canceling touchstart suppresses the browser's default actions for the entire
-            // touch sequence: scrolling, back gesture, pull-to-refresh, AND the compatibility
-            // mouse events - and at touchstart time we can't yet know whether Compose will
+            // touch sequence: scrolling, back gesture, pull-to-refresh, and the compatibility
+            // mouse events. At touchstart time we can't yet know whether Compose will
             // actually handle the gesture. The decision is deferred to where it can be made
             // correctly: touchmove (move-based gestures) and touchend (tap-based defaults).
-            // The listener is passive and empty; it exists to document this decision.
         }
 
         addTypedEvent<TouchEvent>("touchend", passive = false) { evt ->
@@ -654,6 +671,9 @@ internal class ComposeWindow(
 
     private val activeTouchPointers = mutableIntObjectMapOf<TouchEventWithContainerOffset>()
 
+
+    private var lastPointerDownId: Int = -1
+
     // Whether Compose consumed the most recent touch pointerup. Read (and then reset) by the
     // touchend handler, which the browser dispatches right after pointerup, to decide whether
     // to suppress the compatibility mouse events. A single flag suffices because every
@@ -823,6 +843,8 @@ internal class ComposeWindow(
                 event.preventDefault()
                 if (eventType == PointerEventType.Move) {
                     activeTouchPointersConsumedMoves.add(event.pointerId)
+                } else if (eventType == PointerEventType.Press) {
+                    lastPointerDownId = event.pointerId
                 }
             }
         }


### PR DESCRIPTION
(cherry picked from commit 4c37d7cb6e65a033338f07f5b3201277122bef8d)

**Explanation:**
It's possible that after a `touchstart` there is no other events. In such a case iOS Safari changes the focus, "bluring" the active text input and making the virtual keyboard hide.
If there are other events after `touchstart` (usually a `touchmove` or eventually a `touchend`), then Compose will likely consume them, preventing the browser's "default" behaviour.
To avoid unexpected keyboard hiding for a longtap (touchstart + delay), we call `preventDefault` for touchstart only when the corresponding pointer hits the active text input rectangle.

Fixes
https://youtrack.jetbrains.com/issue/CMP-10519/Web-Mobile.-iOS.-The-virtual-keyboard-hides-after-long-tap-to-trigger-the-context-menu

## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- _(prerelease fix)_ Virtual keyboard gets hidden after a long tap on the text field

