### PR TITLE
Support configuring spell checking type on iOS

### DIFF
--- a/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.ios.kt
+++ b/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.ios.kt
@@ -229,7 +229,8 @@ val IosImeOptionsExample = Screen.Selection(
     IosImeOptionsAutocapitalizationTypeExample,
     IosImeOptionsAutocorrectionTypeExample,
     IosImeOptionsInputViewExample,
-    IosImeOptionsWritingToolsBehaviorExample
+    IosImeOptionsWritingToolsBehaviorExample,
+    IosImeOptionsSpellCheckingExample
 )
 
 @Composable

--- a/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/IosSpellCheckingExample.ios.kt
+++ b/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/IosSpellCheckingExample.ios.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material.TriStateCheckbox
+import androidx.compose.mpp.demo.textfield.ClearFocusBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UITextSpellCheckingType
+
+private const val TextWithTypos = "The quick brwon fox jumps over the lazzy dog"
+
+val IosImeOptionsSpellCheckingExample = Screen.Example("Spell Checking") {
+    ClearFocusBox {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SpellCheckingBlock("BTF1", nativeInput = false, textFieldState = false)
+            SpellCheckingBlock("BTF2", nativeInput = false, textFieldState = true)
+            SpellCheckingBlock("NITI BTF1", nativeInput = true, textFieldState = false)
+            SpellCheckingBlock("NITI BTF2", nativeInput = true, textFieldState = true)
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun SpellCheckingBlock(
+    title: String,
+    nativeInput: Boolean,
+    textFieldState: Boolean
+) {
+    var autoCorrect by remember { mutableStateOf(OptionValue.NotSet) }
+    var autocorrection by remember { mutableStateOf(OptionValue.NotSet) }
+    var spellChecking by remember { mutableStateOf(OptionValue.NotSet) }
+
+    val keyboardOptions = KeyboardOptions(
+        autoCorrectEnabled = autoCorrect.toBooleanOrNull(),
+        platformImeOptions = PlatformImeOptions {
+            usingNativeTextInput(nativeInput)
+            autocorrectionType(autocorrection.toAutocorrectionType())
+            spellCheckingType(spellChecking.toSpellCheckingType())
+        }
+    )
+
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .background(Color.White, RoundedCornerShape(12.dp))
+            .border(1.dp, Color.LightGray, RoundedCornerShape(12.dp))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(title, color = Color.Black, fontSize = 18.sp)
+
+        val fieldModifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+        val textStyle = TextStyle(color = Color.Black, fontSize = 16.sp)
+
+        if (textFieldState) {
+            val state = rememberTextFieldState(TextWithTypos)
+            BasicTextField(
+                state = state,
+                modifier = fieldModifier,
+                keyboardOptions = keyboardOptions,
+                textStyle = textStyle
+            )
+        } else {
+            var text by remember { mutableStateOf(TextWithTypos) }
+            BasicTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = fieldModifier,
+                keyboardOptions = keyboardOptions,
+                textStyle = textStyle
+            )
+        }
+
+        OptionRow(
+            "KeyboardOptions.autoCorrectEnabled",
+            autoCorrect,
+            autoCorrect.label(on = "true", off = "false")
+        ) { autoCorrect = autoCorrect.next() }
+
+        OptionRow(
+            "PlatformImeOptions.autocorrectionType",
+            autocorrection,
+            autocorrection.label(on = "Yes", off = "No")
+        ) { autocorrection = autocorrection.next() }
+
+        OptionRow(
+            "PlatformImeOptions.spellCheckingType",
+            spellChecking,
+            spellChecking.label(on = "Yes", off = "No")
+        ) { spellChecking = spellChecking.next() }
+    }
+}
+
+@Composable
+private fun OptionRow(
+    name: String,
+    value: OptionValue,
+    valueLabel: String,
+    onClick: () -> Unit
+) {
+    Row(
+        Modifier.fillMaxWidth().clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TriStateCheckbox(
+            state = value.toToggleableState(),
+            onClick = onClick
+        )
+        Text("$name = $valueLabel", color = Color.Black, fontSize = 14.sp)
+    }
+}
+
+private enum class OptionValue {
+    NotSet,
+    On,
+    Off,
+}
+
+private fun OptionValue.next() = when (this) {
+    OptionValue.NotSet -> OptionValue.On
+    OptionValue.On -> OptionValue.Off
+    OptionValue.Off -> OptionValue.NotSet
+}
+
+private fun OptionValue.toToggleableState() = when (this) {
+    OptionValue.NotSet -> ToggleableState.Off
+    OptionValue.On -> ToggleableState.On
+    OptionValue.Off -> ToggleableState.Indeterminate
+}
+
+private fun OptionValue.label(on: String, off: String) = when (this) {
+    OptionValue.NotSet -> "not set"
+    OptionValue.On -> on
+    OptionValue.Off -> off
+}
+
+private fun OptionValue.toBooleanOrNull() = when (this) {
+    OptionValue.NotSet -> null
+    OptionValue.On -> true
+    OptionValue.Off -> false
+}
+
+private fun OptionValue.toAutocorrectionType() = when (this) {
+    OptionValue.NotSet -> null
+    OptionValue.On -> UITextAutocorrectionType.UITextAutocorrectionTypeYes
+    OptionValue.Off -> UITextAutocorrectionType.UITextAutocorrectionTypeNo
+}
+
+private fun OptionValue.toSpellCheckingType() = when (this) {
+    OptionValue.NotSet -> null
+    OptionValue.On -> UITextSpellCheckingType.UITextSpellCheckingTypeYes
+    OptionValue.Off -> UITextSpellCheckingType.UITextSpellCheckingTypeNo
+}

--- a/compose/ui/ui-text/src/iosMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.ios.kt
+++ b/compose/ui/ui-text/src/iosMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.ios.kt
@@ -25,6 +25,7 @@ import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
+import platform.UIKit.UITextSpellCheckingType
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehavior
 import platform.UIKit.UIWritingToolsBehaviorDefault
@@ -39,6 +40,7 @@ private data class PlatformImeOptionsImpl(
     val enablesReturnKeyAutomatically: Boolean,
     val autocapitalizationType: UITextAutocapitalizationType?,
     val autocorrectionType: UITextAutocorrectionType?,
+    val spellCheckingType: UITextSpellCheckingType?,
     val hasExplicitTextContentType: Boolean,
     val inputView: UIView?,
     val inputAccessoryView: UIView?,
@@ -59,6 +61,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
     private var enablesReturnKeyAutomatically: Boolean = false
     private var autocapitalizationType: UITextAutocapitalizationType? = null
     private var autocorrectionType: UITextAutocorrectionType? = null
+    private var spellCheckingType: UITextSpellCheckingType? = null
     private var hasExplicitTextContentType: Boolean = false
     private var inputView: UIView? = null
     private var inputAccessoryView: UIView? = null
@@ -151,6 +154,17 @@ class PlatformImeOptionsConfiguration internal constructor() {
     }
 
     /**
+     * Sets the spell checking behavior to apply.
+     * If not set, the value will be derived from [ImeOptions].
+     *
+     * See [UIKit documentation](https://developer.apple.com/documentation/uikit/uitextinputtraits/spellcheckingtype).
+     */
+    @ExperimentalComposeUiApi
+    fun spellCheckingType(value: UITextSpellCheckingType?): PlatformImeOptionsConfiguration = apply {
+        spellCheckingType = value
+    }
+
+    /**
      * Sets a custom input view to be presented instead of the system keyboard when IME becomes first responder.
      * Default value is `null`.
      *
@@ -204,6 +218,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
             enablesReturnKeyAutomatically = enablesReturnKeyAutomatically,
             autocapitalizationType = autocapitalizationType,
             autocorrectionType = autocorrectionType,
+            spellCheckingType = spellCheckingType,
             hasExplicitTextContentType = hasExplicitTextContentType,
             inputView = inputView,
             inputAccessoryView = inputAccessoryView,
@@ -258,6 +273,10 @@ val PlatformImeOptions.autocapitalizationType: UITextAutocapitalizationType?
 @ExperimentalComposeUiApi
 val PlatformImeOptions.autocorrectionType: UITextAutocorrectionType?
     get() = (this as? PlatformImeOptionsImpl)?.autocorrectionType
+
+@ExperimentalComposeUiApi
+val PlatformImeOptions.spellCheckingType: UITextSpellCheckingType?
+    get() = (this as? PlatformImeOptionsImpl)?.spellCheckingType
 
 @ExperimentalComposeUiApi
 val PlatformImeOptions.hasExplicitTextContentType: Boolean

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.ios.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.input.isSecureTextEntry
 import androidx.compose.ui.text.input.keyboardAppearance
 import androidx.compose.ui.text.input.keyboardType
 import androidx.compose.ui.text.input.returnKeyType
+import androidx.compose.ui.text.input.spellCheckingType
 import androidx.compose.ui.text.input.textContentType
 import androidx.compose.ui.text.input.writingToolsBehavior
 import platform.UIKit.UIKeyboardAppearance
@@ -49,6 +50,7 @@ import platform.UIKit.UITextContentType
 import platform.UIKit.UITextContentTypeEmailAddress
 import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
+import platform.UIKit.UITextSpellCheckingType
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehavior
 import platform.UIKit.UIWritingToolsBehaviorDefault
@@ -77,6 +79,9 @@ internal interface SkikoUITextInputTraits {
 
     fun autocorrectionType(): UITextAutocorrectionType =
         UITextAutocorrectionType.UITextAutocorrectionTypeYes
+
+    fun spellCheckingType(): UITextSpellCheckingType =
+        UITextSpellCheckingType.UITextSpellCheckingTypeDefault
 
     fun inputView(): UIView? = null
 
@@ -193,6 +198,18 @@ internal fun getUITextInputTraits(currentImeOptions: ImeOptions?) =
                 true -> UITextAutocorrectionType.UITextAutocorrectionTypeYes
                 false -> UITextAutocorrectionType.UITextAutocorrectionTypeNo
                 else -> UITextAutocorrectionType.UITextAutocorrectionTypeDefault
+            }
+        }
+
+        override fun spellCheckingType(): UITextSpellCheckingType {
+            currentImeOptions?.platformImeOptions?.spellCheckingType?.let {
+                return it
+            }
+
+            return when (currentImeOptions?.autoCorrect) {
+                true -> UITextSpellCheckingType.UITextSpellCheckingTypeYes
+                false -> UITextSpellCheckingType.UITextSpellCheckingTypeNo
+                else -> UITextSpellCheckingType.UITextSpellCheckingTypeDefault
             }
         }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -66,6 +66,7 @@ import platform.UIKit.UITextLayoutDirectionUp
 import platform.UIKit.UITextPosition
 import platform.UIKit.UITextRange
 import platform.UIKit.UITextSelectionRect
+import platform.UIKit.UITextSpellCheckingType
 import platform.UIKit.UITextStorageDirection
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehavior
@@ -439,6 +440,7 @@ internal class ComposeTextInputView(
     override fun enablesReturnKeyAutomatically(): Boolean = inputTraits.enablesReturnKeyAutomatically()
     override fun autocapitalizationType(): UITextAutocapitalizationType = inputTraits.autocapitalizationType()
     override fun autocorrectionType(): UITextAutocorrectionType = inputTraits.autocorrectionType()
+    override fun spellCheckingType(): UITextSpellCheckingType = inputTraits.spellCheckingType()
     override fun writingToolsBehavior(): UIWritingToolsBehavior = inputTraits.writingToolsBehavior()
 
     /**

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -93,6 +93,7 @@ import platform.UIKit.UITextLayoutDirectionUp
 import platform.UIKit.UITextPosition
 import platform.UIKit.UITextRange
 import platform.UIKit.UITextSelectionRect
+import platform.UIKit.UITextSpellCheckingType
 import platform.UIKit.UITextStorageDirection
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
@@ -538,6 +539,7 @@ internal class NativeTextInputView
     override fun enablesReturnKeyAutomatically(): Boolean = inputTraits.enablesReturnKeyAutomatically()
     override fun autocapitalizationType(): UITextAutocapitalizationType = inputTraits.autocapitalizationType()
     override fun autocorrectionType(): UITextAutocorrectionType = inputTraits.autocorrectionType()
+    override fun spellCheckingType(): UITextSpellCheckingType = inputTraits.spellCheckingType()
     override fun writingToolsBehavior(): UIWritingToolsBehavior = inputTraits.writingToolsBehavior()
 
     /**

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -64,6 +64,7 @@ import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
 import platform.UIKit.UITextContentTypeUsername
 import platform.UIKit.UITextInputProtocol
+import platform.UIKit.UITextSpellCheckingType
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehaviorDefault
 import platform.UIKit.UIWritingToolsBehaviorLimited
@@ -459,6 +460,52 @@ internal class ImeOptionsTest {
             imeOptions = PlatformImeOptions { writingToolsBehavior(UIWritingToolsBehaviorLimited) }
         )
         assertEquals(UIWritingToolsBehaviorLimited, input.writingToolsBehavior)
+    }
+
+    @Test
+    fun testSpellCheckingTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(
+            UITextSpellCheckingType.UITextSpellCheckingTypeYes,
+            input.spellCheckingType
+        )
+    }
+
+    @Test
+    fun testSpellCheckingType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions {
+                spellCheckingType(UITextSpellCheckingType.UITextSpellCheckingTypeNo)
+            }
+        )
+        assertEquals(
+            UITextSpellCheckingType.UITextSpellCheckingTypeNo,
+            input.spellCheckingType
+        )
+    }
+
+    @Test
+    fun testSpellCheckingTypeFollowsDisabledAutoCorrect() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(autoCorrectEnabled = false)
+        )
+        assertEquals(
+            UITextSpellCheckingType.UITextSpellCheckingTypeNo,
+            input.spellCheckingType
+        )
+    }
+
+    @Test
+    fun testPlatformOverridesCommonSpellCheckingType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                autoCorrectEnabled = false,
+                platformImeOptions = PlatformImeOptions { spellCheckingType(UITextSpellCheckingType.UITextSpellCheckingTypeYes) }
+            )
+        )
+        assertEquals(UITextSpellCheckingType.UITextSpellCheckingTypeYes, input.spellCheckingType)
     }
 
     private fun UIKitInstrumentedTest.setContentAndFindInputView(


### PR DESCRIPTION
Added forwarding spellchecking type to PlatformImeOptions

Added example screen to the demo app

Added related instrumented tests

Fixes: [CMP-10632](https://youtrack.jetbrains.com/issue/CMP-10632) Forward spellCheckingType to the UITextInputTraits

## Testing
Manual, instrumented tests

## Release Notes
### Features - iOS
Added possibility to configure `spellCheckingType` for textfields with `usingNativeTextInput = true` via `PlatformImeOptions`

### Fixes - iOS
`KeyboardOptions.autoCorrectEnabled = false` now disables spell checking too (in addition to iOS autocorrection) in textfields with `usingNativeTextInput = true`
