### PR TITLE
Update iOS pop transition methods to respect custom transitions

### DIFF
--- a/navigation/navigation-compose/src/iosMain/kotlin/androidx/navigation/compose/DefaultNavTransitions.ios.kt
+++ b/navigation/navigation-compose/src/iosMain/kotlin/androidx/navigation/compose/DefaultNavTransitions.ios.kt
@@ -107,6 +107,10 @@ public actual object DefaultNavTransitions {
         (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
         null
 
+    // ios specific: by default the enter and the popEnter transitions are different.
+    // BUT when user overrides only the default enter transition in NavHost function
+    // then return the new enter transition as default popEnterTransition.
+    // This is a NavHost API expectation
     public actual fun popEnterTransition(
         enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
     ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
@@ -130,6 +134,10 @@ public actual object DefaultNavTransitions {
         }
     }
 
+    // ios specific: by default the exit and the popExit transitions are different.
+    // BUT when user overrides only the default exit transition in NavHost function
+    // then return the new exit transition as default popExitTransition.
+    // This is a NavHost API expectation
     public actual fun popExitTransition(
         exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
     ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {

--- a/navigation/navigation-compose/src/iosMain/kotlin/androidx/navigation/compose/DefaultNavTransitions.ios.kt
+++ b/navigation/navigation-compose/src/iosMain/kotlin/androidx/navigation/compose/DefaultNavTransitions.ios.kt
@@ -109,31 +109,41 @@ public actual object DefaultNavTransitions {
 
     public actual fun popEnterTransition(
         enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
-    ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
-        slideIntoContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.End,
-            initialOffset = { it / 4 },
-            animationSpec = tween(
-                DEFAULT_TRANSITION_DURATION_MILLISECOND,
-                easing = IosTransitionEasing
-            ),
-        ) + unveilIn(
-            animationSpec = tween(
-                DEFAULT_TRANSITION_DURATION_MILLISECOND,
-                easing = IosTransitionEasing
+    ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
+        if (enterTransition !== DefaultNavTransitions.enterTransition) {
+            return enterTransition
+        }
+        return {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                initialOffset = { it / 4 },
+                animationSpec = tween(
+                    DEFAULT_TRANSITION_DURATION_MILLISECOND,
+                    easing = IosTransitionEasing
+                ),
+            ) + unveilIn(
+                animationSpec = tween(
+                    DEFAULT_TRANSITION_DURATION_MILLISECOND,
+                    easing = IosTransitionEasing
+                )
             )
-        )
+        }
     }
 
     public actual fun popExitTransition(
         exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
-    ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
-        slideOutOfContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.End,
-            animationSpec = tween(
-                DEFAULT_TRANSITION_DURATION_MILLISECOND,
-                easing = IosTransitionEasing
-            ),
-        )
+    ): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {
+        if (exitTransition !== DefaultNavTransitions.exitTransition) {
+            return exitTransition
+        }
+        return {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(
+                    DEFAULT_TRANSITION_DURATION_MILLISECOND,
+                    easing = IosTransitionEasing
+                ),
+            )
+        }
     }
 }


### PR DESCRIPTION
Use custom enter/exit animations on iOS when the defaults are changed

Fixes https://youtrack.jetbrains.com/issue/CMP-10639

## Release Notes
### Fixes - Navigation
- Fix pop animations on iOS when custom enter/exit animations are set