### PR TITLE
Support multiple SemanticOwners in CMP Web

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform.accessibility
 
+import androidx.collection.MutableIntSet
 import androidx.collection.MutableScatterMap
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
@@ -161,7 +162,7 @@ internal class ComposeWebSemanticsListener(
     private val webNodes = MutableScatterMap<Int, HTMLElement>()
 
     // A reusable set of node ids for sync purposes
-    private val allNodesIds = mutableSetOf<Int>()
+    private val allNodesIds = MutableIntSet()
 
     /**
      * Event delegation: Single shared click listener for all a11y nodes
@@ -230,7 +231,7 @@ internal class ComposeWebSemanticsListener(
      */
     private fun syncSemanticsWithWebA11Y(
         semanticsOwner: SemanticsOwner,
-        allNodesIds: MutableSet<Int>
+        allNodesIds: MutableIntSet
     ) {
         fun SemanticsNode.isValid() = layoutNode.let { it.isPlaced && it.isAttached }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -513,11 +513,11 @@ private fun removeAllChildrenOf(element: HTMLElement) {
  *  because they cannot receive focus or be clicked.
  */
 private fun Element.setInert(inert: Boolean) {
-    if (inert == hasAttribute("inert")) return
+    val element = this.unsafeCast<CanToggleAttribute>()
+    element.toggleAttribute("inert", inert)
+}
 
-    if (inert) {
-        setAttribute("inert", "")
-    } else {
-        removeAttribute("inert")
-    }
+private external interface CanToggleAttribute : JsAny {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute
+    fun toggleAttribute(attributeName: String, force: Boolean): Boolean
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -130,15 +130,17 @@ internal class ComposeWebSemanticsListener(
         webSemanticsRoot.addEventListener("click", onClick)
     }
 
-    private var semanticsOwner: SemanticsOwner? = null
+    private val semanticsOwners = mutableListOf<SemanticsOwner>()
 
     override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
-        this.semanticsOwner = semanticsOwner
+        if (semanticsOwners.contains(semanticsOwner)) return
+        semanticsOwners.add(semanticsOwner)
+        invalidationChannel.trySend(Unit)
     }
 
     override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
-        if (semanticsOwner == this.semanticsOwner) {
-            this.semanticsOwner = null
+        if (semanticsOwners.remove(semanticsOwner)) {
+            invalidationChannel.trySend(Unit)
         }
     }
 
@@ -157,6 +159,9 @@ internal class ComposeWebSemanticsListener(
     private val nodes = MutableScatterMap<Int, SemanticsNode>()
     private val nodeToParent = MutableScatterMap<Int, Int>()
     private val webNodes = MutableScatterMap<Int, HTMLElement>()
+
+    // A reusable set of node ids for sync purposes
+    private val allNodesIds = mutableSetOf<Int>()
 
     /**
      * Event delegation: Single shared click listener for all a11y nodes
@@ -179,16 +184,61 @@ internal class ComposeWebSemanticsListener(
 
 
     private fun syncSemanticsWithWebA11Y() {
-        fun SemanticsNode.isValid() = layoutNode.let { it.isPlaced && it.isAttached }
+        allNodesIds.clear()
 
-        val root = semanticsOwner?.rootSemanticsNode ?: return
-
-        if (root.isValid()) {
-            dfsDeque.addLast(root)
+        semanticsOwners.fastForEach {
+            syncSemanticsWithWebA11Y(it, allNodesIds)
         }
 
+        val removedIds = mutableSetOf<Int>()
 
-        val allIds = mutableSetOf<Int>()
+        webNodes.forEachKey {
+            if (it !in allNodesIds) {
+                webNodes[it]?.remove()
+                removedIds.add(it)
+            }
+        }
+
+        removedIds.forEach {
+            webNodes.remove(it)
+            nodes.remove(it)
+            nodeToParent.remove(it)
+        }
+
+        updateInertRoots()
+    }
+
+    // The last (top) root is never inert.
+    // Other owners might become inert when the top root contains a dialog.
+    // See LayersA11YTest.
+    private fun updateInertRoots() {
+        val lastOwnerRoot = webSemanticsRoot.lastElementChild
+        lastOwnerRoot?.setInert(false)
+
+        // Assuming the dialog semantics are set on the first node of the owner:
+        val isModalOnTop = lastOwnerRoot?.firstElementChild?.hasAttribute("aria-modal") == true
+
+        val children = webSemanticsRoot.children
+        repeat(children.length - 1) {
+            val ownerRoot = children.item(it)
+            ownerRoot?.setInert(isModalOnTop)
+        }
+    }
+
+    /**
+     * Sync the tree corresponding to the [semanticsOwner] and populate [allNodesIds] - a set of node ids.
+     */
+    private fun syncSemanticsWithWebA11Y(
+        semanticsOwner: SemanticsOwner,
+        allNodesIds: MutableSet<Int>
+    ) {
+        fun SemanticsNode.isValid() = layoutNode.let { it.isPlaced && it.isAttached }
+
+        val root = semanticsOwner.rootSemanticsNode
+        if (!root.isValid()) return
+
+        dfsDeque.clear()
+        dfsDeque.addLast(root)
 
         val rootPosition = webSemanticsRoot.getBoundingClientRect().let {
             Offset(it.left.toFloat(), it.top.toFloat())
@@ -197,7 +247,10 @@ internal class ComposeWebSemanticsListener(
         while (!dfsDeque.isEmpty()) {
             val node = dfsDeque.removeLast()
             val currentId = node.id
-            allIds.add(currentId)
+            allNodesIds.add(currentId)
+
+            // `config` recreates the merged subtree on every call, so read it once
+            val config = node.config
 
             val children = node.replacedChildren.asReversed()
             dfsDeque.addAll(children)
@@ -215,7 +268,7 @@ internal class ComposeWebSemanticsListener(
                     removeAllChildrenOf(htmlNode)
                 }
 
-                syncNode(node, htmlNode, rootPosition)
+                syncNode(node, config, htmlNode, rootPosition)
                 htmlNode
             } else {
                 nodes[currentId] = node
@@ -226,7 +279,7 @@ internal class ComposeWebSemanticsListener(
                 }
 
                 webNodes[currentId] = htmlNode
-                syncNode(node, htmlNode, rootPosition, true)
+                syncNode(node, config, htmlNode, rootPosition, true)
                 htmlNode
             }
 
@@ -235,25 +288,11 @@ internal class ComposeWebSemanticsListener(
             val htmlParent = parentId?.let { webNodes[it] } ?: webSemanticsRoot
             htmlParent.appendChild(htmlNode)
         }
-
-        val removedIds = mutableSetOf<Int>()
-
-        webNodes.forEachKey {
-            if (it !in allIds) {
-                webNodes[it]?.remove()
-                removedIds.add(it)
-            }
-        }
-
-        removedIds.forEach {
-            webNodes.remove(it)
-            nodes.remove(it)
-            nodeToParent.remove(it)
-        }
     }
 
     private fun syncNode(
         sn: SemanticsNode,
+        config: SemanticsConfiguration,
         htmlNode: HTMLElement,
         rootOffset: Offset,
         justCreated: Boolean = false,
@@ -263,8 +302,6 @@ internal class ComposeWebSemanticsListener(
             // https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes
             htmlNode.setAttribute(DATA_SEMANTICS_ID_KEY, sn.id.toString())
         }
-
-        val config = sn.config
 
         if (config.contains(SemanticsProperties.Text)) {
             val text = config[SemanticsProperties.Text]
@@ -300,6 +337,12 @@ internal class ComposeWebSemanticsListener(
         }
 
         setA11YAriaRole(element = htmlNode, config.getRoleId())
+
+        if (config.contains(SemanticsProperties.IsDialog)) {
+            htmlNode.setAttribute("aria-modal", "true")
+        } else {
+            htmlNode.removeAttribute("aria-modal")
+        }
 
         val density = sn.layoutNode.density
         sn.boundsInRoot.let { rect ->
@@ -346,6 +389,7 @@ internal object AriaRoleId {
     const val TextBox = 8
     const val List = 9
     const val Grid = 10
+    const val Dialog = 11
 }
 
 internal fun SemanticsConfiguration.getRoleId(): Int {
@@ -392,6 +436,11 @@ internal fun SemanticsConfiguration.getRoleId(): Int {
         }
     }
 
+    // Checked last: a layer's structural role outranks whatever its content looks like.
+    if (this.contains(SemanticsProperties.IsDialog)) {
+        roleId = AriaRoleId.Dialog
+    }
+
     return roleId
 }
 
@@ -436,6 +485,9 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
             case 10: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role
                 roleValue = "grid";
                 break;
+            case 11: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role
+                roleValue = "dialog";
+                break;
             default:
                 break;
         }
@@ -451,4 +503,20 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
 private fun removeAllChildrenOf(element: HTMLElement) {
     // language=javascript
     js("element.replaceChildren()")
+}
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert
+ *  When an element is inert, it along with all of the element's descendants,
+ *  including normally interactive elements such as links, buttons, and form controls are disabled
+ *  because they cannot receive focus or be clicked.
+ */
+private fun Element.setInert(inert: Boolean) {
+    if (inert == hasAttribute("inert")) return
+
+    if (inert) {
+        setAttribute("inert", "")
+    } else {
+        removeAttribute("inert")
+    }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LayersA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LayersA11YTest.kt
@@ -88,6 +88,36 @@ class LayersA11YTest : OnCanvasTests {
         }
 
         awaitUntil { ownerCount() == 2 }
+
+        assertTrue(
+            ownerRoot(0).innerText.contains("Root"),
+            "main content root must be present"
+        )
+        assertTrue(
+            ownerRoot(1).innerText.contains("Dialog"),
+            "dialog root must be present"
+        )
+    }
+
+    @Test
+    fun popupAddsAdditionalOwnerRootInHtml() = runApplicationTest {
+        createComposeWindow {
+            Text("Root")
+            Popup {
+                Text("Popup")
+            }
+        }
+
+        awaitUntil { ownerCount() == 2 }
+
+        assertTrue(
+            ownerRoot(0).innerText.contains("Root"),
+            "main content root must be present"
+        )
+        assertTrue(
+            ownerRoot(1).innerText.contains("Popup"),
+            "popup root must be present"
+        )
     }
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LayersA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LayersA11YTest.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.currentTimeMillis
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.get
+
+/**
+ * Verifies how the a11y mirror DOM handles multiple [androidx.compose.ui.semantics.SemanticsOwner]s
+ */
+class LayersA11YTest : OnCanvasTests {
+
+    private fun HTMLElement.isInert() = hasAttribute("inert")
+
+    private fun a11yContainer() = getA11YContainer() ?: error("a11y container is missing")
+
+    /** Root element of the layer at [index] in z-order (0 == the scene's main content). */
+    private fun ownerRoot(index: Int): HTMLElement =
+        a11yContainer().children[index] as? HTMLElement
+            ?: error("no a11y root element for layer $index")
+
+    private fun ownerCount() = a11yContainer().childElementCount
+
+    /**
+     * A single [awaitA11YChanges] only waits for the next mutation, which is not necessarily the one
+     * that settles the whole layer state - a layer's root element appears before its content has
+     * been laid out. So poll instead of assuming one sync is enough.
+     */
+    private suspend fun awaitUntil(timeout: Duration = 5.seconds, condition: () -> Boolean) {
+        if (condition()) return
+        val deadline = currentTimeMillis() + timeout.inWholeMilliseconds
+        while (true) {
+            awaitA11YChanges(timeout)
+            if (condition()) return
+            assertTrue(
+                currentTimeMillis() < deadline,
+                "condition still not met after $timeout.\ninnerHTML = ${a11yContainer().innerHTML}"
+            )
+        }
+    }
+
+    /**
+     * Dialogs animate by default ([androidx.compose.ui.ComposeUiFlags.isDialogAnimationEnabled]),
+     * which keeps invalidating layout and makes the a11y tree settle at an unpredictable time.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun noAnimation() = DialogProperties(animateTransition = false)
+
+    @Test
+    fun dialogAddsAdditionalOwnerRootInHtml() = runApplicationTest {
+        createComposeWindow {
+            Text("Root")
+            Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                Text("Dialog")
+            }
+        }
+
+        awaitUntil { ownerCount() == 2 }
+    }
+
+    @Test
+    fun nonFocusablePopupKeepsContentBelowReadable() = runApplicationTest {
+        createComposeWindow {
+            Text("Root")
+            Popup(properties = PopupProperties(focusable = false)) {
+                Text("Popup")
+            }
+        }
+
+        awaitUntil { ownerCount() == 2 }
+
+        // A non-focusable popup does not take over: everything stays readable.
+        assertFalse(ownerRoot(0).isInert(), "main content must stay readable under a popup")
+        assertFalse(ownerRoot(1).isInert(), "popup content must be readable")
+
+        // Popups are not modal, so they must not be announced as dialogs.
+        assertFalse(
+            ownerRoot(1).outerHTML.contains("aria-modal"),
+            "a popup must not be marked aria-modal"
+        )
+    }
+
+    @Test
+    fun dialogMakesContentBelowInert() = runApplicationTest {
+        createComposeWindow {
+            Text("Root")
+            Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                Text("Dialog")
+            }
+        }
+
+        awaitUntil { ownerCount() == 2 && ownerRoot(0).isInert() }
+
+        assertFalse(ownerRoot(1).isInert(), "dialog content must stay readable")
+
+        // The `dialog()` marker sits on a node inside the layer, not on the layer root, so search
+        // the whole subtree rather than asserting on a fixed depth.
+        assertNotNull(
+            ownerRoot(1).querySelector("[role=\"dialog\"][aria-modal=\"true\"]"),
+            "dialog must expose role=dialog and aria-modal=true"
+        )
+    }
+
+    @Test
+    fun dismissingDialogRestoresContentBelow() = runApplicationTest {
+        var showDialog by mutableStateOf(false)
+
+        createComposeWindow {
+            Text("Root")
+            if (showDialog) {
+                Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                    Text("Dialog")
+                }
+            }
+        }
+
+        awaitUntil { ownerCount() == 1 }
+        assertFalse(ownerRoot(0).isInert())
+
+        showDialog = true
+        awaitUntil { ownerCount() == 2 && ownerRoot(0).isInert() }
+
+        showDialog = false
+        awaitUntil { ownerCount() == 1 && !ownerRoot(0).isInert() }
+        assertTrue(
+            ownerRoot(0).innerText.contains("Root"),
+            "main content must be readable again once the dialog is gone"
+        )
+    }
+
+    @Test
+    fun mainTreeSurvivesPopupDismissal() = runApplicationTest {
+        // Regression test: the listener used to keep a single SemanticsOwner, so opening a popup
+        // dropped the main tree, and closing it left the popup's stale nodes behind forever.
+        var showPopup by mutableStateOf(false)
+
+        createComposeWindow {
+            Text("Root")
+            if (showPopup) {
+                Popup(properties = PopupProperties()) {
+                    Text("Popup")
+                }
+            }
+        }
+
+        awaitUntil { ownerCount() == 1 }
+        assertTrue(ownerRoot(0).innerText.contains("Root"))
+
+        showPopup = true
+        awaitUntil { ownerCount() == 2 }
+        assertTrue(
+            ownerRoot(0).innerText.contains("Root"),
+            "main tree must survive a popup being shown"
+        )
+
+        showPopup = false
+        awaitUntil { ownerCount() == 1 }
+        assertTrue(
+            ownerRoot(0).innerText.contains("Root"),
+            "main tree must survive a popup being dismissed"
+        )
+        assertFalse(
+            a11yContainer().innerText.contains("Popup"),
+            "a dismissed popup must not stay readable"
+        )
+    }
+
+    @Test
+    fun dialogOverPopupMakesBothLayersBelowInert() = runApplicationTest {
+        createComposeWindow {
+            Text("Root")
+            Popup(properties = PopupProperties()) {
+                Text("Popup")
+            }
+            Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                Text("Dialog")
+            }
+        }
+
+        awaitUntil { ownerCount() == 3 && ownerRoot(0).isInert() }
+
+        assertTrue(ownerRoot(1).isInert(), "a popup below a dialog must be inert too")
+        assertFalse(ownerRoot(2).isInert(), "the dialog itself must stay readable")
+    }
+
+    @Test
+    fun onlyLayersBelowTheTopmostDialogAreInert() = runApplicationTest {
+        // Two stacked dialogs: the intermediate one is modal but must still be inert, because a
+        // modal layer above it wins.
+        createComposeWindow {
+            Text("Root")
+            Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                Text("Dialog1")
+                Dialog(onDismissRequest = {}, properties = noAnimation()) {
+                    Text("Dialog2")
+                }
+            }
+        }
+
+        awaitUntil { ownerCount() == 3 && ownerRoot(1).isInert() }
+
+        assertTrue(ownerRoot(0).isInert(), "main content must be inert under two dialogs")
+        assertFalse(ownerRoot(2).isInert(), "the topmost dialog must stay readable")
+    }
+
+    @Test
+    fun focusablePopupDoesNotYetMakeContentBelowInert() = runApplicationTest {
+        // Pins a known limitation: `ComposeSceneLayer.focusable` is not carried by the semantics
+        // tree, so a focusable Popup is indistinguishable from a non-focusable one here and is
+        // treated as non-modal. Update this test when modality is plumbed through properly.
+        createComposeWindow {
+            Text("Root")
+            Popup(properties = PopupProperties(focusable = true)) {
+                Text("Popup")
+            }
+        }
+
+        awaitUntil { ownerCount() == 2 }
+
+        assertFalse(ownerRoot(0).isInert(), "known limitation: focusable popups are not modal yet")
+        assertEquals(2, ownerCount())
+    }
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9368/Web-A11y.-Incorrect-semantics-after-closing-dialogs-popups

## Testing
- Added new unit tests
- This should be tested by QA

## Release Notes
### Fixes - Web
- Fix incorrect a11y tree state after opening and closing a popup or dialog

