### PR TITLE
Remove `@ExperimentalComposeUiApi` annotation from HtmlElementView, ComposeViewport

### DIFF
--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -4950,6 +4950,12 @@ final val androidx.compose.ui.window/androidx_compose_ui_window_MediaQueryStatus
 final val androidx.compose.ui.window/androidx_compose_ui_window_MediaQueryStatus_UNSUPPORTED$stableprop // androidx.compose.ui.window/androidx_compose_ui_window_MediaQueryStatus_UNSUPPORTED$stableprop|#static{}androidx_compose_ui_window_MediaQueryStatus_UNSUPPORTED$stableprop[0]
 
 // Targets: [js, wasmJs]
+final fun <#A: org.w3c.dom/HTMLElement> androidx.compose.ui.viewinterop/HtmlElementView(kotlin/Function0<#A>, androidx.compose.ui/Modifier?, kotlin/Function1<#A, kotlin/Unit>?, kotlin/Function1<#A, kotlin/Unit>?, kotlin/Function1<#A, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // androidx.compose.ui.viewinterop/HtmlElementView|HtmlElementView(kotlin.Function0<0:0>;androidx.compose.ui.Modifier?;kotlin.Function1<0:0,kotlin.Unit>?;kotlin.Function1<0:0,kotlin.Unit>?;kotlin.Function1<0:0,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<org.w3c.dom.HTMLElement>}[0]
+
+// Targets: [js, wasmJs]
+final fun <#A: org.w3c.dom/HTMLElement> androidx.compose.ui.viewinterop/WebElementView(kotlin/Function0<#A>, androidx.compose.ui/Modifier?, kotlin/Function1<#A, kotlin/Unit>?, kotlin/Function1<#A, kotlin/Unit>?, kotlin/Function1<#A, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // androidx.compose.ui.viewinterop/WebElementView|WebElementView(kotlin.Function0<0:0>;androidx.compose.ui.Modifier?;kotlin.Function1<0:0,kotlin.Unit>?;kotlin.Function1<0:0,kotlin.Unit>?;kotlin.Function1<0:0,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<org.w3c.dom.HTMLElement>}[0]
+
+// Targets: [js, wasmJs]
 final fun androidx.compose.ui.input.pointer/PointerIcon(kotlin/String): androidx.compose.ui.input.pointer/PointerIcon // androidx.compose.ui.input.pointer/PointerIcon|PointerIcon(kotlin.String){}[0]
 
 // Targets: [js, wasmJs]
@@ -4963,6 +4969,12 @@ final fun androidx.compose.ui.platform/androidx_compose_ui_platform_WebTextToolb
 
 // Targets: [js, wasmJs]
 final fun androidx.compose.ui.platform/androidx_compose_ui_platform_WebTextToolbar_TextToolbarMenu$stableprop_getter(): kotlin/Int // androidx.compose.ui.platform/androidx_compose_ui_platform_WebTextToolbar_TextToolbarMenu$stableprop_getter|androidx_compose_ui_platform_WebTextToolbar_TextToolbarMenu$stableprop_getter(){}[0]
+
+// Targets: [js, wasmJs]
+final fun androidx.compose.ui.window/ComposeViewport(kotlin/String? = ..., kotlin/Function1<androidx.compose.ui.window/ComposeViewportConfiguration, kotlin/Unit> = ..., kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit> = ...) // androidx.compose.ui.window/ComposeViewport|ComposeViewport(kotlin.String?;kotlin.Function1<androidx.compose.ui.window.ComposeViewportConfiguration,kotlin.Unit>;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
+
+// Targets: [js, wasmJs]
+final fun androidx.compose.ui.window/ComposeViewport(org.w3c.dom/Element, kotlin/Function1<androidx.compose.ui.window/ComposeViewportConfiguration, kotlin/Unit> = ..., kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit> = ...) // androidx.compose.ui.window/ComposeViewport|ComposeViewport(org.w3c.dom.Element;kotlin.Function1<androidx.compose.ui.window.ComposeViewportConfiguration,kotlin.Unit>;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
 
 // Targets: [js, wasmJs]
 final fun androidx.compose.ui.window/androidx_compose_ui_window_ComposeViewportConfiguration$stableprop_getter(): kotlin/Int // androidx.compose.ui.window/androidx_compose_ui_window_ComposeViewportConfiguration$stableprop_getter|androidx_compose_ui_window_ComposeViewportConfiguration$stableprop_getter(){}[0]

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
@@ -45,7 +45,6 @@ actual typealias InteropView = Any
  * containing [T] was reused. If null, [T] will not be reused, a new instance of [T] will be created
  * using [factory] every time this function enters the composition.
  */
-@ExperimentalComposeUiApi
 @Composable
 fun <T : HTMLElement> HtmlElementView(
     factory: () -> T,
@@ -54,12 +53,22 @@ fun <T : HTMLElement> HtmlElementView(
     onRelease: (T) -> Unit = NoOp,
     onReset: ((T) -> Unit)? = null,
 ) {
-    InternalHtmlElementView(
-        factory = factory,
-        modifier = modifier,
-        update = update,
-        onRelease = onRelease,
-        onReset = onReset,
+    val interopContainer = LocalInteropContainer.current
+
+    InteropView(
+        factory = { compositeKeyHash ->
+            WebInteropViewHolder(
+                factory,
+                interopContainer,
+                compositeKeyHash
+            )
+        },
+        modifier.focusInteropModifier(),
+        onReset,
+        onRelease,
+        update = {
+            update(it)
+        }
     )
 }
 /**
@@ -86,7 +95,6 @@ fun <T : HTMLElement> HtmlElementView(
  * using [factory] every time this function enters the composition.
  */
 @Deprecated("Use HtmlElementView instead", replaceWith = ReplaceWith("HtmlElementView(factory, modifier, update, onRelease, onReset)"))
-@ExperimentalComposeUiApi
 @Composable
 fun <T : HTMLElement> WebElementView(
     factory: () -> T,
@@ -105,30 +113,3 @@ fun <T : HTMLElement> WebElementView(
 }
 
 internal actual class InteropViewGroup(val htmlElement: HTMLElement)
-
-@Composable
-internal fun <T : HTMLElement> InternalHtmlElementView(
-    factory: () -> T,
-    modifier: Modifier,
-    update: (T) -> Unit,
-    onRelease: (T) -> Unit,
-    onReset: ((T) -> Unit)?,
-) {
-    val interopContainer = LocalInteropContainer.current
-
-    InteropView(
-        factory = { compositeKeyHash ->
-            WebInteropViewHolder(
-                factory,
-                interopContainer,
-                compositeKeyHash
-            )
-        },
-        modifier.focusInteropModifier(),
-        onReset,
-        onRelease,
-        update = {
-            update(it)
-        }
-    )
-}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import kotlin.js.js
 import kotlinx.browser.document
 import org.w3c.dom.Element
@@ -29,8 +28,6 @@ import org.w3c.dom.ShadowRootInit
 import org.w3c.dom.ShadowRootMode
 
 /**
- * EXPERIMENTAL! Might be deleted or changed in the future!
- *
  * Creates the composition in HTML canvas created in parent container identified by [viewportContainerId] id.
  * This size of canvas is adjusted with the size of the container
  *
@@ -40,7 +37,6 @@ import org.w3c.dom.ShadowRootMode
  * See [ComposeViewportConfiguration] for available options.
  * @param content - The Composable content to be rendered on the `<canvas>` element.
  */
-@ExperimentalComposeUiApi
 fun ComposeViewport(
     viewportContainerId: String? = null,
     configure: ComposeViewportConfiguration.() -> Unit = {},
@@ -58,8 +54,6 @@ fun ComposeViewport(
 }
 
 /**
- * EXPERIMENTAL! Might be deleted or changed in the future!
- *
  * Creates the composition in HTML canvas created in parent container identified by [viewportContainer] Element.
  * This size of canvas is adjusted with the size of the container
  *
@@ -78,7 +72,6 @@ fun ComposeViewport(
  *
  * Note: The viewportContainer will be cleared on composition creation.
  */
-@ExperimentalComposeUiApi
 fun ComposeViewport(
     viewportContainer: Element,
     configure: ComposeViewportConfiguration.() -> Unit = {},


### PR DESCRIPTION
We consider this API stable enough

## Testing
Not needed

## Release Notes
### Highlights - Web
- ComposeViewportConfiguration is no longer experimental
