### PR TITLE
Pass SKIKO_VERSION setup in non-AOSP mode

### DIFF
--- a/buildSrc-fork/settingsScripts/skiko-setup.groovy
+++ b/buildSrc-fork/settingsScripts/skiko-setup.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.GradleException
+import org.gradle.api.initialization.Settings
+
+class SkikoSetup {
+    /**
+     * Declares the skiko entry in the version catalog of the given settings instance.
+     *
+     * @param settings The settings instance for the current root project
+     */
+    static void defineSkikoInVersionCatalog(Settings settings) {
+        settings.dependencyResolutionManagement {
+            versionCatalogs {
+                libs {
+                    def skikoOverride = System.getenv("SKIKO_VERSION")
+                    if (skikoOverride != null) {
+                        org.gradle.api.logging.Logging.getLogger(SkikoSetup.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
+                                "SKIKO_VERSION being set.")
+                        version('skiko', skikoOverride)
+                    }
+                    String os = System.getProperty("os.name").toLowerCase(Locale.US)
+                    String currentOsArtifact
+                    if (os.contains("mac os x") || os.contains("darwin") || os.contains("osx")) {
+                        def arch = System.getProperty("os.arch")
+                        if (arch == "aarch64") {
+                            currentOsArtifact = "skiko-awt-runtime-macos-arm64"
+                        } else {
+                            currentOsArtifact = "skiko-awt-runtime-macos-x64"
+                        }
+                    } else if (os.startsWith("win")) {
+                        currentOsArtifact = "skiko-awt-runtime-windows-x64"
+                    } else if (os.startsWith("linux")) {
+                        def arch = System.getProperty("os.arch")
+                        if (arch == "aarch64") {
+                            currentOsArtifact = "skiko-awt-runtime-linux-arm64"
+                        } else {
+                            currentOsArtifact = "skiko-awt-runtime-linux-x64"
+                        }
+                    } else {
+                        throw new GradleException("Unsupported operating system $os")
+                    }
+                    library("skikoCurrentOs", "org.jetbrains.skiko",
+                            currentOsArtifact).versionRef("skiko")
+                }
+            }
+        }
+    }
+}
+
+ext.skikoSetup = new SkikoSetup()

--- a/buildSrc-fork/settingsScripts/skiko-setup.groovy
+++ b/buildSrc-fork/settingsScripts/skiko-setup.groovy
@@ -54,8 +54,6 @@ class SkikoSetup {
                     } else {
                         throw new GradleException("Unsupported operating system $os")
                     }
-                    library("skikoCurrentOs", "org.jetbrains.skiko",
-                            currentOsArtifact).versionRef("skiko")
                 }
             }
         }

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
     }
 }
 
-// Apply the fork's skiko setup so that the SKIKO_VERSION env var override is repsected
+// Apply the fork's skiko setup so that the SKIKO_VERSION env var override is respected
 apply(from: "buildSrc-fork/settingsScripts/skiko-setup.groovy")
 skikoSetup.defineSkikoInVersionCatalog(settings)
 

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -15,6 +15,11 @@ dependencyResolutionManagement {
     }
 }
 
+// Reuse the shared skiko setup so that the SKIKO_VERSION env var override is
+// respected in JetBrains fork mode (same behavior as in AOSP mode).
+apply(from: "buildSrc/settingsScripts/skiko-setup.groovy")
+skikoSetup.defineSkikoInVersionCatalog(settings)
+
 def supportRootFolder = buildscript.sourceFile.getParentFile()
 
 /* In JetBrains Fork we don't force Android Studio usage.

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -15,8 +15,7 @@ dependencyResolutionManagement {
     }
 }
 
-// Apply the fork's skiko setup so that the SKIKO_VERSION env var override is
-// respected in JetBrains fork mode (same behavior as in AOSP mode).
+// Apply the fork's skiko setup so that the SKIKO_VERSION env var override is repsected
 apply(from: "buildSrc-fork/settingsScripts/skiko-setup.groovy")
 skikoSetup.defineSkikoInVersionCatalog(settings)
 

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -15,9 +15,9 @@ dependencyResolutionManagement {
     }
 }
 
-// Reuse the shared skiko setup so that the SKIKO_VERSION env var override is
+// Apply the fork's skiko setup so that the SKIKO_VERSION env var override is
 // respected in JetBrains fork mode (same behavior as in AOSP mode).
-apply(from: "buildSrc/settingsScripts/skiko-setup.groovy")
+apply(from: "buildSrc-fork/settingsScripts/skiko-setup.groovy")
 skikoSetup.defineSkikoInVersionCatalog(settings)
 
 def supportRootFolder = buildscript.sourceFile.getParentFile()


### PR DESCRIPTION
The goal of this PR is to restore the behaviour of skiko version resolution in non-AOSP mode

## Testing
Launch any run configuration with SKIKO_VERSION set

## Release Notes
N/A
