### PR TITLE
Remove @ExperimentalComposeUiApi from ComposeViewportConfiguration completely

### DIFF
--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -4909,6 +4909,19 @@ final fun androidx.compose.ui.window/ComposeUIViewController(kotlin/Function1<an
 final fun androidx.compose.ui.window/ComposeUIViewController(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): platform.UIKit/UIViewController // androidx.compose.ui.window/ComposeUIViewController|ComposeUIViewController(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
 
 // Targets: [js, wasmJs]
+final class androidx.compose.ui.window/ComposeViewportConfiguration { // androidx.compose.ui.window/ComposeViewportConfiguration|null[0]
+    final var enableBrowserWindowInsets // androidx.compose.ui.window/ComposeViewportConfiguration.enableBrowserWindowInsets|{}enableBrowserWindowInsets[0]
+        final fun <get-enableBrowserWindowInsets>(): kotlin/Boolean // androidx.compose.ui.window/ComposeViewportConfiguration.enableBrowserWindowInsets.<get-enableBrowserWindowInsets>|<get-enableBrowserWindowInsets>(){}[0]
+        final fun <set-enableBrowserWindowInsets>(kotlin/Boolean) // androidx.compose.ui.window/ComposeViewportConfiguration.enableBrowserWindowInsets.<set-enableBrowserWindowInsets>|<set-enableBrowserWindowInsets>(kotlin.Boolean){}[0]
+    final var isA11YEnabled // androidx.compose.ui.window/ComposeViewportConfiguration.isA11YEnabled|{}isA11YEnabled[0]
+        final fun <get-isA11YEnabled>(): kotlin/Boolean // androidx.compose.ui.window/ComposeViewportConfiguration.isA11YEnabled.<get-isA11YEnabled>|<get-isA11YEnabled>(){}[0]
+        final fun <set-isA11YEnabled>(kotlin/Boolean) // androidx.compose.ui.window/ComposeViewportConfiguration.isA11YEnabled.<set-isA11YEnabled>|<set-isA11YEnabled>(kotlin.Boolean){}[0]
+    final var isClearFocusOnMouseDownEnabled // androidx.compose.ui.window/ComposeViewportConfiguration.isClearFocusOnMouseDownEnabled|{}isClearFocusOnMouseDownEnabled[0]
+        final fun <get-isClearFocusOnMouseDownEnabled>(): kotlin/Boolean // androidx.compose.ui.window/ComposeViewportConfiguration.isClearFocusOnMouseDownEnabled.<get-isClearFocusOnMouseDownEnabled>|<get-isClearFocusOnMouseDownEnabled>(){}[0]
+        final fun <set-isClearFocusOnMouseDownEnabled>(kotlin/Boolean) // androidx.compose.ui.window/ComposeViewportConfiguration.isClearFocusOnMouseDownEnabled.<set-isClearFocusOnMouseDownEnabled>|<set-isClearFocusOnMouseDownEnabled>(kotlin.Boolean){}[0]
+}
+
+// Targets: [js, wasmJs]
 final object androidx.compose.ui.input.pointer/DummyPointerIcon : androidx.compose.ui.input.pointer/PointerIcon // androidx.compose.ui.input.pointer/DummyPointerIcon|null[0]
 
 // Targets: [js, wasmJs]

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
@@ -30,8 +30,6 @@ class ComposeViewportConfiguration internal constructor() {
      * That DOM tree is visibly hidden, but reachable by the accessibility tools.
      * It can be disabled to avoid the overhead of maintaining the DOM tree.
      * By default, it is set to `true`.
-     *
-     * Note: This API is experimental and subject to change in the future.
      */
     var isA11YEnabled: Boolean = true
 
@@ -64,8 +62,6 @@ class ComposeViewportConfiguration internal constructor() {
      * changes as the user scrolls, so the insets may become invalid. In that case
      * it is recommended to disable inset handling entirely (`enableBrowserWindowInsets = false`) and
      * manage padding manually.
-     *
-     * Note: This API is experimental and subject to change in the future.
      */
     var enableBrowserWindowInsets: Boolean = false
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeViewportConfiguration.web.kt
@@ -17,13 +17,11 @@
 package androidx.compose.ui.window
 
 import androidx.compose.ui.ComposeUiFlags
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 
 /**
  * Configuration of [ComposeViewport] behavior.
  */
-@ExperimentalComposeUiApi
 class ComposeViewportConfiguration internal constructor() {
 
     /**
@@ -35,14 +33,12 @@ class ComposeViewportConfiguration internal constructor() {
      *
      * Note: This API is experimental and subject to change in the future.
      */
-    @ExperimentalComposeUiApi
     var isA11YEnabled: Boolean = true
 
     /**
      * Controls whether a mouse clicks on an unfocused element clears focus.
      * It's clearing focus on mouse down by default.
      */
-    @ExperimentalComposeUiApi
     var isClearFocusOnMouseDownEnabled: Boolean = ComposeUiFlags.isClearFocusOnMouseDownEnabled
 
     /**
@@ -71,6 +67,5 @@ class ComposeViewportConfiguration internal constructor() {
      *
      * Note: This API is experimental and subject to change in the future.
      */
-    @ExperimentalComposeUiApi
     var enableBrowserWindowInsets: Boolean = false
 }


### PR DESCRIPTION
The purpose of this PR is to remove entirely `@ExperimentalComposeUiApi` annotation from `ComposeViewportConfiguration`, here's the reasoning:

* ComposeViewportConfiguration::isA11YEnabled - is flag that definitely will stay and hardly can be commonised (on iOS there's no such flag but rather application relies mobile settings) 
* isClearFocusOnMouseDownEnabled is shadowing the ComposeUiFlags.isClearFocusOnMouseDownEnabled which is common and is still `@ExperimentalComposeUiApi`-annotated  - but for ComposeViewportConfiguration it's detail of implementation hidden from user so we can safely remove our annotation
* enableBrowserWindowInsets won't be commonized because of desktop
* Removing all three annotations lead to possibility to remove the annotation on class as well

## Testing
Not needed

## Release Notes
### Highlights - Web
- ComposeViewportConfiguration is no longer experimental