### PR TITLE
Support SemanticProperties.disabled in Compose web A11y

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -258,9 +258,11 @@ internal class ComposeWebSemanticsListener(
         rootOffset: Offset,
         justCreated: Boolean = false,
     ) {
-        // Mark the element with the semantics node ID for click event delegation lookup.
-        // https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes
-        htmlNode.setAttribute(DATA_SEMANTICS_ID_KEY, sn.id.toString())
+        if (justCreated) {
+            // Mark the element with the semantics node ID for click event delegation lookup.
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes
+            htmlNode.setAttribute(DATA_SEMANTICS_ID_KEY, sn.id.toString())
+        }
 
         val config = sn.config
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -38,7 +38,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.Event
 
 internal class ComposeWebSemanticsListener(
     val webSemanticsRoot: HTMLElement,
@@ -52,6 +54,7 @@ internal class ComposeWebSemanticsListener(
     private companion object {
         const val MAX_TIME_IN_DEBOUNCE_MS = 1000L
         const val DEBOUNCE_MS = 100L
+        const val DATA_SEMANTICS_ID_KEY = "data-semantics-id"
     }
 
 
@@ -122,6 +125,9 @@ internal class ComposeWebSemanticsListener(
                 }
             }
         }
+
+        // Event delegation: all nodes delegate to one global click listener
+        webSemanticsRoot.addEventListener("click", onClick)
     }
 
     private var semanticsOwner: SemanticsOwner? = null
@@ -151,6 +157,25 @@ internal class ComposeWebSemanticsListener(
     private val nodes = MutableScatterMap<Int, SemanticsNode>()
     private val nodeToParent = MutableScatterMap<Int, Int>()
     private val webNodes = MutableScatterMap<Int, HTMLElement>()
+
+    /**
+     * Event delegation: Single shared click listener for all a11y nodes
+     */
+    private val onClick: (Event) -> Unit = onClick@ { event ->
+        val element = (event.target as? Element)
+            ?.closest("[$DATA_SEMANTICS_ID_KEY]")
+            ?: return@onClick
+        val semanticsId = element.getAttribute(DATA_SEMANTICS_ID_KEY)?.toIntOrNull() ?: return@onClick
+        val config = nodes[semanticsId]?.config ?: return@onClick
+
+        if (config.contains(SemanticsProperties.Disabled)) {
+            return@onClick
+        }
+
+        if (config.contains(SemanticsActions.OnClick)) {
+            config[SemanticsActions.OnClick].action?.invoke()
+        }
+    }
 
 
     private fun syncSemanticsWithWebA11Y() {
@@ -233,6 +258,10 @@ internal class ComposeWebSemanticsListener(
         rootOffset: Offset,
         justCreated: Boolean = false,
     ) {
+        // Mark the element with the semantics node ID for click event delegation lookup.
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes
+        htmlNode.setAttribute(DATA_SEMANTICS_ID_KEY, sn.id.toString())
+
         val config = sn.config
 
         if (config.contains(SemanticsProperties.Text)) {
@@ -243,15 +272,6 @@ internal class ComposeWebSemanticsListener(
         if (config.contains(SemanticsProperties.ContentDescription)) {
             val contentDescription = config[SemanticsProperties.ContentDescription]
             htmlNode.setAttribute("aria-label", contentDescription.fastJoinToString(", "))
-        }
-
-        if (config.contains(SemanticsActions.OnClick) && justCreated) {
-            val listener = config[SemanticsActions.OnClick].action!!
-
-            // TODO: need to remove the click listener when the new config version doesn't have OnClick action
-            htmlNode.addEventListener("click", {
-                listener.invoke()
-            })
         }
 
         if (config.contains(SemanticsProperties.TestTag)) {
@@ -269,6 +289,12 @@ internal class ComposeWebSemanticsListener(
                     htmlNode.click()
                 })
             }
+        }
+
+        if (config.contains(SemanticsProperties.Disabled)) {
+            htmlNode.setAttribute("aria-disabled", "true")
+        } else {
+            htmlNode.removeAttribute("aria-disabled")
         }
 
         setA11YAriaRole(element = htmlNode, config.getRoleId())

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -527,6 +527,49 @@ class CfWA11YTest : OnCanvasTests {
         assertTrue(a11yContainer.innerHTML.contains("ChildText"))
     }
 
+    @Test // https://youtrack.jetbrains.com/issue/CMP-8614
+    fun disabledButtonAriaDisabledAndClickBehavior() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
+        var clickCounter = 0
+        var buttonEnabled by mutableStateOf(true)
+
+        createComposeWindow {
+            Button(
+                onClick = { clickCounter++ },
+                enabled = buttonEnabled,
+                modifier = Modifier.testTag("disabledButtonTestTag")
+            ) {
+                Text("Button")
+            }
+        }
+
+        awaitA11YChanges()
+
+        val button = getShadowRoot().getElementById("disabledButtonTestTag") as? HTMLElement
+        assertNotNull(button)
+        assertEquals("button", button.getAttribute("role"))
+        assertNull(button.getAttribute("aria-disabled"), "Button should not have aria-disabled when enabled")
+
+        button.click()
+        assertEquals(1, clickCounter, "Enabled button must fire click action")
+
+        // Disable the button
+        buttonEnabled = false
+        awaitA11YChanges()
+
+        assertEquals("true", button.getAttribute("aria-disabled"), "Button must have aria-disabled=\"true\" when disabled")
+        button.click()
+        assertEquals(1, clickCounter, "Disabled button must not fire click action")
+
+        // Re-enable the button
+        buttonEnabled = true
+        awaitA11YChanges()
+
+        assertNull(button.getAttribute("aria-disabled"), "Button must not have aria-disabled when re-enabled")
+        button.click()
+        assertEquals(2, clickCounter, "Re-enabled button must fire click action")
+    }
+
     @Test // Reproduces the user-reported scenario from CMP-10226
     fun spacerReappearsAfterGraphicsLayerClipToggle() = runApplicationTest {
         // graphicsLayer sets Shape semantics ONLY when clip=true

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -20,6 +20,7 @@
 
 package androidx.compose.ui.platform.a11y
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material.Button
@@ -525,6 +526,44 @@ class CfWA11YTest : OnCanvasTests {
         awaitA11YChanges()
         assertNotNull(getShadowRoot().getElementById("myColumn"))
         assertTrue(a11yContainer.innerHTML.contains("ChildText"))
+    }
+
+    @Test // https://youtrack.jetbrains.com/issue/CMP-8614
+    fun clickableRemovalStopsFiringClick() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
+        var clickCounter = 0
+        var clickable by mutableStateOf(true)
+
+        createComposeWindow {
+            Text(
+                "Tap me",
+                modifier = Modifier
+                    .testTag("clickableText")
+                    .then(if (clickable) Modifier.clickable { clickCounter++ } else Modifier)
+            )
+        }
+
+        awaitA11YChanges()
+
+        val text = getShadowRoot().getElementById("clickableText") as? HTMLElement
+        assertNotNull(text)
+
+        text.click()
+        assertEquals(1, clickCounter, "Clickable text must fire click action")
+
+        // Remove clickable
+        clickable = false
+        awaitA11YChanges()
+
+        text.click()
+        assertEquals(1, clickCounter, "Text without clickable must not fire click action")
+
+        // Re-add clickable
+        clickable = true
+        awaitA11YChanges()
+
+        text.click()
+        assertEquals(2, clickCounter, "Re-added clickable text must fire click action")
     }
 
     @Test // https://youtrack.jetbrains.com/issue/CMP-8614


### PR DESCRIPTION
**Changes:**
- add `aria-disabled="true"` for nodes with`SemanticProperties.disabled`
- ensure the click callback is not trigerred for a node with `SemanticProperties.disabled`
- Refactor to have one global click listener on the a11y root node - all nodes delegate to it

Fixes https://youtrack.jetbrains.com/issue/CMP-8614/Web-A11y.-Disabled-components-dont-have-disabled-attribute

## Testing
- Added a unit test
- This should be tested by QA

## Release Notes
### Fixes - Web
- Support `SemanticProperties.disabled` in Compose Web a11y

