### PR TITLE
Improve iOS Instrumented Tests for textfields

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.navigationevent.IosBackNavigationEventInput
@@ -111,6 +112,17 @@ internal class ComposeContainer(
         get() = view.window?.windowScene?.let { FrameChoreographer.choreographerForScene(it) }
 
     private var mediator: ComposeSceneMediator? = null
+
+    @OptIn(InternalComposeUiApi::class)
+    var rootForTestListener: PlatformContext.RootForTestListener? = null
+        set(value) {
+            field = value
+            mediator?.rootForTestListener = value
+            layersHolder?.layersViewController?.withLayers { layers ->
+                layers.forEach { it.rootForTestListener = value }
+            }
+        }
+
     private val sceneSizing = ComposeSceneSizing(
         view = view,
         measureSceneSize = { constraints -> mediator?.measureSceneSize(constraints) },
@@ -327,6 +339,7 @@ internal class ComposeContainer(
             navigationEventInput = navigationEventInput,
             interfaceOrientationState = interfaceOrientationState,
         ).also { mediator ->
+            mediator.rootForTestListener = rootForTestListener
             view.embedSubview(mediator.backgroundView)
             view.updateMetalView(
                 metalView = metalView,
@@ -425,6 +438,7 @@ internal class ComposeContainer(
                     invalidateDraw = { layersHolder.getLayersViewController().invalidateDraw() },
                 )
 
+                layer.rootForTestListener = rootForTestListener
                 layersHolder.getLayersViewController().attach(layer)
                 onFocusConditionsChanged()
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -19,6 +19,8 @@ package androidx.compose.ui.scene
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.uikit.ComposeUIViewConfiguration
 import androidx.compose.ui.uikit.utils.CMPView
 import androidx.compose.ui.unit.DpSize
@@ -55,6 +57,12 @@ internal class ComposeHostingView(
 
     @VisibleForTesting
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+    @VisibleForTesting
+    @OptIn(InternalComposeUiApi::class)
+    var rootForTestListener: PlatformContext.RootForTestListener?
+        get() = container.rootForTestListener
+        set(value) { container.rootForTestListener = value }
+
     @VisibleForTesting
     val lifecycleState: Lifecycle.State get() = container.currentLifecycleState
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -18,7 +18,9 @@ package androidx.compose.ui.scene
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.animation.withAnimationProgress
+import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowContext
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
 import androidx.compose.ui.uikit.utils.CMPViewController
@@ -56,6 +58,12 @@ internal class ComposeHostingViewController(
 
     @VisibleForTesting
     fun hasInvalidations(): Boolean = container.hasInvalidations()
+
+    @VisibleForTesting
+    @OptIn(InternalComposeUiApi::class)
+    var rootForTestListener: PlatformContext.RootForTestListener?
+        get() = container.rootForTestListener
+        set(value) { container.rootForTestListener = value }
 
     @VisibleForTesting
     val lifecycleState: Lifecycle.State get() = container.currentLifecycleState

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.navigationevent.IosBackNavigationEventInput
 import androidx.compose.ui.platform.AccessibilityMediator
 import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.platform.DefaultInputModeManager
+import androidx.compose.ui.platform.DelegateRootForTestListener
 import androidx.compose.ui.platform.FrameChoreographer
 import androidx.compose.ui.platform.PlatformArchitectureComponentsOwner
 import androidx.compose.ui.platform.PlatformContext
@@ -396,6 +397,9 @@ internal class ComposeSceneMediator(
      */
     private fun isPointInsideInteractionBounds(point: CValue<CGPoint>) =
         interactionBounds.contains(point.toDpOffset().toOffset(screenDensity).round())
+
+    @OptIn(InternalComposeUiApi::class)
+    var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
 
     private val semanticsOwnerListener by lazy {
         SemanticsOwnerListenerImpl(
@@ -916,6 +920,7 @@ internal class ComposeSceneMediator(
         override val textInputService get() = this@ComposeSceneMediator.textInputServiceAdapter
         override val textToolbar get() = this@ComposeSceneMediator.textInputService.textToolbar
         override val semanticsOwnerListener get() = this@ComposeSceneMediator.semanticsOwnerListener
+        override val rootForTestListener get() = this@ComposeSceneMediator.rootForTestListener
         override val dragAndDropManager get() = this@ComposeSceneMediator.dragAndDropManager
         override val windowInsets get() = this@ComposeSceneMediator.windowInsetsManager.windowInsets
         override val outOfFrameExecutor get() = this@ComposeSceneMediator.frameChoreographer.outOfFrameExecutor

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/IosComposeSceneLayer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/IosComposeSceneLayer.ios.kt
@@ -121,6 +121,12 @@ internal class IosComposeSceneLayer(
         it.isInterceptingOutsideEvents = consumePointerInputOutside
     }
 
+    var rootForTestListener: PlatformContext.RootForTestListener?
+        get() = mediator.rootForTestListener
+        set(value) {
+            mediator.rootForTestListener = value
+        }
+
     private fun createComposeScene(platformContext: PlatformContext): ComposeScene =
         PlatformLayersComposeScene(
             frameRecomposer = frameChoreographer.frameRecomposer,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SelectionContainerInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SelectionContainerInteractionTest.kt
@@ -40,15 +40,22 @@ import androidx.compose.ui.test.findNodeWithTagOrNull
 import androidx.compose.ui.test.firstNodeOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.tapContextMenuButton
+import androidx.compose.ui.test.utils.TestHandle
+import androidx.compose.ui.test.utils.TestSelectionHandleAnchor
+import androidx.compose.ui.test.utils.dragSelectionHandle
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.hold
 import androidx.compose.ui.test.utils.isLoupeView
+import androidx.compose.ui.test.utils.multiTapCharacter
+import androidx.compose.ui.test.utils.selectionHandles
+import androidx.compose.ui.test.utils.tapCharacter
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.test.waitForContextMenu
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -85,14 +92,50 @@ class SelectionContainerInteractionTest {
 
         setSelectionContainerContent(state = selectionState, text = text)
 
-        findNodeWithTag(Tag).focusThenDoubleTap()
-        waitUntil("SelectionContainer should select the word after double tap") {
-            selectionState.selectedText() == text
-        }
+        selectWordAt(selectionState, offset = 5, word = text)
 
         assertEquals(
             listOf(text),
             selectionState.selectedTexts.map { it.text },
+        )
+    }
+
+    @Test
+    fun testSelectionContainer_SelectionHandleAnchors() = runUIKitInstrumentedTest {
+        val selectionState = SelectionState()
+
+        setSelectionContainerContent(state = selectionState, text = "The quick brown fox")
+
+        selectWordAt(selectionState, offset = 6, word = "quick")
+
+        val handles = assertNotNull(
+            selectionHandles(),
+            "expected the selected '${selectionState.selectedText()}' to show handles",
+        )
+        assertEquals(
+            listOf(TestSelectionHandleAnchor.Left, TestSelectionHandleAnchor.Right),
+            listOf(handles.start.info.anchor, handles.end.info.anchor),
+            "the start handle should be drawn on the left of the selection and the end handle on its right",
+        )
+    }
+
+    @Test
+    fun testSelectionContainer_DragEndHandleExtendsSelection() = runUIKitInstrumentedTest {
+        val selectionState = SelectionState()
+
+        setSelectionContainerContent(state = selectionState, text = "The quick brown fox jumps")
+
+        selectWordAt(selectionState, offset = 6, word = "quick")
+
+        dragSelectionHandle(TestHandle.SelectionEnd, FirstTextTag, toOffset = 18)
+        waitForIdle()
+
+        // A SelectionContainer publishes no selection to aim a handle drag against, so the edge lands
+        // only approximately: all that can be asserted is that the selection grew past the word.
+        val selectedText = selectionState.selectedText()
+        assertTrue(
+            selectedText.startsWith("quick") && selectedText.length > "quick".length,
+            "Expected the end handle drag to extend the selection, but got: $selectedText",
         )
     }
 
@@ -306,8 +349,16 @@ class SelectionContainerInteractionTest {
         contentWidth: Dp = 320.dp,
     ) {
         setSelectionContainerContent(state = state) {
-            BasicText(text = text, modifier = Modifier.width(contentWidth))
+            BasicText(text = text, modifier = Modifier.width(contentWidth).testTag(FirstTextTag))
         }
+    }
+
+    private fun UIKitInstrumentedTest.selectWordAt(state: SelectionState, offset: Int, word: String) {
+        awaitNodeLaidOut(FirstTextTag)
+        tapCharacter(FirstTextTag, offset)
+        delay(DoubleTapPreparationDelayMillis)
+        multiTapCharacter(FirstTextTag, offset, count = 2)
+        waitUntil("Double tap at $offset should select '$word'") { state.selectedText() == word }
     }
 
     private fun UIKitInstrumentedTest.awaitNodeLaidOut(tag: String) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SelectionContainerInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/SelectionContainerInteractionTest.kt
@@ -42,13 +42,10 @@ import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.tapContextMenuButton
 import androidx.compose.ui.test.utils.TestHandle
 import androidx.compose.ui.test.utils.TestSelectionHandleAnchor
-import androidx.compose.ui.test.utils.dragSelectionHandle
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.hold
 import androidx.compose.ui.test.utils.isLoupeView
-import androidx.compose.ui.test.utils.multiTapCharacter
 import androidx.compose.ui.test.utils.selectionHandles
-import androidx.compose.ui.test.utils.tapCharacter
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.test.waitForContextMenu
 import androidx.compose.ui.unit.Dp
@@ -127,7 +124,7 @@ class SelectionContainerInteractionTest {
 
         selectWordAt(selectionState, offset = 6, word = "quick")
 
-        dragSelectionHandle(TestHandle.SelectionEnd, FirstTextTag, toOffset = 18)
+        findNodeWithTag(FirstTextTag).dragSelectionHandle(TestHandle.SelectionEnd, toOffset = 18)
         waitForIdle()
 
         // A SelectionContainer publishes no selection to aim a handle drag against, so the edge lands
@@ -355,9 +352,9 @@ class SelectionContainerInteractionTest {
 
     private fun UIKitInstrumentedTest.selectWordAt(state: SelectionState, offset: Int, word: String) {
         awaitNodeLaidOut(FirstTextTag)
-        tapCharacter(FirstTextTag, offset)
+        findNodeWithTag(FirstTextTag).tapCharacter(offset)
         delay(DoubleTapPreparationDelayMillis)
-        multiTapCharacter(FirstTextTag, offset, count = 2)
+        findNodeWithTag(FirstTextTag).multiTapCharacter(offset, count = 2)
         waitUntil("Double tap at $offset should select '$word'") { state.selectedText() == word }
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldCaretPlacementTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldCaretPlacementTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.BasicTextFieldType
+import androidx.compose.ui.test.utils.longPressCharacter
+import androidx.compose.ui.test.utils.tapCharacter
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TextFieldCaretPlacementTest {
+
+    @Test fun tapCharacter_btf1() = runUIKitInstrumentedTest { checkTapCharacter(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun tapCharacter_btf2() = runUIKitInstrumentedTest { checkTapCharacter(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun tapCharacter_nitiBtf1() = runUIKitInstrumentedTest { checkTapCharacter(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun tapCharacter_nitiBtf2() = runUIKitInstrumentedTest { checkTapCharacter(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun longPressCharacter_btf1() = runUIKitInstrumentedTest { checkLongPressCharacter(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun longPressCharacter_btf2() = runUIKitInstrumentedTest { checkLongPressCharacter(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun longPressCharacter_nitiBtf1() = runUIKitInstrumentedTest { checkLongPressCharacter(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun longPressCharacter_nitiBtf2() = runUIKitInstrumentedTest { checkLongPressCharacter(BasicTextFieldType.V2, nativeInput = true) }
+}
+
+private const val FIELD_TAG = "textField"
+
+@Composable
+private fun CaptionedField(caption: String?, field: @Composable () -> Unit) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (caption != null) {
+                BasicText(
+                    text = caption,
+                    style = TextStyle(
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    ),
+                    modifier = Modifier.padding(bottom = 24.dp),
+                )
+            }
+            field()
+        }
+    }
+}
+
+private fun UIKitInstrumentedTest.setUpField(
+    text: String,
+    btf: BasicTextFieldType,
+    nativeInput: Boolean,
+    caption: String? = null,
+): () -> TextRange {
+    val ime = KeyboardOptions(
+        // Disable autocorrect/spell-check so the native iOS replacement-suggestion bubble does not
+        // pop over the selection during the test (spellCheckingType defaults to follow this).
+        autoCorrectEnabled = false,
+        platformImeOptions = PlatformImeOptions { usingNativeTextInput(nativeInput) }
+    )
+    val focusRequester = FocusRequester()
+    val variant = "${if (nativeInput) "NITI" else "Compose"} BTF${if (btf == BasicTextFieldType.V1) "1" else "2"}"
+    val label = caption?.let { "$variant\n$it" }
+    val selection: () -> TextRange = when (btf) {
+        BasicTextFieldType.V1 -> {
+            val value = mutableStateOf(TextFieldValue(text))
+            setContent {
+                CaptionedField(label) {
+                    BasicTextField(
+                        value = value.value,
+                        onValueChange = { value.value = it },
+                        keyboardOptions = ime,
+                        modifier = Modifier
+                            .focusRequester(focusRequester)
+                            .testTag(FIELD_TAG),
+                    )
+                }
+            }
+            ({ value.value.selection })
+        }
+        BasicTextFieldType.V2 -> {
+            val state = TextFieldState(text)
+            setContent {
+                CaptionedField(label) {
+                    BasicTextField(
+                        state = state,
+                        keyboardOptions = ime,
+                        modifier = Modifier
+                            .focusRequester(focusRequester)
+                            .testTag(FIELD_TAG),
+                    )
+                }
+            }
+            ({ state.selection })
+        }
+    }
+    focusRequester.requestFocus()
+    waitForIdle()
+    return selection
+}
+
+private fun UIKitInstrumentedTest.checkTapCharacter(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField("The quick brown fox", btf, nativeInput)
+    tapCharacter(FIELD_TAG, offset = 8)
+    waitForIdle()
+    val resultSelection = selection()
+    assertTrue(resultSelection.collapsed, "expected a collapsed cursor after tap, got $resultSelection")
+    assertEquals(9, resultSelection.start, "trailing tap in 'quick' should snap to its end; landed at ${resultSelection.start}")
+}
+
+private fun UIKitInstrumentedTest.checkLongPressCharacter(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField("The quick brown fox", btf, nativeInput)
+    longPressCharacter(FIELD_TAG, offset = 6)
+    waitForIdle()
+    assertEquals(TextRange(6), selection(), "long press at offset 6 should leave the caret there")
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldCaretPlacementTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldCaretPlacementTest.kt
@@ -32,10 +32,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.BasicTextFieldType
-import androidx.compose.ui.test.utils.longPressCharacter
-import androidx.compose.ui.test.utils.tapCharacter
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -141,7 +140,7 @@ private fun UIKitInstrumentedTest.setUpField(
 
 private fun UIKitInstrumentedTest.checkTapCharacter(btf: BasicTextFieldType, nativeInput: Boolean) {
     val selection = setUpField("The quick brown fox", btf, nativeInput)
-    tapCharacter(FIELD_TAG, offset = 8)
+    findNodeWithTag(FIELD_TAG).tapCharacter(offset = 8)
     waitForIdle()
     val resultSelection = selection()
     assertTrue(resultSelection.collapsed, "expected a collapsed cursor after tap, got $resultSelection")
@@ -150,7 +149,7 @@ private fun UIKitInstrumentedTest.checkTapCharacter(btf: BasicTextFieldType, nat
 
 private fun UIKitInstrumentedTest.checkLongPressCharacter(btf: BasicTextFieldType, nativeInput: Boolean) {
     val selection = setUpField("The quick brown fox", btf, nativeInput)
-    longPressCharacter(FIELD_TAG, offset = 6)
+    findNodeWithTag(FIELD_TAG).longPressCharacter(offset = 6)
     waitForIdle()
     assertEquals(TextRange(6), selection(), "long press at offset 6 should leave the caret there")
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.test.findNodeWithLabelOrNull
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.tapContextMenuButton
+import androidx.compose.ui.test.utils.BasicTextFieldType
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.isLoupeView
 import androidx.compose.ui.test.utils.up
@@ -307,9 +308,9 @@ class TextFieldEditMenuTest {
             )
         }
 
-    private fun runComplexTextFieldTest(test: UIKitInstrumentedTest.(EditableTextFieldKind, newContextMenuEnabled: Boolean) -> Unit) {
+    private fun runComplexTextFieldTest(test: UIKitInstrumentedTest.(BasicTextFieldType, newContextMenuEnabled: Boolean) -> Unit) {
         for (newContextMenuEnabled in arrayOf(false, true)) {
-            for (textFieldKind in EditableTextFieldKind.entries) {
+            for (textFieldKind in BasicTextFieldType.entries) {
                 runContextMenuTest(newContextMenuEnabled) {
                     test(textFieldKind, newContextMenuEnabled)
                 }
@@ -758,7 +759,7 @@ class TextFieldEditMenuTest {
     }
 
     private fun UIKitInstrumentedTest.setTextFieldContent(
-        textFieldKind: EditableTextFieldKind,
+        textFieldKind: BasicTextFieldType,
         initialValue: TextFieldValue,
         readOnly: Boolean,
     ) {
@@ -766,7 +767,7 @@ class TextFieldEditMenuTest {
             val focusRequester = remember { FocusRequester() }
             Column(modifier = Modifier.safeDrawingPadding()) {
                 when (textFieldKind) {
-                    EditableTextFieldKind.BasicTextField -> {
+                    BasicTextFieldType.V1 -> {
                         val textFieldValue = remember {
                             mutableStateOf(initialValue)
                         }
@@ -777,7 +778,7 @@ class TextFieldEditMenuTest {
                             readOnly = readOnly
                         )
                     }
-                    EditableTextFieldKind.BasicTextField2 -> {
+                    BasicTextFieldType.V2 -> {
                         val textFieldState = remember {
                             TextFieldState(initialValue.text, initialValue.selection)
                         }
@@ -793,11 +794,6 @@ class TextFieldEditMenuTest {
                 focusRequester.requestFocus()
             }
         }
-    }
-
-    private enum class EditableTextFieldKind {
-        BasicTextField,
-        BasicTextField2
     }
 
     private companion object {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMultiTapSelectionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMultiTapSelectionTest.kt
@@ -29,11 +29,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.BasicTextFieldType
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.isLoupeView
-import androidx.compose.ui.test.utils.multiTapCharacter
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
@@ -52,7 +52,7 @@ class TextFieldMultiTapSelectionTest {
     @Test
     fun double_tap_selects_word() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
         textFieldOption.setup(this, TEXT, TAG)
-        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2)
+        findNodeWithTag(TAG).multiTapCharacter(offset = WORD_OFFSET, count = 2)
         waitForIdle()
         assertEquals(
             WORD_RANGE,
@@ -65,7 +65,7 @@ class TextFieldMultiTapSelectionTest {
     @Test
     fun triple_tap_selects_all_text() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
         textFieldOption.setup(this, TEXT, TAG)
-        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 3)
+        findNodeWithTag(TAG).multiTapCharacter(offset = WORD_OFFSET, count = 3)
         waitForIdle()
         assertEquals(
             TextRange(0, TEXT.length),
@@ -78,7 +78,7 @@ class TextFieldMultiTapSelectionTest {
     @Test
     fun multitap_does_not_show_magnifier() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
         textFieldOption.setup(this, TEXT, TAG)
-        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2) // double tap is enough
+        findNodeWithTag(TAG).multiTapCharacter(offset = WORD_OFFSET, count = 2) // double tap is enough
         delay(200)
         assertEquals(
             findFirstDescendant { it.isLoupeView },
@@ -92,7 +92,7 @@ class TextFieldMultiTapSelectionTest {
     fun BTF2_triple_tap_then_double_tap_selects_word() = runUIKitInstrumentedTest(params = listOf(TextFieldFactory(BasicTextFieldType.V2, nativeInput = false))) { textFieldOption ->
         textFieldOption.setup(this, TEXT, TAG)
 
-        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 3)
+        findNodeWithTag(TAG).multiTapCharacter(offset = WORD_OFFSET, count = 3)
         waitForIdle()
         assertEquals(
             TextRange(0, TEXT.length),
@@ -103,7 +103,7 @@ class TextFieldMultiTapSelectionTest {
         // After triple tap selects all, a subsequent double tap should re-select only a word.
         // This exercises the clearSelection fix that allows selection to be updated by repeated taps.
         delay(400)
-        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2)
+        findNodeWithTag(TAG).multiTapCharacter(offset = WORD_OFFSET, count = 2)
         waitForIdle()
 
         assertEquals(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMultiTapSelectionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMultiTapSelectionTest.kt
@@ -20,160 +20,172 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.UIKitInstrumentedTest
-import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
-import androidx.compose.ui.test.utils.center
-import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.test.utils.BasicTextFieldType
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.isLoupeView
+import androidx.compose.ui.test.utils.multiTapCharacter
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import platform.UIKit.endEditing
 
 class TextFieldMultiTapSelectionTest {
 
-    private val tfOptions = listOf(TextFieldFactory.BTF1, TextFieldFactory.BTF2)
+    // Each field on both text input paths: the Compose one and the native one.
+    private val tfOptions = listOf(false, true).flatMap { nativeInput ->
+        BasicTextFieldType.entries.map { TextFieldFactory(it, nativeInput) }
+    }
 
     @Test
     fun double_tap_selects_word() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
-        textFieldOption.setup(this, MULTI_WORD_TEXT, TAG)
-        findNodeWithTag(TAG).focusThenDoubleTap()
-        assertFalse(textFieldOption.selection.collapsed, "[${textFieldOption.name}] Expected a word to be selected after double tap")
-        assertTrue(
-            textFieldOption.selection.length < MULTI_WORD_TEXT.length,
-            "[${textFieldOption.name}] Expected only a word to be selected, not the entire text, but got: ${textFieldOption.selection}"
+        textFieldOption.setup(this, TEXT, TAG)
+        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2)
+        waitForIdle()
+        assertEquals(
+            WORD_RANGE,
+            textFieldOption.selection,
+            "[${textFieldOption.name}] Expected double tap inside '$WORD' to select it, but got: ${textFieldOption.selection}"
         )
+        if (textFieldOption.nativeInput) dropNativeSelection()
     }
 
     @Test
     fun triple_tap_selects_all_text() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
-        textFieldOption.setup(this, MULTI_WORD_TEXT, TAG)
-        focusThenTripleTap(TAG)
-        assertTrue(
-            textFieldOption.selection.start == 0 && textFieldOption.selection.end == MULTI_WORD_TEXT.length,
+        textFieldOption.setup(this, TEXT, TAG)
+        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 3)
+        waitForIdle()
+        assertEquals(
+            TextRange(0, TEXT.length),
+            textFieldOption.selection,
             "[${textFieldOption.name}] Expected all text to be selected after triple tap, but got: ${textFieldOption.selection}"
         )
+        if (textFieldOption.nativeInput) dropNativeSelection()
     }
 
     @Test
     fun multitap_does_not_show_magnifier() = runUIKitInstrumentedTest(params = tfOptions) { textFieldOption ->
-        textFieldOption.setup(this, MULTI_WORD_TEXT, TAG)
-        findNodeWithTag(TAG).focusThenDoubleTap() // double tap is enough
+        textFieldOption.setup(this, TEXT, TAG)
+        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2) // double tap is enough
         delay(200)
         assertEquals(
             findFirstDescendant { it.isLoupeView },
             null,
             "[${textFieldOption.name}] Magnifier should not appear during multi-tap selection"
         )
+        if (textFieldOption.nativeInput) dropNativeSelection()
     }
 
     @Test
-    fun BTF2_triple_tap_then_double_tap_selects_word() = runUIKitInstrumentedTest(params = listOf(TextFieldFactory.BTF2)) { textFieldOption ->
-        textFieldOption.setup(this, MULTI_WORD_TEXT, TAG)
+    fun BTF2_triple_tap_then_double_tap_selects_word() = runUIKitInstrumentedTest(params = listOf(TextFieldFactory(BasicTextFieldType.V2, nativeInput = false))) { textFieldOption ->
+        textFieldOption.setup(this, TEXT, TAG)
 
-        focusThenTripleTap(TAG)
-        assertTrue(
-            textFieldOption.selection.start == 0 && textFieldOption.selection.end == MULTI_WORD_TEXT.length,
-            "BTF2: triple tap should select all text"
+        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 3)
+        waitForIdle()
+        assertEquals(
+            TextRange(0, TEXT.length),
+            textFieldOption.selection,
+            "BTF2: triple tap should select all text, but got: ${textFieldOption.selection}"
         )
 
         // After triple tap selects all, a subsequent double tap should re-select only a word.
         // This exercises the clearSelection fix that allows selection to be updated by repeated taps.
         delay(400)
-        findNodeWithTag(TAG).doubleTap()
+        multiTapCharacter(TAG, offset = WORD_OFFSET, count = 2)
         waitForIdle()
 
-        val afterDoubleTap = textFieldOption.selection
-        assertFalse(afterDoubleTap.collapsed, "BTF2: Expected a word to be selected after double tap")
-        assertTrue(
-            afterDoubleTap.length < MULTI_WORD_TEXT.length,
-            "BTF2: Expected only a word to be selected after double tap, but got: $afterDoubleTap"
+        assertEquals(
+            WORD_RANGE,
+            textFieldOption.selection,
+            "BTF2: Expected only '$WORD' to be selected after double tap, but got: ${textFieldOption.selection}"
         )
     }
 
-    private fun UIKitInstrumentedTest.focusThenDoubleTap(tag: String) {
-        findNodeWithTag(tag).tap()
-        delay(400)
-        findNodeWithTag(tag).doubleTap()
-        waitForIdle()
-    }
-
-    private fun UIKitInstrumentedTest.focusThenTripleTap(tag: String) {
-        findNodeWithTag(tag).tap()
-        delay(400)
-        // Tap at 10% from left to stay inside the first word on any screen width.
-        // Tapping at the frame center might be failed because the frame center
-        // might be near the edge of the double-tapped word's selection handle.
-        val frame = findNodeWithTag(tag).frame!!
-        val tapPoint = DpOffset(frame.left + (frame.right - frame.left) * 0.1f, frame.center().y)
-        tap(tapPoint)
-        delay(50)
-        tap(tapPoint)
-        delay(50)
-        tap(tapPoint)
-        waitForIdle()
+    /** Ends the native editing session, so its selection does not outlive the test. */
+    private fun UIKitInstrumentedTest.dropNativeSelection() {
+        viewController.view.endEditing(force = true)
+        // TODO: CMP-10641
+        delay(500)
     }
 
     companion object {
         private const val TAG = "textField"
-        private const val MULTI_WORD_TEXT = "accomplishment extraordinary magnificent establishment"
+        private const val TEXT = "The quick brown fox"
+        /** The word the tests tap on, and the selection a double tap on it should produce. */
+        private const val WORD = "quick"
+        private val WORD_RANGE = TextRange(TEXT.indexOf(WORD), TEXT.indexOf(WORD) + WORD.length)
+        /** The middle of [WORD], so that a tap lands inside it rather than on either edge. */
+        private val WORD_OFFSET = WORD_RANGE.min + WORD.length / 2
     }
 }
 
-private sealed class TextFieldFactory(val name: String) {
+private class TextFieldFactory(val type: BasicTextFieldType, val nativeInput: Boolean) {
     private var _selection: (() -> TextRange)? = null
+
     val selection: TextRange get() = _selection!!()
 
+    val name: String get() {
+        val field = when (type) {
+            BasicTextFieldType.V1 -> "BasicTextField(value)"
+            BasicTextFieldType.V2 -> "BasicTextField(state)"
+        }
+        return if (nativeInput) "$field, native input" else field
+    }
+
     fun setup(test: UIKitInstrumentedTest, text: String, tag: String) {
-        _selection = setupTextFieldAndFetchSelection(test, text, tag)
-    }
+        val focusRequester = FocusRequester()
+        val keyboardOptions = KeyboardOptions(
+            autoCorrectEnabled = false,
+            platformImeOptions = PlatformImeOptions { usingNativeTextInput(nativeInput) }
+        )
+        val modifier = Modifier
+            .focusRequester(focusRequester)
+            .testTag(tag)
+            .padding(16.dp)
 
-    protected abstract fun setupTextFieldAndFetchSelection(test: UIKitInstrumentedTest, text: String, tag: String): () -> TextRange
-
-    object BTF1 : TextFieldFactory("BasicTextField(value)") {
-        override fun setupTextFieldAndFetchSelection(test: UIKitInstrumentedTest, text: String, tag: String): () -> TextRange {
-            val valueState = mutableStateOf(TextFieldValue(text))
-            test.setContent {
-                Box(Modifier.fillMaxSize()) {
-                    BasicTextField(
-                        value = valueState.value,
-                        onValueChange = { valueState.value = it },
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .testTag(tag)
-                            .padding(16.dp)
-                    )
+        _selection = when (type) {
+            BasicTextFieldType.V1 -> {
+                val valueState = mutableStateOf(TextFieldValue(text))
+                test.setContent {
+                    Box(Modifier.fillMaxSize()) {
+                        BasicTextField(
+                            value = valueState.value,
+                            onValueChange = { valueState.value = it },
+                            keyboardOptions = keyboardOptions,
+                            modifier = Modifier.align(Alignment.Center).then(modifier)
+                        )
+                    }
                 }
+                ({ valueState.value.selection })
             }
-            return { valueState.value.selection }
-        }
-    }
-
-    object BTF2 : TextFieldFactory("BasicTextField(state)") {
-        override fun setupTextFieldAndFetchSelection(test: UIKitInstrumentedTest, text: String, tag: String): () -> TextRange {
-            val state = TextFieldState(text)
-            test.setContent {
-                Box(Modifier.fillMaxSize()) {
-                    BasicTextField(
-                        state = state,
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .testTag(tag)
-                            .padding(16.dp)
-                    )
+            BasicTextFieldType.V2 -> {
+                val state = TextFieldState(text)
+                test.setContent {
+                    Box(Modifier.fillMaxSize()) {
+                        BasicTextField(
+                            state = state,
+                            keyboardOptions = keyboardOptions,
+                            modifier = Modifier.align(Alignment.Center).then(modifier)
+                        )
+                    }
                 }
+                ({ state.selection })
             }
-            return { state.selection }
         }
+        // Focused programmatically, so no focus-tap is fed to UIKit's multi-tap recognizer.
+        focusRequester.requestFocus()
+        test.waitForIdle()
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldSelectionHandlesTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldSelectionHandlesTest.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.BasicTextFieldType
+import androidx.compose.ui.test.utils.TestHandle
+import androidx.compose.ui.test.utils.TestSelectionHandleAnchor
+import androidx.compose.ui.test.utils.characterPosition
+import androidx.compose.ui.test.utils.dragSelectionHandle
+import androidx.compose.ui.test.utils.multiTapCharacter
+import androidx.compose.ui.test.utils.selectionHandles
+import androidx.compose.ui.test.utils.tapCharacter
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import platform.UIKit.endEditing
+
+class TextFieldSelectionHandlesTest {
+
+    @Test fun selectionHandles_ltr_btf1() = runUIKitInstrumentedTest { checkSelectionHandlesLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun selectionHandles_ltr_btf2() = runUIKitInstrumentedTest { checkSelectionHandlesLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun selectionHandles_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkSelectionHandlesLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun selectionHandles_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkSelectionHandlesLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun noSelectionHandlesForCaret_ltr_btf1() = runUIKitInstrumentedTest { checkNoSelectionHandlesForCaretLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun noSelectionHandlesForCaret_ltr_btf2() = runUIKitInstrumentedTest { checkNoSelectionHandlesForCaretLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun noSelectionHandlesForCaret_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkNoSelectionHandlesForCaretLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun noSelectionHandlesForCaret_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkNoSelectionHandlesForCaretLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun dragEndSelectionHandle_ltr_btf1() = runUIKitInstrumentedTest { checkDragEndSelectionHandleLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun dragEndSelectionHandle_ltr_btf2() = runUIKitInstrumentedTest { checkDragEndSelectionHandleLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun dragEndSelectionHandle_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkDragEndSelectionHandleLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun dragEndSelectionHandle_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkDragEndSelectionHandleLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun dragStartSelectionHandle_ltr_btf1() = runUIKitInstrumentedTest { checkDragStartSelectionHandleLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun dragStartSelectionHandle_ltr_btf2() = runUIKitInstrumentedTest { checkDragStartSelectionHandleLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun dragStartSelectionHandle_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkDragStartSelectionHandleLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun dragStartSelectionHandle_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkDragStartSelectionHandleLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun dragEndSelectionHandleAcrossLines_ltr_btf1() = runUIKitInstrumentedTest { checkDragEndSelectionHandleAcrossLinesLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun dragEndSelectionHandleAcrossLines_ltr_btf2() = runUIKitInstrumentedTest { checkDragEndSelectionHandleAcrossLinesLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun dragEndSelectionHandleAcrossLines_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkDragEndSelectionHandleAcrossLinesLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun dragEndSelectionHandleAcrossLines_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkDragEndSelectionHandleAcrossLinesLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun dragStartSelectionHandleAcrossLines_ltr_btf1() = runUIKitInstrumentedTest { checkDragStartSelectionHandleAcrossLinesLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun dragStartSelectionHandleAcrossLines_ltr_btf2() = runUIKitInstrumentedTest { checkDragStartSelectionHandleAcrossLinesLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun dragStartSelectionHandleAcrossLines_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkDragStartSelectionHandleAcrossLinesLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun dragStartSelectionHandleAcrossLines_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkDragStartSelectionHandleAcrossLinesLtr(BasicTextFieldType.V2, nativeInput = true) }
+
+    @Test fun crossSelectionHandles_ltr_btf1() = runUIKitInstrumentedTest { checkCrossSelectionHandlesLtr(BasicTextFieldType.V1, nativeInput = false) }
+    @Test fun crossSelectionHandles_ltr_btf2() = runUIKitInstrumentedTest { checkCrossSelectionHandlesLtr(BasicTextFieldType.V2, nativeInput = false) }
+    @Test fun crossSelectionHandles_ltr_nitiBtf1() = runUIKitInstrumentedTest { checkCrossSelectionHandlesLtr(BasicTextFieldType.V1, nativeInput = true) }
+    @Test fun crossSelectionHandles_ltr_nitiBtf2() = runUIKitInstrumentedTest { checkCrossSelectionHandlesLtr(BasicTextFieldType.V2, nativeInput = true) }
+}
+
+private const val FIELD_TAG = "textField"
+
+private const val TEXT = "The quick brown fox jumps"
+
+private const val THREE_LINE_TEXT = "The quick brown fox\njumps over the lazy dog\nand back to the kennel"
+
+private val SECOND_LINE_BREAK_OFFSET = THREE_LINE_TEXT.lastIndexOf('\n')
+
+private fun String.rangeOf(word: String, from: Int = 0): TextRange {
+    val start = indexOf(word, from)
+    require(start >= 0) { "'$word' is not in \"$this\"" }
+    return TextRange(start, start + word.length)
+}
+
+private val TextRange.middle: Int get() = (min + max) / 2
+
+private fun UIKitInstrumentedTest.dropNativeSelection() {
+    viewController.view.endEditing(force = true)
+    // TODO: CMP-10641
+    delay(500)
+}
+
+private fun UIKitInstrumentedTest.setUpField(
+    text: String,
+    btf: BasicTextFieldType,
+    nativeInput: Boolean,
+): () -> TextRange {
+    val ime = KeyboardOptions(
+        // Disable autocorrect/spell-check so the native iOS replacement-suggestion bubble does not
+        // pop over the selection during the test (spellCheckingType defaults to follow this).
+        autoCorrectEnabled = false,
+        platformImeOptions = PlatformImeOptions { usingNativeTextInput(nativeInput) }
+    )
+    val focusRequester = FocusRequester()
+    return when (btf) {
+        BasicTextFieldType.V1 -> {
+            val value = mutableStateOf(TextFieldValue(text))
+            setContent {
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                Box(Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        value = value.value,
+                        onValueChange = { value.value = it },
+                        keyboardOptions = ime,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .focusRequester(focusRequester)
+                            .testTag(FIELD_TAG),
+                    )
+                }
+            }
+            ({ value.value.selection })
+        }
+        BasicTextFieldType.V2 -> {
+            val state = TextFieldState(text)
+            setContent {
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                Box(Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        state = state,
+                        keyboardOptions = ime,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .focusRequester(focusRequester)
+                            .testTag(FIELD_TAG),
+                    )
+                }
+            }
+            ({ state.selection })
+        }
+    }
+}
+
+private fun UIKitInstrumentedTest.checkSelectionHandlesLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(TEXT, btf, nativeInput)
+    val quick = TEXT.rangeOf("quick")
+
+    multiTapCharacter(FIELD_TAG, offset = quick.middle, count = 2)
+    waitForIdle()
+
+    val handles = assertNotNull(
+        selectionHandles(),
+        "expected 'quick' selected at $quick, got ${selection()}",
+    )
+    assertEquals(
+        listOf(TestSelectionHandleAnchor.Left, TestSelectionHandleAnchor.Right),
+        listOf(handles.start.info.anchor, handles.end.info.anchor),
+        "the start handle should be drawn on the left of the selection and the end handle on its right",
+    )
+    if (nativeInput) dropNativeSelection()
+}
+
+private fun UIKitInstrumentedTest.checkNoSelectionHandlesForCaretLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(TEXT, btf, nativeInput)
+
+    tapCharacter(FIELD_TAG, offset = TEXT.rangeOf("quick").middle)
+    waitForIdle()
+
+    val caret = selection()
+    assertTrue(caret.collapsed, "expected a caret after the tap, got $caret")
+    assertNull(selectionHandles(), "a caret must expose no selection handles")
+}
+
+private fun UIKitInstrumentedTest.checkDragEndSelectionHandleLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(TEXT, btf, nativeInput)
+    val fox = TEXT.rangeOf("fox")
+
+    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("quick").middle, count = 2)
+    waitForIdle()
+    val before = selection()
+    assertTrue(!before.collapsed, "expected a word selection, got $before")
+
+    // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
+    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = fox.max)
+    waitForIdle()
+
+    val after = selection()
+    assertEquals(fox.max, after.max, "end handle drag should extend selection to the end of 'fox': $before -> $after")
+    assertEquals(before.min, after.min, "start should not move: $before -> $after")
+    if (nativeInput) dropNativeSelection()
+}
+
+private fun UIKitInstrumentedTest.checkDragStartSelectionHandleLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(TEXT, btf, nativeInput)
+    val quick = TEXT.rangeOf("quick")
+
+    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("brown").middle, count = 2)
+    waitForIdle()
+    val before = selection()
+    assertTrue(!before.collapsed, "expected a word selection, got $before")
+
+    // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
+    dragSelectionHandle(TestHandle.SelectionStart, FIELD_TAG, toOffset = quick.min)
+    waitForIdle()
+
+    val after = selection()
+    assertEquals(quick.min, after.min, "start handle drag should extend selection to the start of 'quick': $before -> $after")
+    assertEquals(before.max, after.max, "end should not move: $before -> $after")
+    if (nativeInput) dropNativeSelection()
+}
+
+private fun UIKitInstrumentedTest.checkDragEndSelectionHandleAcrossLinesLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(THREE_LINE_TEXT, btf, nativeInput)
+    val quick = THREE_LINE_TEXT.rangeOf("quick")
+    val theOnLastLine = THREE_LINE_TEXT.rangeOf("the", from = SECOND_LINE_BREAK_OFFSET)
+
+    multiTapCharacter(FIELD_TAG, offset = quick.middle, count = 2)
+    waitForIdle()
+    val before = selection()
+    assertTrue(!before.collapsed, "expected a word selection on the first line, got $before")
+
+    // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
+    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = theOnLastLine.max)
+    waitForIdle()
+
+    val after = selection()
+    assertEquals(theOnLastLine.max, after.max, "end handle should cross both line breaks and land on the end of 'the': $before -> $after")
+    assertEquals(before.min, after.min, "start should not move: $before -> $after")
+
+    val handles = assertNotNull(selectionHandles(), "expected the selection $after to show handles")
+    assertTrue(
+        handles.start.grabPoint.y < characterPosition(FIELD_TAG, offset = quick.middle).y,
+        "start handle should sit above the first line, was ${handles.start.grabPoint}",
+    )
+    assertTrue(
+        handles.end.grabPoint.y > characterPosition(FIELD_TAG, offset = theOnLastLine.max).y,
+        "end handle should sit below the third line, was ${handles.end.grabPoint}",
+    )
+    if (nativeInput) dropNativeSelection()
+}
+
+private fun UIKitInstrumentedTest.checkDragStartSelectionHandleAcrossLinesLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(THREE_LINE_TEXT, btf, nativeInput)
+    val quick = THREE_LINE_TEXT.rangeOf("quick")
+    val theOnLastLine = THREE_LINE_TEXT.rangeOf("the", from = SECOND_LINE_BREAK_OFFSET)
+
+    multiTapCharacter(FIELD_TAG, offset = theOnLastLine.middle, count = 2)
+    waitForIdle()
+    val before = selection()
+    assertTrue(!before.collapsed, "expected a word selection on the third line, got $before")
+
+    // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
+    dragSelectionHandle(TestHandle.SelectionStart, FIELD_TAG, toOffset = quick.min)
+    waitForIdle()
+
+    val after = selection()
+    assertEquals(quick.min, after.min, "start handle should cross both line breaks and land on the start of 'quick': $before -> $after")
+    assertEquals(before.max, after.max, "end should not move: $before -> $after")
+    if (nativeInput) dropNativeSelection()
+}
+
+private fun UIKitInstrumentedTest.checkCrossSelectionHandlesLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
+    val selection = setUpField(TEXT, btf, nativeInput)
+
+    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("brown").middle, count = 2)
+    waitForIdle()
+    val before = selection()
+    assertTrue(!before.collapsed, "expected a word selection, got $before")
+
+    // Past the other edge, into the first word of the text.
+    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = TEXT.rangeOf("The").middle)
+    waitForIdle()
+
+    val after = selection()
+    assertTrue(!after.collapsed, "crossing the handles should keep a selection, got $after")
+    assertTrue(after.min < before.min, "the dragged edge should have crossed the other one: $before -> $after")
+    assertEquals(before.min, after.max, "the fixed edge moved: $before -> $after")
+
+    val handles = assertNotNull(selectionHandles(), "expected the crossed selection $after to show handles")
+    assertEquals(
+        setOf(TestSelectionHandleAnchor.Left, TestSelectionHandleAnchor.Right),
+        setOf(handles.start.info.anchor, handles.end.info.anchor),
+        "a crossed selection should still be drawn with a leading and a trailing handle",
+    )
+    if (nativeInput) dropNativeSelection()
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldSelectionHandlesTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldSelectionHandlesTest.kt
@@ -28,16 +28,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.AccessibilityTestNode
 import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.BasicTextFieldType
 import androidx.compose.ui.test.utils.TestHandle
 import androidx.compose.ui.test.utils.TestSelectionHandleAnchor
-import androidx.compose.ui.test.utils.characterPosition
-import androidx.compose.ui.test.utils.dragSelectionHandle
-import androidx.compose.ui.test.utils.multiTapCharacter
 import androidx.compose.ui.test.utils.selectionHandles
-import androidx.compose.ui.test.utils.tapCharacter
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
@@ -93,6 +91,9 @@ private const val TEXT = "The quick brown fox jumps"
 private const val THREE_LINE_TEXT = "The quick brown fox\njumps over the lazy dog\nand back to the kennel"
 
 private val SECOND_LINE_BREAK_OFFSET = THREE_LINE_TEXT.lastIndexOf('\n')
+
+private fun UIKitInstrumentedTest.getActiveTextFieldNode(): AccessibilityTestNode =
+    findNodeWithTag(FIELD_TAG)
 
 private fun String.rangeOf(word: String, from: Int = 0): TextRange {
     val start = indexOf(word, from)
@@ -163,7 +164,7 @@ private fun UIKitInstrumentedTest.checkSelectionHandlesLtr(btf: BasicTextFieldTy
     val selection = setUpField(TEXT, btf, nativeInput)
     val quick = TEXT.rangeOf("quick")
 
-    multiTapCharacter(FIELD_TAG, offset = quick.middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = quick.middle, count = 2)
     waitForIdle()
 
     val handles = assertNotNull(
@@ -181,7 +182,7 @@ private fun UIKitInstrumentedTest.checkSelectionHandlesLtr(btf: BasicTextFieldTy
 private fun UIKitInstrumentedTest.checkNoSelectionHandlesForCaretLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
     val selection = setUpField(TEXT, btf, nativeInput)
 
-    tapCharacter(FIELD_TAG, offset = TEXT.rangeOf("quick").middle)
+    getActiveTextFieldNode().tapCharacter(offset = TEXT.rangeOf("quick").middle)
     waitForIdle()
 
     val caret = selection()
@@ -193,13 +194,13 @@ private fun UIKitInstrumentedTest.checkDragEndSelectionHandleLtr(btf: BasicTextF
     val selection = setUpField(TEXT, btf, nativeInput)
     val fox = TEXT.rangeOf("fox")
 
-    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("quick").middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = TEXT.rangeOf("quick").middle, count = 2)
     waitForIdle()
     val before = selection()
     assertTrue(!before.collapsed, "expected a word selection, got $before")
 
     // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
-    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = fox.max)
+    getActiveTextFieldNode().dragSelectionHandle(TestHandle.SelectionEnd, toOffset = fox.max)
     waitForIdle()
 
     val after = selection()
@@ -212,13 +213,13 @@ private fun UIKitInstrumentedTest.checkDragStartSelectionHandleLtr(btf: BasicTex
     val selection = setUpField(TEXT, btf, nativeInput)
     val quick = TEXT.rangeOf("quick")
 
-    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("brown").middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = TEXT.rangeOf("brown").middle, count = 2)
     waitForIdle()
     val before = selection()
     assertTrue(!before.collapsed, "expected a word selection, got $before")
 
     // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
-    dragSelectionHandle(TestHandle.SelectionStart, FIELD_TAG, toOffset = quick.min)
+    getActiveTextFieldNode().dragSelectionHandle(TestHandle.SelectionStart, toOffset = quick.min)
     waitForIdle()
 
     val after = selection()
@@ -232,13 +233,13 @@ private fun UIKitInstrumentedTest.checkDragEndSelectionHandleAcrossLinesLtr(btf:
     val quick = THREE_LINE_TEXT.rangeOf("quick")
     val theOnLastLine = THREE_LINE_TEXT.rangeOf("the", from = SECOND_LINE_BREAK_OFFSET)
 
-    multiTapCharacter(FIELD_TAG, offset = quick.middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = quick.middle, count = 2)
     waitForIdle()
     val before = selection()
     assertTrue(!before.collapsed, "expected a word selection on the first line, got $before")
 
     // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
-    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = theOnLastLine.max)
+    getActiveTextFieldNode().dragSelectionHandle(TestHandle.SelectionEnd, toOffset = theOnLastLine.max)
     waitForIdle()
 
     val after = selection()
@@ -247,11 +248,11 @@ private fun UIKitInstrumentedTest.checkDragEndSelectionHandleAcrossLinesLtr(btf:
 
     val handles = assertNotNull(selectionHandles(), "expected the selection $after to show handles")
     assertTrue(
-        handles.start.grabPoint.y < characterPosition(FIELD_TAG, offset = quick.middle).y,
+        handles.start.grabPoint.y < getActiveTextFieldNode().characterPosition(offset = quick.middle).y,
         "start handle should sit above the first line, was ${handles.start.grabPoint}",
     )
     assertTrue(
-        handles.end.grabPoint.y > characterPosition(FIELD_TAG, offset = theOnLastLine.max).y,
+        handles.end.grabPoint.y > getActiveTextFieldNode().characterPosition(offset = theOnLastLine.max).y,
         "end handle should sit below the third line, was ${handles.end.grabPoint}",
     )
     if (nativeInput) dropNativeSelection()
@@ -262,13 +263,13 @@ private fun UIKitInstrumentedTest.checkDragStartSelectionHandleAcrossLinesLtr(bt
     val quick = THREE_LINE_TEXT.rangeOf("quick")
     val theOnLastLine = THREE_LINE_TEXT.rangeOf("the", from = SECOND_LINE_BREAK_OFFSET)
 
-    multiTapCharacter(FIELD_TAG, offset = theOnLastLine.middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = theOnLastLine.middle, count = 2)
     waitForIdle()
     val before = selection()
     assertTrue(!before.collapsed, "expected a word selection on the third line, got $before")
 
     // Aimed at a word boundary — word acceleration, see dragSelectionHandle.
-    dragSelectionHandle(TestHandle.SelectionStart, FIELD_TAG, toOffset = quick.min)
+    getActiveTextFieldNode().dragSelectionHandle(TestHandle.SelectionStart, toOffset = quick.min)
     waitForIdle()
 
     val after = selection()
@@ -280,13 +281,13 @@ private fun UIKitInstrumentedTest.checkDragStartSelectionHandleAcrossLinesLtr(bt
 private fun UIKitInstrumentedTest.checkCrossSelectionHandlesLtr(btf: BasicTextFieldType, nativeInput: Boolean) {
     val selection = setUpField(TEXT, btf, nativeInput)
 
-    multiTapCharacter(FIELD_TAG, offset = TEXT.rangeOf("brown").middle, count = 2)
+    getActiveTextFieldNode().multiTapCharacter(offset = TEXT.rangeOf("brown").middle, count = 2)
     waitForIdle()
     val before = selection()
     assertTrue(!before.collapsed, "expected a word selection, got $before")
 
     // Past the other edge, into the first word of the text.
-    dragSelectionHandle(TestHandle.SelectionEnd, FIELD_TAG, toOffset = TEXT.rangeOf("The").middle)
+    getActiveTextFieldNode().dragSelectionHandle(TestHandle.SelectionEnd, toOffset = TEXT.rangeOf("The").middle)
     waitForIdle()
 
     val after = selection()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -989,14 +989,14 @@ internal fun UIKitInstrumentedTest.allSemanticsNodes(): List<SemanticsNode> =
         it.semanticsOwner.getAllSemanticsNodes(mergingEnabled = false)
     }
 
-internal fun UIKitInstrumentedTest.findSemanticsNodeOrNull(tag: String): SemanticsNode? {
+private fun UIKitInstrumentedTest.findSemanticsNodeOrNull(tag: String): SemanticsNode? {
     waitForIdle()
     return allSemanticsNodes().firstOrNull {
         it.config.getOrNull(SemanticsProperties.TestTag) == tag
     }
 }
 
-internal fun UIKitInstrumentedTest.findSemanticsNode(tag: String): SemanticsNode =
+private fun UIKitInstrumentedTest.findSemanticsNode(tag: String): SemanticsNode =
     findSemanticsNodeOrNull(tag) ?: run {
         val knownTags = allSemanticsNodes().mapNotNull { it.config.getOrNull(SemanticsProperties.TestTag) }
         error("No semantics node with testTag \"$tag\". Known tags: $knownTags")

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -27,14 +27,17 @@ import androidx.compose.ui.platform.PlatformRootForTest
 import androidx.compose.ui.scene.ComposeHostingView
 import androidx.compose.ui.scene.ComposeHostingViewController
 import androidx.compose.ui.scene.ComposeLayersViewController
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.utils.TestHandle
 import androidx.compose.ui.test.utils.beginKeyPress
 import androidx.compose.ui.test.utils.beginModifierKeyPress
 import androidx.compose.ui.test.utils.beginPress
 import androidx.compose.ui.test.utils.center
+import androidx.compose.ui.test.utils.dragSelectionHandleImpl
 import androidx.compose.ui.test.utils.findFirstDescendant
 import androidx.compose.ui.test.utils.getTouchesEvent
 import androidx.compose.ui.test.utils.hold
@@ -49,6 +52,7 @@ import androidx.compose.ui.test.utils.rightCenter
 import androidx.compose.ui.test.utils.toCGPoint
 import androidx.compose.ui.test.utils.touchDown
 import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.uikit.ComposeContainerConfiguration
 import androidx.compose.ui.uikit.ComposeUIViewConfiguration
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
@@ -660,6 +664,75 @@ internal class UIKitInstrumentedTest(
             y = frame.top + (frame.bottom - frame.top) * yFraction,
         )
     }
+
+    /**
+     * The semantics node this accessibility node was built from, located by its test tag.
+     */
+    val AccessibilityTestNode.semanticsNode: SemanticsNode
+        get() = findSemanticsNode(
+            identifier ?: error("Accessibility node \"$label\" has no testTag to be found by.")
+        )
+
+    /**
+     * The window-space point (in Dp) of the caret for character [offset] in this text node. Use it
+     * to aim touch gestures at a specific character.
+     *
+     * Caveat — a tap on an iOS field (including the focus-gaining tap) does not leave the caret
+     * mid-word: it snaps to a word boundary, so this point is an aim, not a guaranteed landing offset.
+     * On the Compose path the snap splits at the word's midpoint (first half → word start, second half
+     * → word end; see `determineCursorDesiredOffset`). The native UITextInput path follows the same
+     * idea, but its split point is private to iOS and varies with word length, font and more; treat it
+     * as the Compose path, yet only clearly-leading and clearly-trailing taps are deterministic — a tap
+     * in the start-to-middle zone may snap either way.
+     */
+    fun AccessibilityTestNode.characterPosition(offset: Int): DpOffset {
+        val node = semanticsNode
+        val results = mutableListOf<TextLayoutResult>()
+        node.config.getOrNull(SemanticsActions.GetTextLayoutResult)?.action?.invoke(results)
+        val layout = results.firstOrNull()
+            ?: error("Node with testTag \"$identifier\" has no GetTextLayoutResult action (not a text field?).")
+        val caret = layout.getCursorRect(offset)
+        val origin = node.positionInWindow
+        return with(density) {
+            DpOffset(
+                (origin.x + caret.center.x).toDp(),
+                (origin.y + caret.center.y).toDp(),
+            )
+        }
+    }
+
+    fun AccessibilityTestNode.tapCharacter(offset: Int) {
+        tap(characterPosition(offset))
+    }
+
+    fun AccessibilityTestNode.longPressCharacter(offset: Int) {
+        val touch = touchDown(characterPosition(offset))
+        waitUntil("Selection loupe should appear after long press") {
+            findFirstDescendant { it.isLoupeView } != null
+        }
+        touch.up()
+    }
+
+    /** Taps character [offset] in this text node [count] times in a row: 2 = double tap, 3 = triple. */
+    fun AccessibilityTestNode.multiTapCharacter(offset: Int, count: Int) {
+        require(count >= 1) { "count must be >= 1, was $count" }
+        val point = characterPosition(offset)
+        repeat(count) { i ->
+            if (i > 0) delay(50)
+            tap(point)
+        }
+    }
+
+    /**
+     * Drags the [handle] of the selection in this text node until the edge it holds reaches
+     * character [toOffset]. See [dragSelectionHandleImpl] for which offset the edge actually lands
+     * on.
+     */
+    fun AccessibilityTestNode.dragSelectionHandle(
+        handle: TestHandle,
+        toOffset: Int,
+        duration: Duration = 0.5.seconds,
+    ) = dragSelectionHandleImpl(this, handle, toOffset, duration)
 
     /**
      * Simulates a drag gesture on the screen, moving the touch from its current location to a specified position

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -18,12 +18,19 @@ package androidx.compose.ui.test
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.AccessibilityNotification
 import androidx.compose.ui.platform.FrameChoreographer
 import androidx.compose.ui.platform.InfiniteAnimationPolicy
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformRootForTest
 import androidx.compose.ui.scene.ComposeHostingView
 import androidx.compose.ui.scene.ComposeHostingViewController
 import androidx.compose.ui.scene.ComposeLayersViewController
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getAllSemanticsNodes
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.utils.beginKeyPress
 import androidx.compose.ui.test.utils.beginModifierKeyPress
 import androidx.compose.ui.test.utils.beginPress
@@ -201,7 +208,7 @@ internal fun runUIKitInstrumentedTest(
  * Constructor properties are initialized with the attributes of the main screen and a mock delegate to simulate
  * the application setup.
  */
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, InternalComposeUiApi::class)
 internal class UIKitInstrumentedTest(
     val useHostingView: Boolean
 ) {
@@ -231,6 +238,8 @@ internal class UIKitInstrumentedTest(
 
         val isRunningOnIPad: Boolean get() = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad
     }
+
+    internal val rootForTestRegistry = RootForTestRegistry()
 
     private val screen = UIScreen.mainScreen()
     val density = Density(density = screen.scale.toFloat())
@@ -344,6 +353,7 @@ internal class UIKitInstrumentedTest(
             configuration = configuration,
             content = content,
         ).also {
+            it.rootForTestListener = rootForTestRegistry
             this.hostingView = it
         }
     }
@@ -364,6 +374,7 @@ internal class UIKitInstrumentedTest(
             configuration = configuration,
             content = content,
         ).also {
+            it.rootForTestListener = rootForTestRegistry
             this.hostingViewController = it
         }
     }
@@ -878,6 +889,45 @@ internal fun UIKitInstrumentedTest.findFocusedUITextInput(): UITextInputProtocol
         findFirstResponder(view = it as UIView)
     } as? UITextInputProtocol
 }
+
+/**
+ * A registry to track roots for testing purposes in the context of the platform UI.
+ * Implements the `PlatformContext.RootForTestListener` interface to manage the lifecycle
+ * of roots being created and disposed.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class RootForTestRegistry : PlatformContext.RootForTestListener {
+    private val trackedRoots = mutableSetOf<PlatformRootForTest>()
+
+    val roots: Set<PlatformRootForTest> get() = trackedRoots.toSet()
+
+    override fun onRootForTestCreated(root: PlatformRootForTest) {
+        trackedRoots.add(root)
+    }
+
+    override fun onRootForTestDisposed(root: PlatformRootForTest) {
+        trackedRoots.remove(root)
+    }
+}
+
+@OptIn(InternalComposeUiApi::class)
+internal fun UIKitInstrumentedTest.allSemanticsNodes(): List<SemanticsNode> =
+    rootForTestRegistry.roots.flatMap {
+        it.semanticsOwner.getAllSemanticsNodes(mergingEnabled = false)
+    }
+
+internal fun UIKitInstrumentedTest.findSemanticsNodeOrNull(tag: String): SemanticsNode? {
+    waitForIdle()
+    return allSemanticsNodes().firstOrNull {
+        it.config.getOrNull(SemanticsProperties.TestTag) == tag
+    }
+}
+
+internal fun UIKitInstrumentedTest.findSemanticsNode(tag: String): SemanticsNode =
+    findSemanticsNodeOrNull(tag) ?: run {
+        val knownTags = allSemanticsNodes().mapNotNull { it.config.getOrNull(SemanticsProperties.TestTag) }
+        error("No semantics node with testTag \"$tag\". Known tags: $knownTags")
+    }
 
 internal fun ComposeHostingViewController.waitForIdle() {
     UIKitInstrumentedTest.waitUntil { !this.hasInvalidations() }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/SelectionHandle+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/SelectionHandle+Utils.kt
@@ -20,10 +20,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.AccessibilityTestNode
 import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.allSemanticsNodes
 import androidx.compose.ui.test.findFocusedUITextInput
-import androidx.compose.ui.test.findSemanticsNode
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
@@ -180,13 +180,14 @@ private fun UIView.descendants(): List<UIView> =
     subviews.flatMap { val view = it as UIView; listOf(view) + view.descendants() }
 
 /**
- * Drags the [handle] selection handle to character [toOffset] of the text field tagged [tag].
+ * Drags the [handle] selection handle to character [toOffset] of the text [node]. Called through
+ * `AccessibilityTestNode.dragSelectionHandle`.
  *
  * The handle is grabbed at its [grabPoint][TestSelectionHandle.grabPoint] — the popup center for a
  * Compose handle, or the lollipop blob for a native one — and from there the two paths differ.
  *
  * A Compose drag moves the grabbed edge by how far the finger travelled rather than to where it
- * stopped, so the finger follows the caret-to-caret vector (see [characterPosition]), stretched by
+ * stopped, so the finger follows the caret-to-caret vector (see `characterPosition`), stretched by
  * [clearingLineBoundary].
  *
  * A native handle cannot be driven that way — UIKit moves it to the next line only after the finger
@@ -198,17 +199,17 @@ private fun UIView.descendants(): List<UIView> =
  * and within a line whenever the edge already sits on a boundary — so an offset inside a word is
  * reachable only while shrinking. UIKit does not snap and lands on the requested offset.
  */
-internal fun UIKitInstrumentedTest.dragSelectionHandle(
+internal fun UIKitInstrumentedTest.dragSelectionHandleImpl(
+    node: AccessibilityTestNode,
     handle: TestHandle,
-    tag: String,
     toOffset: Int,
-    duration: Duration = 0.5.seconds,
+    duration: Duration,
 ) {
     val isNative = composeSelectionHandles() == null
     if (isNative) delay(NativeTapSequenceWindowMillis)
 
-    val target = characterPosition(tag, toOffset)
-    val selection = selectionRange(tag)
+    val target = node.characterPosition(toOffset)
+    val selection = selectionRange(node)
     val grabPoint = selectionHandle(handle).grabPoint
     val touch = touchDown(grabPoint)
     var failure: String? = null
@@ -220,7 +221,7 @@ internal fun UIKitInstrumentedTest.dragSelectionHandle(
     } else if (isNative) {
         failure = stepHandleTo(touch, from = grabPoint, aim = target)
     } else {
-        val vector = (target - characterPosition(tag, selection.edgeOf(handle))).clearingLineBoundary()
+        val vector = (target - node.characterPosition(selection.edgeOf(handle))).clearingLineBoundary()
         touch.dragBy(offset = vector, duration = duration)
         waitForIdle()
     }
@@ -325,9 +326,8 @@ private fun Float.clampedToStep(): Float = coerceIn(-NativeHandleDrag.Step, Nati
 /** Makes the vertical travel 1.5x longer, so touch slop does not stop the drag before the next line. */
 private fun DpOffset.clearingLineBoundary(): DpOffset = DpOffset(x, y * 1.5f)
 
-/** The selection published by the node tagged [tag], or null if it publishes none. */
-private fun UIKitInstrumentedTest.selectionRange(tag: String): TextRange? =
-    findSemanticsNode(tag).config.getOrNull(SemanticsProperties.TextSelectionRange)
+private fun UIKitInstrumentedTest.selectionRange(node: AccessibilityTestNode): TextRange? =
+    node.semanticsNode.config.getOrNull(SemanticsProperties.TextSelectionRange)
 
 private fun TextRange.edgeOf(handle: TestHandle): Int =
     if (handle == TestHandle.SelectionStart) start else end

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/SelectionHandle+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/SelectionHandle+Utils.kt
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.utils
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.allSemanticsNodes
+import androidx.compose.ui.test.findFocusedUITextInput
+import androidx.compose.ui.test.findSemanticsNode
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import kotlin.math.abs
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import platform.UIKit.UITouch
+import platform.UIKit.UIView
+
+// Mirror's foundation `Handle`, except Cursor (no-op on iOS)
+internal enum class TestHandle { SelectionStart, SelectionEnd }
+// Mirror's foundation `SelectionHandleAnchor`, except Middle (no-op on iOS)
+internal enum class TestSelectionHandleAnchor { Left, Right }
+
+/**
+ * The contents of a selection handle, either parsed from foundation's internal `SelectionHandleInfo`
+ * (Compose-rendered handles) or read off the private UIKit handle views of a native text field.
+ *
+ * @property position The point the handle is anchored to. For Compose handles it is read verbatim
+ *   from foundation (relative to the selectable content; may be [Offset.Unspecified]); for native
+ *   handles it is the selection edge in window-space points.
+ */
+internal data class TestSelectionHandleInfo(
+    val handle: TestHandle,
+    val position: Offset,
+    val anchor: TestSelectionHandleAnchor,
+    val visible: Boolean,
+)
+
+/**
+ * A selection handle located for a test.
+ *
+ * @property grabPoint The window-space point (Dp) to aim a touch at to grab this handle: the center
+ *   of the popup for Compose handles, or the "blob" of the lollipop for native ones.
+ * @property node The semantics node backing a Compose-rendered handle popup, or null for a native
+ *   iOS handle (which has no Compose semantics).
+ */
+internal class TestSelectionHandle(
+    val info: TestSelectionHandleInfo,
+    val grabPoint: DpOffset,
+    val node: SemanticsNode? = null,
+)
+
+internal class SelectionHandlePair(
+    val start: TestSelectionHandle,
+    val end: TestSelectionHandle,
+)
+
+private const val SelectionHandleInfoKeyName = "SelectionHandleInfo"
+
+/**
+ * How long UIKit keeps a finished tap open for one more tap of the same sequence. Touches sent
+ * within this window continue the sequence instead of starting a new gesture.
+ * 500ms should be enough
+ * TODO: CMP-10641
+ */
+private const val NativeTapSequenceWindowMillis = 500L
+
+private val offsetRegex = Regex("""Offset\((-?[\d.]+),\s*(-?[\d.]+)\)""")
+
+/**
+ * Parses the `toString()` of foundation's internal `SelectionHandleInfo` data class, e.g.
+ * `SelectionHandleInfo(handle=SelectionStart, position=Offset(12.3, 45.6), anchor=Left, visible=true)`.
+ */
+internal fun parseSelectionHandleInfo(raw: String): TestSelectionHandleInfo {
+    fun field(name: String): String =
+        Regex("""$name=(\w+)""").find(raw)?.groupValues?.get(1)
+            ?: error("Could not parse '$name' from SelectionHandleInfo: $raw")
+
+    val position = offsetRegex.find(raw)?.let { m ->
+        Offset(m.groupValues[1].toFloat(), m.groupValues[2].toFloat())
+    } ?: Offset.Unspecified
+
+    return TestSelectionHandleInfo(
+        handle = TestHandle.valueOf(field("handle")),
+        position = position,
+        anchor = TestSelectionHandleAnchor.valueOf(field("anchor")),
+        visible = field("visible").toBooleanStrict(),
+    )
+}
+
+internal fun UIKitInstrumentedTest.selectionHandles(): SelectionHandlePair? =
+    composeSelectionHandles() ?: nativeSelectionHandles()
+
+private fun UIKitInstrumentedTest.composeSelectionHandles(): SelectionHandlePair? {
+    waitForIdle()
+    val handles = allSemanticsNodes().mapNotNull { node ->
+        val raw = node.config.firstOrNull { it.key.name == SelectionHandleInfoKeyName }?.value
+            ?: return@mapNotNull null
+        val info = parseSelectionHandleInfo(raw.toString())
+        TestSelectionHandle(info = info, grabPoint = composeGrabPoint(node), node = node)
+    }
+    val start = handles.singleOrNull { it.info.handle == TestHandle.SelectionStart } ?: return null
+    val end = handles.singleOrNull { it.info.handle == TestHandle.SelectionEnd } ?: return null
+    return SelectionHandlePair(start, end)
+}
+
+/** The center of a Compose handle popup, in window-space Dp. */
+private fun UIKitInstrumentedTest.composeGrabPoint(node: SemanticsNode): DpOffset {
+    val bounds = node.boundsInWindow
+    return with(density) { DpOffset(bounds.center.x.toDp(), bounds.center.y.toDp()) }
+}
+
+/**
+ * Selection handles drawn by UIKit for a native text field, read off the private
+ * `_UITextSelectionLollipopView` views under the focused `UITextInput`. UIKit shows both of them only
+ * for a ranged selection: for a caret they stay in the view tree but hidden, so this returns null.
+ */
+private fun UIKitInstrumentedTest.nativeSelectionHandles(): SelectionHandlePair? {
+    waitForIdle()
+    val handles = nativeHandleViews().mapNotNull { nativeHandle(it) }
+    val start = handles.singleOrNull { it.info.handle == TestHandle.SelectionStart } ?: return null
+    val end = handles.singleOrNull { it.info.handle == TestHandle.SelectionEnd } ?: return null
+    return SelectionHandlePair(start, end)
+}
+
+private fun UIKitInstrumentedTest.nativeHandleViews(): List<UIView> =
+    (findFocusedUITextInput() as? UIView)?.descendants()
+        ?.filter { it.isNativeSelectionHandle && !it.hidden && it.alpha > 0.0 }
+        .orEmpty()
+
+/** The stem covering the line at the selection edge and the blob to grab, or null for other views. */
+private fun UIView.nativeHandleParts(): Pair<DpRect, DpRect>? {
+    val parts = subviews.map { (it as UIView).dpRectInWindow() }
+    if (parts.size != 2) return null
+    return parts.minBy { it.width } to parts.maxBy { it.width }
+}
+
+/**
+ * Builds a native [TestSelectionHandle] out of a handle view.
+ */
+private fun nativeHandle(handleView: UIView): TestSelectionHandle? {
+    val (stem, blob) = handleView.nativeHandleParts() ?: return null
+
+    val leading = blob.center().y < stem.center().y
+    val edge = if (leading) stem.topCenter() else stem.bottomCenter()
+    return TestSelectionHandle(
+        info = TestSelectionHandleInfo(
+            handle = if (leading) TestHandle.SelectionStart else TestHandle.SelectionEnd,
+            position = Offset(edge.x.value, edge.y.value),
+            anchor = if (leading) TestSelectionHandleAnchor.Left else TestSelectionHandleAnchor.Right,
+            visible = true,
+        ),
+        grabPoint = blob.center(),
+    )
+}
+
+private val UIView.isNativeSelectionHandle: Boolean
+    get() = objcClassName(this)?.contains("_UITextSelectionLollipopView") == true
+
+private fun UIView.descendants(): List<UIView> =
+    subviews.flatMap { val view = it as UIView; listOf(view) + view.descendants() }
+
+/**
+ * Drags the [handle] selection handle to character [toOffset] of the text field tagged [tag].
+ *
+ * The handle is grabbed at its [grabPoint][TestSelectionHandle.grabPoint] — the popup center for a
+ * Compose handle, or the lollipop blob for a native one — and from there the two paths differ.
+ *
+ * A Compose drag moves the grabbed edge by how far the finger travelled rather than to where it
+ * stopped, so the finger follows the caret-to-caret vector (see [characterPosition]), stretched by
+ * [clearingLineBoundary].
+ *
+ * A native handle cannot be driven that way — UIKit moves it to the next line only after the finger
+ * has travelled far past that line, and publishes no selection until the touch is lifted, so there
+ * is nothing to correct against. It is stepped towards its destination instead, see [stepHandleTo].
+ *
+ * The edge does not always land on [toOffset]. A Compose drag that expands the selection snaps to
+ * word boundaries (`SelectionAdjustment.CharacterWithWordAccelerate`) — always when it changes line,
+ * and within a line whenever the edge already sits on a boundary — so an offset inside a word is
+ * reachable only while shrinking. UIKit does not snap and lands on the requested offset.
+ */
+internal fun UIKitInstrumentedTest.dragSelectionHandle(
+    handle: TestHandle,
+    tag: String,
+    toOffset: Int,
+    duration: Duration = 0.5.seconds,
+) {
+    val isNative = composeSelectionHandles() == null
+    if (isNative) delay(NativeTapSequenceWindowMillis)
+
+    val target = characterPosition(tag, toOffset)
+    val selection = selectionRange(tag)
+    val grabPoint = selectionHandle(handle).grabPoint
+    val touch = touchDown(grabPoint)
+    var failure: String? = null
+
+    if (selection == null) {
+        // A SelectionContainer publishes no selection to measure against, so a single aimed drag is
+        // all there is and the edge lands only approximately.
+        touch.dragTo(x = target.x, y = target.y, duration = duration)
+    } else if (isNative) {
+        failure = stepHandleTo(touch, from = grabPoint, aim = target)
+    } else {
+        val vector = (target - characterPosition(tag, selection.edgeOf(handle))).clearingLineBoundary()
+        touch.dragBy(offset = vector, duration = duration)
+        waitForIdle()
+    }
+
+    touch.up()
+    waitForIdle()
+
+    // Lift the touch before failing, so one stuck drag does not leave a finger down for the tests
+    // that follow.
+    failure?.let { error(it) }
+
+    if (isNative) {
+        // TODO: CMP-10641
+        waitUntil("Selection loupe should hide after the drag") {
+            findFirstDescendant { it.isLoupeView } == null
+        }
+    }
+}
+
+/**
+ * Walks [touch] from [from] in small steps until the dragged selection edge reaches [aim]. Returns
+ * null once it does, or why it did not.
+ *
+ * UIKit holds a dragged handle on its line until the finger has travelled far past the next one, by
+ * an amount it never publishes, so the travel is discovered rather than computed: every step re-reads
+ * where the edge actually is and aims the next one at what is left. The handle views are also the
+ * only feedback there is, the selection being published only once the touch is lifted.
+ */
+private fun UIKitInstrumentedTest.stepHandleTo(
+    touch: UITouch,
+    from: DpOffset,
+    aim: DpOffset,
+): String? {
+    var finger = from
+    var previous: DpOffset? = null
+    var motionless = 0
+
+    repeat(NativeHandleDrag.MaxSteps) {
+        val edge = draggedSelectionEdge(underPosition = finger)
+            ?: return "Lost the native handle at $finger."
+        val dx = aim.x.value - edge.x.value
+        val dy = aim.y.value - edge.y.value
+        // Vertical first and alone: UIKit obeys horizontal movement at once while still holding the
+        // line change back, so a diagonal step would slide the handle far along its current line.
+        val move = when {
+            abs(dy) > NativeHandleDrag.Tolerance -> DpOffset(0.dp, dy.clampedToStep().dp)
+            abs(dx) > NativeHandleDrag.Tolerance -> DpOffset(dx.clampedToStep().dp, 0.dp)
+            else -> return null
+        }
+
+        // Standing still is normal while UIKit holds a line change back; standing still for longer
+        // than that hysteresis means the edge is against something and will not move at all.
+        val stillness = previous?.let { abs(edge.x.value - it.x.value) + abs(edge.y.value - it.y.value) }
+        motionless = if (stillness != null && stillness <= NativeHandleDrag.Tolerance) motionless + 1 else 0
+        if (motionless > NativeHandleDrag.MotionlessSteps) {
+            return "Native selection edge stuck at $edge, aiming for $aim."
+        }
+        previous = edge
+
+        touch.dragBy(offset = move, duration = NativeHandleDrag.StepDuration)
+        finger += move
+    }
+    return "Native selection edge did not reach $aim in ${NativeHandleDrag.MaxSteps} steps."
+}
+
+/**
+ * The line center at the selection edge of the handle whose blob is closest to [underPosition] — the
+ * one the finger holds. Handles are told apart by side, not by role, and a drag past the other one
+ * swaps the sides, so the finger is what to follow.
+ */
+private fun UIKitInstrumentedTest.draggedSelectionEdge(underPosition: DpOffset): DpOffset? {
+    waitForIdle()
+    return nativeHandleViews()
+        .mapNotNull { it.nativeHandleParts() }
+        .minByOrNull { (_, blob) ->
+            val center = blob.center()
+            abs(center.x.value - underPosition.x.value) + abs(center.y.value - underPosition.y.value)
+        }
+        ?.first?.center()
+}
+
+/** The shape of a native handle drag, measured against the simulator rather than derived. */
+private object NativeHandleDrag {
+    /** Finger travel per step, short enough to catch the line snap within one step. */
+    const val Step = 4f
+
+    /** How close to the aim counts as arrived, kept under half a character. */
+    const val Tolerance = 1.5f
+
+    /** Upper bound on the loop, not a working count: the drags in the tests settle in about 25. */
+    const val MaxSteps = 80
+
+    /** Steps the edge may stand still for, above the ~14 that a downward line change costs. */
+    const val MotionlessSteps = 20
+
+    /** Long enough for UIKit to move the handle before the next step re-reads it. */
+    val StepDuration = 0.05.seconds
+}
+
+private fun Float.clampedToStep(): Float = coerceIn(-NativeHandleDrag.Step, NativeHandleDrag.Step)
+
+/** Makes the vertical travel 1.5x longer, so touch slop does not stop the drag before the next line. */
+private fun DpOffset.clearingLineBoundary(): DpOffset = DpOffset(x, y * 1.5f)
+
+/** The selection published by the node tagged [tag], or null if it publishes none. */
+private fun UIKitInstrumentedTest.selectionRange(tag: String): TextRange? =
+    findSemanticsNode(tag).config.getOrNull(SemanticsProperties.TextSelectionRange)
+
+private fun TextRange.edgeOf(handle: TestHandle): Int =
+    if (handle == TestHandle.SelectionStart) start else end
+
+private fun UIKitInstrumentedTest.selectionHandle(handle: TestHandle): TestSelectionHandle =
+    when (handle) {
+        TestHandle.SelectionStart -> selectionHandles()?.start
+        TestHandle.SelectionEnd -> selectionHandles()?.end
+    } ?: error("No $handle selection handle present.")

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/TextField+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/TextField+Utils.kt
@@ -16,20 +16,22 @@
 
 package androidx.compose.ui.test.utils
 
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.UIKitInstrumentedTest
-import kotlinx.cinterop.BetaInteropApi
-import platform.Foundation.NSStringFromClass
+import androidx.compose.ui.test.findSemanticsNode
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.DpOffset
 import platform.UIKit.UIView
 import platform.UIKit.UIWindow
+
+internal enum class BasicTextFieldType { V1, V2 }
 
 internal val loupeClassNames = listOf(
     "_UITextMagnifiedLoupeView",
     "_UITextLoupeView",
     "LoupeView"
 )
-
-@OptIn(BetaInteropApi::class)
-private fun objcClassName(view: UIView): String? = view.`class`()?.let { NSStringFromClass(it) }
 
 internal val UIView.isLoupeView: Boolean get() {
     val name = objcClassName(this) ?: return false
@@ -54,4 +56,59 @@ internal fun UIKitInstrumentedTest.findFirstDescendant(predicate: (UIView) -> Bo
         if (hit != null) return hit
     }
     return null
+}
+
+/**
+ * The window-space point (in Dp) of the caret for character [offset] in the text field tagged
+ * [tag]. Use it to aim touch gestures at a specific character.
+ *
+ * Caveat — a tap on an iOS field (including the focus-gaining tap) does not leave the caret
+ * mid-word: it snaps to a word boundary, so this point is an aim, not a guaranteed landing offset.
+ * On the Compose path the snap splits at the word's midpoint (first half → word start, second half
+ * → word end; see `determineCursorDesiredOffset`). The native UITextInput path follows the same
+ * idea, but its split point is private to iOS and varies with word length, font and more; treat it
+ * as the Compose path, yet only clearly-leading and clearly-trailing taps are deterministic — a tap
+ * in the start-to-middle zone may snap either way.
+ */
+internal fun UIKitInstrumentedTest.characterPosition(tag: String, offset: Int): DpOffset {
+    val node = findSemanticsNode(tag)
+    val results = mutableListOf<TextLayoutResult>()
+    node.config.getOrNull(SemanticsActions.GetTextLayoutResult)?.action?.invoke(results)
+    val layout = results.firstOrNull()
+        ?: error("Node with testTag \"$tag\" has no GetTextLayoutResult action (not a text field?).")
+    val caret = layout.getCursorRect(offset)
+    val origin = node.positionInWindow
+    return with(density) {
+        DpOffset(
+            (origin.x + caret.center.x).toDp(),
+            (origin.y + caret.center.y).toDp(),
+        )
+    }
+}
+
+/** Taps character [offset] in the text field tagged [tag]. */
+internal fun UIKitInstrumentedTest.tapCharacter(tag: String, offset: Int) {
+    tap(characterPosition(tag, offset))
+}
+
+/** Long-presses character [offset] in the text field tagged [tag]. */
+internal fun UIKitInstrumentedTest.longPressCharacter(tag: String, offset: Int) {
+    val touch = touchDown(characterPosition(tag, offset))
+    waitUntil("Selection loupe should appear after long press") {
+        findFirstDescendant { it.isLoupeView } != null
+    }
+    touch.up()
+}
+
+/**
+ * Taps character [offset] in the text field tagged [tag] [count] times in a row (e.g. 2 = double
+ * tap to select a word, 3 = triple tap to select all). [count] must be >= 1.
+ */
+internal fun UIKitInstrumentedTest.multiTapCharacter(tag: String, offset: Int, count: Int) {
+    require(count >= 1) { "count must be >= 1, was $count" }
+    val point = characterPosition(tag, offset)
+    repeat(count) { i ->
+        if (i > 0) delay(50)
+        tap(point)
+    }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/TextField+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/TextField+Utils.kt
@@ -16,12 +16,7 @@
 
 package androidx.compose.ui.test.utils
 
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.UIKitInstrumentedTest
-import androidx.compose.ui.test.findSemanticsNode
-import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.unit.DpOffset
 import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 
@@ -56,59 +51,4 @@ internal fun UIKitInstrumentedTest.findFirstDescendant(predicate: (UIView) -> Bo
         if (hit != null) return hit
     }
     return null
-}
-
-/**
- * The window-space point (in Dp) of the caret for character [offset] in the text field tagged
- * [tag]. Use it to aim touch gestures at a specific character.
- *
- * Caveat — a tap on an iOS field (including the focus-gaining tap) does not leave the caret
- * mid-word: it snaps to a word boundary, so this point is an aim, not a guaranteed landing offset.
- * On the Compose path the snap splits at the word's midpoint (first half → word start, second half
- * → word end; see `determineCursorDesiredOffset`). The native UITextInput path follows the same
- * idea, but its split point is private to iOS and varies with word length, font and more; treat it
- * as the Compose path, yet only clearly-leading and clearly-trailing taps are deterministic — a tap
- * in the start-to-middle zone may snap either way.
- */
-internal fun UIKitInstrumentedTest.characterPosition(tag: String, offset: Int): DpOffset {
-    val node = findSemanticsNode(tag)
-    val results = mutableListOf<TextLayoutResult>()
-    node.config.getOrNull(SemanticsActions.GetTextLayoutResult)?.action?.invoke(results)
-    val layout = results.firstOrNull()
-        ?: error("Node with testTag \"$tag\" has no GetTextLayoutResult action (not a text field?).")
-    val caret = layout.getCursorRect(offset)
-    val origin = node.positionInWindow
-    return with(density) {
-        DpOffset(
-            (origin.x + caret.center.x).toDp(),
-            (origin.y + caret.center.y).toDp(),
-        )
-    }
-}
-
-/** Taps character [offset] in the text field tagged [tag]. */
-internal fun UIKitInstrumentedTest.tapCharacter(tag: String, offset: Int) {
-    tap(characterPosition(tag, offset))
-}
-
-/** Long-presses character [offset] in the text field tagged [tag]. */
-internal fun UIKitInstrumentedTest.longPressCharacter(tag: String, offset: Int) {
-    val touch = touchDown(characterPosition(tag, offset))
-    waitUntil("Selection loupe should appear after long press") {
-        findFirstDescendant { it.isLoupeView } != null
-    }
-    touch.up()
-}
-
-/**
- * Taps character [offset] in the text field tagged [tag] [count] times in a row (e.g. 2 = double
- * tap to select a word, 3 = triple tap to select all). [count] must be >= 1.
- */
-internal fun UIKitInstrumentedTest.multiTapCharacter(tag: String, offset: Int, count: Int) {
-    require(count >= 1) { "count must be >= 1, was $count" }
-    val point = characterPosition(tag, offset)
-    repeat(count) { i ->
-        if (i > 0) delay(50)
-        tap(point)
-    }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIVIew+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIVIew+Utils.kt
@@ -21,18 +21,24 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.unit.toCGSize
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.size
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.usePinned
 import org.jetbrains.skia.Image
+import platform.Foundation.NSStringFromClass
 import platform.UIKit.UIGraphicsBeginImageContextWithOptions
 import platform.UIKit.UIGraphicsEndImageContext
 import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
 import platform.UIKit.UIImagePNGRepresentation
 import platform.UIKit.UIScreen
 import platform.UIKit.UIView
+import platform.darwin.NSObject
 import platform.posix.memcpy
+
+@OptIn(BetaInteropApi::class)
+internal fun objcClassName(nsObject: NSObject): String? = nsObject.`class`()?.let { NSStringFromClass(it) }
 
 @OptIn(ExperimentalForeignApi::class)
 internal fun UIView.captureToImage(): ImageBitmap {


### PR DESCRIPTION
- Added `PlatformContext.RootForTestListener` propagation to the iOS layer
- Added test utilities for caret placement via tap and long press, as well as for finding and dragging selection handles for both BasicTextField implementations, including NITI variants
- Added example tests using the new API
- Rewrote the multitap tests to use the new API

### New test API (internal)

#### test/utils/TextField+Utils.kt 
provides character positioning and tap utilities:

- `tapCharacter(tag, offset)`
- `longPressCharacter(tag, offset)`
- `multiTapCharacter(tag, offset, count)` (for double/triple tap)

All of these are based on `characterPosition`, which reads from `TextLayoutResult` via `RootForTestListener`

#### test/utils/SelectionHandle+Utils.kt 
provides utilities for selection handles:

- `selectionHandles()` returns a `SelectionHandlePair`

- `dragSelectionHandle(handle, tag, toOffset, duration = 0.5s)` provides a single entry point for dragging a handle in Compose TextField, Native TextField, and SelectionContainer

- `SelectionHandlePair` is a helper data class that stores the start and end TestSelectionHandle in deterministic order

- `TestSelectionHandle` is a data class containing the information required by tests, parsed from Compose SelectionHandle and iOS native SelectionHandle (`_UITextSelectionLollipopView`)

Fixes: 
[CMP-10037](https://youtrack.jetbrains.com/issue/CMP-10037) Extend iOSInstrumentedTest API for TextField testing
[CMP-10648](https://youtrack.jetbrains.com/issue/CMP-10648) [iOS] Instrumented Tests: native selection handle has a positional hysteresis when dragged downwards

## Release Notes
N/A