### PR TITLE
Web: Fix pointer event handling to preserve sub-pixel movement on high-DPI screens

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -1029,8 +1029,8 @@ private fun PointerEvent.toScenePointerEvent(
     val event = this
     val type = event.getPointerEventType()
     val position = Offset(
-        x = (event.clientX - containerOffset.x) * density.density,
-        y = (event.clientY - containerOffset.y) * density.density
+        x = (clientXOf(event).toFloat() - containerOffset.x) * density.density,
+        y = (clientYOf(event).toFloat() - containerOffset.y) * density.density
     )
     return ComposeScenePointer(
         id = PointerId(event.pointerId.toLong()),
@@ -1088,6 +1088,19 @@ private fun checkViewportFitCover(): Unit = js(
         }
     })()"""
 )
+
+// `MouseEvent.clientX`/`clientY` are declared as `Int` in the Kotlin DOM bindings, while the CSSOM
+// View spec defines them as `double`. Going through the typed accessors truncates the coordinates to
+// whole CSS pixels, which on a high-DPI screen quantizes every pointer position to `devicePixelRatio`
+// Compose pixels and turns slow, sub-pixel movement into a stream of zero-delta moves. Compose reads
+// a move with a zero position delta as "no one is handling this gesture", so an outer scrollable can
+// take an ongoing drag away from an inner one - see https://youtrack.jetbrains.com/issue/CMP-10575.
+// Read the raw values instead to keep the fractional part.
+// language=js
+private fun clientXOf(event: PointerEvent): Double = js("event.clientX")
+
+// language=js
+private fun clientYOf(event: PointerEvent): Double = js("event.clientY")
 
 // strings checks are faster on a JS side
 // language=js

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/GesturesTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/GesturesTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import kotlin.test.Test
@@ -234,6 +235,38 @@ class GesturesTest : OnCanvasTests {
         assertEquals(1, clicksCount) // still 1 — click was cancelled
     }
 
+    @Test
+    fun subPixelMovesAreNotQuantizedToWholeCssPixels() = runApplicationTest {
+        val moveDeltas = mutableListOf<Offset>()
+
+        createComposeWindow {
+            Box(modifier = Modifier.fillMaxSize().pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (coroutineContext.isActive) {
+                        val event = awaitPointerEvent()
+                        if (event.type == PointerEventType.Move) {
+                            moveDeltas.add(event.changes[0].positionChange())
+                        }
+                    }
+                }
+            })
+        }
+
+        dispatchEvents(
+            fractionalTouchEvent("pointerdown", 0, 10.0, 10.0),
+            fractionalTouchEvent("pointermove", 0, 10.25, 10.0),
+            fractionalTouchEvent("pointermove", 0, 10.5, 10.0)
+        )
+
+        awaitIdle()
+
+        assertEquals(2, moveDeltas.size, "sub-pixel moves were dropped: $moveDeltas")
+        assertTrue(
+            moveDeltas.all { it.x > 0f },
+            "sub-pixel moves must report a non-zero delta: $moveDeltas"
+        )
+    }
+
     private fun touch(id: Int, x: Int, y: Int) = PointerEventInit(
         pointerId = id,
         clientX = x,
@@ -241,3 +274,15 @@ class GesturesTest : OnCanvasTests {
         pointerType = "touch"
     )
 }
+
+/**
+ * [PointerEventInit] types `clientX`/`clientY` as `Int`, so it cannot express the fractional CSS
+ * pixel coordinates a real browser reports. Build the event in JS instead.
+ */
+@OptIn(ExperimentalWasmJsInterop::class)
+// language=js
+private fun fractionalTouchEvent(type: String, id: Int, x: Double, y: Double): WebPointerEvent =
+    js(
+        "new PointerEvent(type, { pointerId: id, clientX: x, clientY: y, " +
+            "pointerType: 'touch', isPrimary: true, cancelable: true })"
+    )


### PR DESCRIPTION
Fix pointer event handling to preserve sub-pixel movement on high-DPI screens

- Avoid quantizing fractional pointer coordinates to whole CSS pixels, ensuring accurate sub-pixel movement detection.
- Added new helper functions to read raw `clientX`/`clientY` values from events for improved precision.
- Included a test verifying that sub-pixel moves are not dropped or misreported.

Fixes https://youtrack.jetbrains.com/issue/CMP-10575

## Testing
New unit test

## Release Notes
### Fixes - Web
- Fixed outer `HorizontalPager` stealing the touch gesture from a nested `HorizontalPager` during a slow drag