### PR TITLE
Reload input views when showing keyboard in iOS text input connection

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.UIKit.UIView
+import platform.UIKit.reloadInputViews
 
 internal abstract class TextInputConnection(
     protected val updateView: () -> Unit,
@@ -83,6 +84,7 @@ internal abstract class TextInputConnection(
         inputTraits = getUITextInputTraits(request.imeOptions)
         attachInputToView()
         showKeyboard()
+        textInputView.reloadInputViews()
     }
 
     protected abstract fun attachInputToView()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.UIKit.UIView
+import platform.UIKit.reloadInputViews
 
 internal abstract class TextInputConnection(
     protected val updateView: () -> Unit,
@@ -84,6 +85,7 @@ internal abstract class TextInputConnection(
         inputTraits = getUITextInputTraits(request.imeOptions)
         attachInputToView()
         showKeyboard()
+        textInputView.reloadInputViews()
     }
 
     protected abstract fun attachInputToView()


### PR DESCRIPTION
Reload input views when showing keyboard in iOS text input connection

Fixes: 
https://youtrack.jetbrains.com/issue/CMP-10672/iOS-input-traits-dont-update-while-the-text-field-keeps-focus

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
A focused text field now applies changed IME options without refocusing it
