### PR TITLE
Make Density modifiable to avoid UI blurring when zooming in a browser

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
@@ -40,7 +40,12 @@ import org.w3c.dom.ImageData
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.Node
 
-internal abstract class WebDragAndDropManager(private val rootNode: Node, eventListener: EventTargetListener, globalEventsListener: EventTargetListener, private val density: Density) :
+internal abstract class WebDragAndDropManager(
+    private val rootNode: Node,
+    eventListener: EventTargetListener,
+    globalEventsListener: EventTargetListener,
+    private val densityProvider: () -> Density
+) :
     PlatformDragAndDropManager {
     override val isRequestDragAndDropTransferRequired: Boolean
         get() = false
@@ -120,7 +125,7 @@ internal abstract class WebDragAndDropManager(private val rootNode: Node, eventL
             previousDragEventIsStart = true
             event as DragEvent
 
-            val scope = InternalStartTransferScope(density)
+            val scope = InternalStartTransferScope(densityProvider())
 
             if (scope.startTransfer(event)) {
                 // without setting any kind of data in data transfer Safari on iOS won't proceed with drag action
@@ -176,7 +181,7 @@ internal abstract class WebDragAndDropManager(private val rootNode: Node, eventL
     private val DragEvent.offset get() = Offset(
         x = offsetX.toFloat(),
         y = offsetY.toFloat()
-    ) * density.density
+    ) * densityProvider().density
 }
 
 @Suppress("UNUSED_PARAMETER")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebWindowInsetsManager.kt
@@ -69,7 +69,7 @@ private class WebWindowInsets(
  *
  */
 internal class WebWindowInsetsManager(
-    private val density: Density,
+    private val densityProvider: () -> Density,
     canvas: Element
 ) {
     private var canvasRect: DOMRect = canvas.getBoundingClientRect()
@@ -127,7 +127,7 @@ internal class WebWindowInsetsManager(
         val adjustedRight = maxOf(0f, readCssVarRight() - (vw - canvasRect.right.toFloat()))
         val adjustedBottom = maxOf(0f, readCssVarBottom() - (vh - canvasRect.bottom.toFloat()))
 
-        safeAreaInsets.value = with(density) {
+        safeAreaInsets.value = with(densityProvider()) {
             PlatformInsets(
                 left = adjustedLeft.dp.roundToPx(),
                 top = adjustedTop.dp.roundToPx(),
@@ -146,7 +146,7 @@ internal class WebWindowInsetsManager(
         val vh = window.innerHeight.toFloat()
         val adjustedBottom = maxOf(0f, rawHeight - (vh - canvasRect.bottom.toFloat()))
 
-        imeInsets.value = with(density) {
+        imeInsets.value = with(densityProvider()) {
             PlatformInsets(bottom = adjustedBottom.dp.roundToPx())
         }
     }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -159,12 +159,16 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     private var viewportTargetListener: EventTargetListener? = null
 
     override fun init() {
+        val resizeListener: (Event) -> Unit = {
+            resizeAndScaleEventsChannel.trySend(getParentContainerBox())
+        }
+
+        globalEvents.addDisposableEvent("resize", resizeListener)
+
         viewportTargetListener = getVisualViewport()?.let { EventTargetListener(it) }
         // Unlike resize on window, this one is also trigerred when visualViewport.scale is changed,
         // so on pinch-to-zoom too:
-        viewportTargetListener?.addDisposableEvent("resize") {
-            resizeAndScaleEventsChannel.trySend(getParentContainerBox())
-        }
+        viewportTargetListener?.addDisposableEvent("resize", resizeListener)
 
         recreateMediaQueryListener()
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
@@ -127,7 +128,6 @@ import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
-import org.w3c.dom.get
 import org.w3c.dom.pointerevents.PointerEvent
 
 private val actualDensity
@@ -150,21 +150,25 @@ private sealed interface KeyboardModeState {
 }
 
 internal class DefaultWindowState(private val viewportContainer: Element) : ComposeWindowState {
-    private val channel = Channel<IntSize>(CONFLATED)
+    private val resizeAndScaleEventsChannel = Channel<IntSize>(CONFLATED)
 
     override val globalEvents = EventTargetListener(window)
 
     private var mediaQueryListener: MediaQueryListener? = null
 
-    override fun init() {
+    private var viewportTargetListener: EventTargetListener? = null
 
-        globalEvents.addDisposableEvent("resize") {
-            channel.trySend(getParentContainerBox())
+    override fun init() {
+        viewportTargetListener = getVisualViewport()?.let { EventTargetListener(it) }
+        // Unlike resize on window, this one is also trigerred when visualViewport.scale is changed,
+        // so on pinch-to-zoom too:
+        viewportTargetListener?.addDisposableEvent("resize") {
+            resizeAndScaleEventsChannel.trySend(getParentContainerBox())
         }
 
         recreateMediaQueryListener()
 
-        channel.trySend(getParentContainerBox())
+        resizeAndScaleEventsChannel.trySend(getParentContainerBox())
     }
 
     private fun getParentContainerBox(): IntSize {
@@ -177,7 +181,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
         mediaQueryListener = object : MediaQueryListener("(resolution: ${contentScale}dppx)") {
             override fun onChange(matches: Boolean) {
                 if (!matches) {
-                    channel.trySend(getParentContainerBox())
+                    resizeAndScaleEventsChannel.trySend(getParentContainerBox())
                 }
                 recreateMediaQueryListener()
             }
@@ -185,11 +189,13 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     }
 
     override fun dispose() {
+        resizeAndScaleEventsChannel.close()
+        viewportTargetListener?.dispose()
         mediaQueryListener?.dispose()
         super.dispose()
     }
 
-    override fun sizeFlow() = channel.receiveAsFlow()
+    override fun sizeFlow() = resizeAndScaleEventsChannel.receiveAsFlow()
 }
 
 @VisibleForTesting
@@ -214,7 +220,7 @@ internal class ComposeWindow(
 
     private var actualActivePointerButtons: PointerButtons = PointerButtons()
 
-    private val density: Density = Density(
+    private var density: Density = Density(
         density = actualDensity.toFloat(),
         fontScale = 1f
     )
@@ -622,7 +628,8 @@ internal class ComposeWindow(
                         state.sizeFlow().collect { size ->
                             // Convert to proper type: IntSize was exposed to public API with meaning of DPs.
                             val boxSize = DpSize(size.width.dp, size.height.dp)
-                            this@ComposeWindow.resize(boxSize)
+                            val viewportScale = getVisualViewportScale()
+                            this@ComposeWindow.resizeAndScale(boxSize, viewportScale)
                         }
                     }
 
@@ -649,7 +656,27 @@ internal class ComposeWindow(
             .navigationEventDispatcher.addInput(navigationEventInput)
     }
 
-    private fun resize(boxSize: DpSize) {
+    private fun resizeAndScale(boxSize: DpSize, viewportScale: Float) = Snapshot.withMutableSnapshot {
+        // Coerce the original value so it doesn't exceed 2.0 to avoid unlimited canvas growth and memory consumption.
+        // Otherwise, the browser might clip the canvas content (tested in Chrome) making some UI parts unreachable.
+        // We accept some blur might be still noticeable and higher than 2.0 scale.
+        val coercedViewportScale = viewportScale.coerceIn(1f, 2f)
+
+        val newDensity = Density(
+            // actualDensity accounts for browser zoom (via Cmd/Ctrl+-),
+            // but it doesn't account for viewport scale.
+            // So account for viewport scale to avoid blurred UI after pinch-to-zoom:
+            density = actualDensity.toFloat() * coercedViewportScale,
+            fontScale = density.fontScale
+        )
+
+        println("newDensity = $newDensity, vs = $coercedViewportScale")
+
+        if (newDensity != density) {
+            density = newDensity
+            scene.density = newDensity
+        }
+
         val sizeInPx = boxSize.toSize(density).toIntSize()
 
         // we need to scale canvas both via CSS styling and HTML attributes
@@ -1193,3 +1220,12 @@ private external interface CustomElementRegistry : JsAny {
 }
 
 private external val customElements: CustomElementRegistry
+
+//language=js
+private fun getVisualViewportScale(): Float =
+    js("window.visualViewport.scale")
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/visualViewport
+// Widely available
+private fun getVisualViewport(): EventTarget =
+    js("window.visualViewport")

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -271,7 +271,7 @@ internal class ComposeWindow(
             override val windowInsets get() = insetsManager?.windowInsets ?: EmptyPlatformWindowInsets
 
             override val dragAndDropManager: PlatformDragAndDropManager = object :
-                WebDragAndDropManager(rootNode, canvasEvents, state.globalEvents, density) {
+                WebDragAndDropManager(rootNode, canvasEvents, state.globalEvents, { density }) {
                 override val rootDragAndDropNode: ComposeSceneDragAndDropNode
                     get() = scene.rootDragAndDropNode
             }
@@ -402,7 +402,7 @@ internal class ComposeWindow(
     private val scene = CanvasLayersComposeScene(
         frameRecomposer = frameRecomposer,
         platformContext = platformContext,
-        density = density,
+        density = density, // initial density
         // TODO: Split layout invalidation from draw invalidation once the web host has distinct
         //  scheduling paths for relayout vs redraw.
         invalidateLayout = sceneRenderingScope::onSceneInvalidation,
@@ -594,14 +594,14 @@ internal class ComposeWindow(
     init {
         if (configuration.enableBrowserWindowInsets) {
             checkViewportFitCover()
-            insetsManager = WebWindowInsetsManager(density, canvas)
+            insetsManager = WebWindowInsetsManager({ density }, canvas)
         }
 
         initEvents(canvas)
         state.init()
 
 
-        scene.density = density
+        scene.density = density // initial density
         archComponentsOwner.enableSavedStateHandles()
 
         val interopContainer = WebInteropContainer(InteropViewGroup(interopContainerElement))
@@ -659,7 +659,7 @@ internal class ComposeWindow(
     private fun resizeAndScale(boxSize: DpSize, viewportScale: Float) = Snapshot.withMutableSnapshot {
         // Coerce the original value so it doesn't exceed 2.0 to avoid unlimited canvas growth and memory consumption.
         // Otherwise, the browser might clip the canvas content (tested in Chrome) making some UI parts unreachable.
-        // We accept some blur might be still noticeable and higher than 2.0 scale.
+        // We accept some blur might be still noticeable on higher than 2.0 scale.
         val coercedViewportScale = viewportScale.coerceIn(1f, 2f)
 
         val newDensity = Density(
@@ -669,8 +669,6 @@ internal class ComposeWindow(
             density = actualDensity.toFloat() * coercedViewportScale,
             fontScale = density.fontScale
         )
-
-        println("newDensity = $newDensity, vs = $coercedViewportScale")
 
         if (newDensity != density) {
             density = newDensity


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7230/Blurry-components-in-zoomed-in-browser
Fixes https://youtrack.jetbrains.com/issue/CMP-8456/Web-Incorrect-position-on-canvas-after-zoom-in-out

Demo:

https://github.com/user-attachments/assets/2575b4f9-a2e1-4cd4-8577-0d426e7f542a



## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fix blurred UI when zooming

