### PR TITLE
Fix ctrl-f/b text field key mappings

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
@@ -181,8 +181,8 @@ internal fun createMacOsDefaultKeyMapping(): KeyMapping {
 
                 KeyModifiers.Ctrl -> {
                     when (event.key) {
-                        Key.F -> KeyCommand.LEFT_CHAR
-                        Key.B -> KeyCommand.RIGHT_CHAR
+                        Key.F -> KeyCommand.RIGHT_CHAR
+                        Key.B -> KeyCommand.LEFT_CHAR
                         Key.P -> KeyCommand.UP
                         Key.N -> KeyCommand.DOWN
                         Key.A -> KeyCommand.LINE_START


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10647

## Testing
Tested manually

## Release Notes
### Fixes - Desktop
- [macOS] Fixed the behavior of `Ctrl+f/b` in text fields (it was reversed).

