### PR TITLE
Change background parameter of deprecated `SwingPanel` back to non-nullable (1.12 branch)

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -669,7 +669,7 @@ public final class androidx/compose/ui/awt/SwingDialog_desktopKt {
 
 public final class androidx/compose/ui/awt/SwingPanel_desktopKt {
 	public static final fun SwingPanel (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
-	public static final fun SwingPanel-iRkQZW0 (Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SwingPanel-euL9pac (JLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun getNoOpUpdate ()Lkotlin/jvm/functions/Function1;
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.awt.toAwtColor
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
 import androidx.compose.ui.layout.Measurable
@@ -67,7 +68,7 @@ val NoOpUpdate: Component.() -> Unit = {}
 )
 @Composable
 fun <T : Component> SwingPanel(
-    background: Color? = Color.White,
+    background: Color = Color.White,
     factory: () -> T,
     modifier: Modifier = Modifier,
     update: (T) -> Unit = NoOpUpdate,
@@ -106,7 +107,7 @@ fun <T : Component> SwingPanel(
         factory = { interopViewHolder },
         modifier = modifier.then(focusSwitcher.modifier),
         update = {
-            if (background != null) {
+            if (background.isSpecified) {
                 it.background = background.toAwtColor()
             }
             update(it)
@@ -137,7 +138,7 @@ fun <T : Component> SwingPanel(
 ) {
     @Suppress("DEPRECATION")
     SwingPanel(
-        background = null,
+        background = Color.Unspecified,
         factory = factory,
         modifier = modifier,
         update = update


### PR DESCRIPTION
This is a cherry-pick of https://github.com/JetBrains/compose-multiplatform-core/pull/3295

Fixes https://youtrack.jetbrains.com/issue/CMP-10653

## Testing
N/A

## Release Notes
### Fixes - Desktop
- _(prerelase fix)_ Reverted `background` parameter of `SwingPanel` to non-nullable to avoid breaking binary compatibility.
