### PR TITLE
Document behavior of AlignedToScreenAvailableBounds and allow actually centering in the screen

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/v2/WindowGeometryProviders.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/v2/WindowGeometryProviders.desktop.kt
@@ -339,7 +339,7 @@ fun interface WindowPositionProvider {
         /**
          * Centers the window on the screen.
          */
-        val CenteredOnScreen = CenteredOnScreen()
+        val CenteredInScreenBounds = CenteredInScreenBounds()
 
         /**
          * Centers the window within its parent window.
@@ -376,7 +376,7 @@ fun interface WindowPositionProvider {
          *
          * @param offset An additional absolute offset added after aligning.
          */
-        fun CenteredOnScreen(
+        fun CenteredInScreenBounds(
             offset: DpOffset = DpOffset.Zero,
         ): WindowPositionProvider = WindowPositionProvider { size ->
             val bounds = windowMetrics.screen.bounds

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/v2/WindowGeometryProviders.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/v2/WindowGeometryProviders.desktop.kt
@@ -337,9 +337,9 @@ fun interface WindowPositionProvider {
         val Current = WindowPositionProvider { windowMetrics.bounds.topLeft }
 
         /**
-         * Centers the window within the screen.
+         * Centers the window on the screen.
          */
-        val CenteredOnScreen = AlignedToScreen(alignment = Alignment.Center)
+        val CenteredOnScreen = CenteredOnScreen()
 
         /**
          * Centers the window within its parent window.
@@ -368,12 +368,38 @@ fun interface WindowPositionProvider {
         fun Absolute(x: Dp, y: Dp): WindowPositionProvider = Absolute(DpOffset(x, y))
 
         /**
-         * Aligns the window within the screen according to [alignment] and [offset].
+         * Centers the window on the screen.
+         *
+         * Note that unlike [AlignedToScreenAvailableBounds], this position provider does not take
+         * into account the screen's insets. If the resulting position overlaps the insets, the
+         * operating system's window manager may move the window to avoid the insets.
+         *
+         * @param offset An additional absolute offset added after aligning.
+         */
+        fun CenteredOnScreen(
+            offset: DpOffset = DpOffset.Zero,
+        ): WindowPositionProvider = WindowPositionProvider { size ->
+            val bounds = windowMetrics.screen.bounds
+
+            val position = Alignment.Center.align(
+                size = size.roundToIntSize(),
+                space = bounds.size.roundToIntSize(),
+                layoutDirection = LayoutDirection.Ltr
+            )
+            DpOffset(
+                x = bounds.left + position.x.dp + offset.x,
+                y = bounds.top + position.y.dp + offset.y
+            )
+        }
+
+        /**
+         * Aligns the window within the screen's available bounds (excluding [Screen.insets])
+         * according to [alignment] and [offset].
          *
          * @param alignment The alignment of the window relative to the screen.
          * @param offset An additional absolute offset added after aligning.
          */
-        fun AlignedToScreen(
+        fun AlignedToScreenAvailableBounds(
             alignment: Alignment,
             offset: DpOffset = DpOffset.Zero,
         ): WindowPositionProvider = WindowPositionProvider { size ->

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
@@ -257,7 +257,7 @@ class DialogWindowV2StateTest {
         val state = DialogState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(200.dp, 200.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds
             )
         )
         lateinit var dialog: ComposeDialog
@@ -281,7 +281,7 @@ class DialogWindowV2StateTest {
         val windowState = WindowState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(400.dp, 400.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds
             )
         )
         lateinit var window: ComposeWindow

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
@@ -250,7 +250,7 @@ class WindowV2StateTest {
         val state = WindowState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(200.dp, 200.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds
             )
         )
         lateinit var window: ComposeWindow
@@ -551,7 +551,7 @@ class WindowV2StateTest {
         val state = WindowState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(200.dp, 200.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen,
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds,
             ),
             initialPlacement = WindowPlacement.Maximized,
         )
@@ -575,7 +575,7 @@ class WindowV2StateTest {
         val state = WindowState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(200.dp, 200.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen,
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds,
             ),
             initiallyMinimized = true
         )
@@ -599,7 +599,7 @@ class WindowV2StateTest {
         val state = WindowState(
             initialBoundsProvider = WindowBoundsProvider(
                 sizeProvider = WindowSizeProvider.Fixed(200.dp, 200.dp),
-                positionProvider = WindowPositionProvider.CenteredOnScreen,
+                positionProvider = WindowPositionProvider.CenteredInScreenBounds,
             ),
             initialPlacement = WindowPlacement.Fullscreen,
         )


### PR DESCRIPTION
Document behavior of `AlignedToScreenAvailableBounds` and add a `WindowPositionProvider` that actually centers in the screen.

Fixes https://youtrack.jetbrains.com/issue/CMP-10643/WindowPositionProvider.AlignedToScreen-positions-in-available-bounds

## Testing
Tested manually

## Release Notes
### Features - Desktop
- Added a new `WindowPositionProvider.CenteredInScreenBounds(DpOffset)` function that centers on the screen.
### Migration Notes - Desktop
- Renamed `AlignedToScreen` to `AlignedToScreenAvailableBounds` and `CenteredOnScreen` to `CenteredInScreenBounds` to clarify their behavior.  `CenteredInScreenBounds` now actually centers on the screen (ignoring insets)
