### PR TITLE
Fix desktop CI

### DIFF
--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -6,7 +6,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         java-version: '21'
-        distribution: 'corretto'
+        distribution: 'jetbrains'
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -27,9 +27,16 @@ jobs:
       - name: Setup Prerequisites
         uses: ./.github/actions/setup-prerequisites
 
+      - name: Setup Window Manager
+        run: sudo apt-get update && sudo apt-get install -y xvfb openbox x11-utils
+
       - name: Start X Server
         run: |
           sudo Xvfb :1 -screen 0 1920x1080x24 -extension RANDR +extension GLX &
+          export DISPLAY=:1
+          until xdpyinfo >/dev/null 2>&1; do sleep 0.1; done
+          openbox &
+          until xprop -root _NET_SUPPORTING_WM_CHECK >/dev/null 2>&1; do sleep 0.1; done
           echo "DISPLAY=:1.0" >> $GITHUB_ENV
 
       - name: Run Desktop

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
@@ -55,19 +55,23 @@ internal fun Dimension.copy(
 ): Dimension = Dimension(width, height)
 
 internal fun Point.toDpOffset() = DpOffset(x.dp, y.dp)
-internal fun Rectangle.toDpRect() = DpRect(
-    left = x.dp,
-    top = y.dp,
-    right = (x + width).dp,
-    bottom = (y + height).dp
-)
+internal fun Rectangle.toDpRect() =
+    DpRect(
+        left = x.dp,
+        top = y.dp,
+        right = (x + width).dp,
+        bottom = (y + height).dp
+    )
 
-internal fun DpSize.roundToDimension() = Dimension(
-    width.value.roundToInt(),
-    height.value.roundToInt()
-)
+internal fun DpSize.roundToDimension() =
+    Dimension(
+        width.value.roundToInt(),
+        height.value.roundToInt()
+    )
 internal fun DpSize.roundToDimensionOrNull() =
     if (isSpecified) roundToDimension() else null
+
+internal fun DpOffset.roundToPoint() = Point(x.value.roundToInt(), y.value.roundToInt())
 
 /**
  * Converts AWT [Insets] to [DpInsets].
@@ -78,3 +82,4 @@ internal fun Insets.toDpInsets() = DpInsets(
     bottom = bottom.dp,
     right = right.dp
 )
+

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowStateTest.kt
@@ -45,7 +45,6 @@ import java.awt.Window
 import java.awt.event.WindowEvent
 import javax.swing.JFrame
 import kotlin.math.abs
-import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.test.assertEquals
 import kotlinx.coroutines.channels.Channel
@@ -828,66 +827,6 @@ class WindowStateTest {
             size.width - insets.left - insets.right,
             size.height - insets.top - insets.bottom,
         )
-}
-
-private const val LinuxCoordinateTolerance = 10
-
-private val CoordinateTolerance = if (isLinux) LinuxCoordinateTolerance else 0
-
-private fun assertCoordinatesApproximatelyEqual(
-    expected: Point,
-    actual: Point,
-) {
-    if (((expected.x - actual.x).absoluteValue > CoordinateTolerance) ||
-        ((expected.y - actual.y).absoluteValue > CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> with absolute tolerance" +
-                " <$CoordinateTolerance>, actual <$actual>."
-        )
-    }
-}
-
-private fun assertSizesApproximatelyEqual(
-    expected: Dimension,
-    actual: Dimension,
-) {
-    if (((expected.width - actual.width).absoluteValue > CoordinateTolerance) ||
-        ((expected.height - actual.height).absoluteValue > CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> with absolute tolerance" +
-                " <$CoordinateTolerance>, actual <$actual>."
-        )
-    }
-}
-
-private fun assertCoordinatesNotApproximatelyEqual(
-    expected: Point,
-    actual: Point,
-) {
-    if (((expected.x - actual.x).absoluteValue <= CoordinateTolerance) &&
-        ((expected.y - actual.y).absoluteValue <= CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> to not equal actual <$actual> with absolute" +
-                " tolerance <$CoordinateTolerance>"
-        )
-    }
-}
-
-private fun assertSizesNotApproximatelyEqual(
-    expected: Dimension,
-    actual: Dimension,
-) {
-    if (((expected.width - actual.width).absoluteValue <= CoordinateTolerance) &&
-        ((expected.height - actual.height).absoluteValue <= CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> to not equal actual <$actual> with absolute" +
-                " tolerance <$CoordinateTolerance>"
-        )
-    }
 }
 
 private fun assertWindowStateEquals(expected: WindowState, actual: WindowState) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowTestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowTestUtils.kt
@@ -16,10 +16,15 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.isLinux
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import java.awt.Dimension
 import java.awt.GraphicsConfiguration
 import java.awt.Insets
+import java.awt.Point
+import kotlin.math.absoluteValue
 
 
 /**
@@ -40,5 +45,86 @@ internal fun GraphicsConfiguration.screenSize(): DpSize {
     return bounds.let {
         // The AWT coordinates are scaled, so they're Dp
         DpSize(it.width.dp, it.height.dp)
+    }
+}
+
+
+private const val LinuxCoordinateTolerance = 10
+
+private val CoordinateTolerance = if (isLinux) LinuxCoordinateTolerance else 0
+
+internal fun assertCoordinatesApproximatelyEqual(
+    expected: Point,
+    actual: Point,
+) {
+    if (((expected.x - actual.x).absoluteValue > CoordinateTolerance) ||
+        ((expected.y - actual.y).absoluteValue > CoordinateTolerance)
+    ) {
+        throw AssertionError(
+            "Expected <$expected> with absolute tolerance" +
+                " <$CoordinateTolerance>, actual <$actual>."
+        )
+    }
+}
+
+internal fun assertCoordinatesApproximatelyEqual(
+    expected: DpOffset,
+    actual: DpOffset,
+) {
+    assertCoordinatesApproximatelyEqual(
+        expected = expected.roundToPoint(),
+        actual = actual.roundToPoint(),
+    )
+}
+
+internal fun assertSizesApproximatelyEqual(
+    expected: Dimension,
+    actual: Dimension,
+) {
+    if (((expected.width - actual.width).absoluteValue > CoordinateTolerance) ||
+        ((expected.height - actual.height).absoluteValue > CoordinateTolerance)
+    ) {
+        throw AssertionError(
+            "Expected <$expected> with absolute tolerance" +
+                " <$CoordinateTolerance>, actual <$actual>."
+        )
+    }
+}
+
+internal fun assertSizesApproximatelyEqual(
+    expected: DpSize,
+    actual: DpSize,
+) {
+    assertSizesApproximatelyEqual(
+        expected = expected.roundToDimension(),
+        actual = actual.roundToDimension(),
+    )
+}
+
+internal fun assertCoordinatesNotApproximatelyEqual(
+    expected: Point,
+    actual: Point,
+) {
+    if (((expected.x - actual.x).absoluteValue <= CoordinateTolerance) &&
+        ((expected.y - actual.y).absoluteValue <= CoordinateTolerance)
+    ) {
+        throw AssertionError(
+            "Expected <$expected> to not equal actual <$actual> with absolute" +
+                " tolerance <$CoordinateTolerance>"
+        )
+    }
+}
+
+internal fun assertSizesNotApproximatelyEqual(
+    expected: Dimension,
+    actual: Dimension,
+) {
+    if (((expected.width - actual.width).absoluteValue <= CoordinateTolerance) &&
+        ((expected.height - actual.height).absoluteValue <= CoordinateTolerance)
+    ) {
+        throw AssertionError(
+            "Expected <$expected> to not equal actual <$actual> with absolute" +
+                " tolerance <$CoordinateTolerance>"
+        )
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
@@ -770,7 +770,7 @@ class DialogWindowV2StateTest {
         testName: String,
         sizeProvider: WindowSizeProvider,
         content: @Composable () -> Unit,
-        expectedWindowSizeSansInsets: DpSize,
+        expectedDialogSizeSansInsets: DpSize,
     ) = runApplicationTest {
         val dialogState = DialogState(
             initialBoundsProvider = WindowBoundsProvider(sizeProvider)
@@ -780,16 +780,21 @@ class DialogWindowV2StateTest {
             DialogWindow(
                 state = dialogState,
                 onCloseRequest = {},
+                // On Linux, insets are not known until the dialog is visible, but we set the
+                // bounds taking them into account before that
+                decoration =
+                    if (isLinux) WindowDecoration.Undecorated() else WindowDecoration.SystemDefault,
                 title = testName
             ) {
                 dialog = this.window
                 content()
             }
         }
+
         awaitIdle()
         assertEquals(
-            expectedWindowSizeSansInsets + dialog.insets.toDpInsets(),
-            dialogState.bounds.size
+            expected = expectedDialogSizeSansInsets + dialog.insets.toDpInsets(),
+            actual = dialogState.bounds.size
         )
     }
 
@@ -802,7 +807,7 @@ class DialogWindowV2StateTest {
                 width = { 400.dp.roundToPx() }
             )
         },
-        expectedWindowSizeSansInsets = DpSize(400.dp, 500.dp)
+        expectedDialogSizeSansInsets = DpSize(400.dp, 500.dp)
     )
 
     @Test
@@ -814,7 +819,7 @@ class DialogWindowV2StateTest {
                 height = { 400.dp.roundToPx() }
             )
         },
-        expectedWindowSizeSansInsets = DpSize(500.dp, 400.dp)
+        expectedDialogSizeSansInsets = DpSize(500.dp, 400.dp)
     )
 
     @Test
@@ -827,7 +832,7 @@ class DialogWindowV2StateTest {
                 layout(size, size) { }
             }
         },
-        expectedWindowSizeSansInsets = DpSize(101.dp, 101.dp)
+        expectedDialogSizeSansInsets = DpSize(101.dp, 101.dp)
     )
 
     private fun runBoundsOverwriteTest(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/DialogWindowV2StateTest.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.unit.size
 import androidx.compose.ui.unit.topLeft
 import androidx.compose.ui.unit.width
 import androidx.compose.ui.window.WindowDecoration
+import androidx.compose.ui.window.assertCoordinatesApproximatelyEqual
+import androidx.compose.ui.window.assertSizesApproximatelyEqual
 import androidx.compose.ui.window.runApplicationTest
 import androidx.compose.ui.window.toDpInsets
 import androidx.compose.ui.window.toDpOffset
@@ -861,8 +863,8 @@ class DialogWindowV2StateTest {
         }
         awaitIdle()
 
-        assertEquals(expectedSize, dialogState.bounds.size)
-        assertEquals(expectedPosition, dialogState.bounds.topLeft)
+        assertSizesApproximatelyEqual(expectedSize, dialogState.bounds.size)
+        assertCoordinatesApproximatelyEqual(expectedPosition, dialogState.bounds.topLeft)
     }
 
     @Test

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.isLinux
 import androidx.compose.ui.isMacOs
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.toDpSize
-import androidx.compose.ui.unit.DpInsets
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
@@ -45,6 +44,10 @@ import androidx.compose.ui.unit.topLeft
 import androidx.compose.ui.unit.width
 import androidx.compose.ui.window.WindowDecoration
 import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.assertCoordinatesApproximatelyEqual
+import androidx.compose.ui.window.assertCoordinatesNotApproximatelyEqual
+import androidx.compose.ui.window.assertSizesApproximatelyEqual
+import androidx.compose.ui.window.assertSizesNotApproximatelyEqual
 import androidx.compose.ui.window.toDpOffset
 import androidx.compose.ui.window.runApplicationTest
 import androidx.compose.ui.window.toDpInsets
@@ -57,7 +60,6 @@ import java.awt.event.ComponentEvent
 import java.awt.event.WindowEvent
 import javax.swing.JFrame
 import kotlin.math.abs
-import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -1099,8 +1101,8 @@ class WindowV2StateTest {
         }
         awaitIdle()
 
-        assertEquals(expectedSize, windowState.bounds.size)
-        assertEquals(expectedPosition, windowState.bounds.topLeft)
+        assertSizesApproximatelyEqual(expectedSize, windowState.bounds.size)
+        assertCoordinatesApproximatelyEqual(expectedPosition, windowState.bounds.topLeft)
     }
 
     @Test
@@ -1134,66 +1136,6 @@ class WindowV2StateTest {
             windowState = windowState,
             expectedSize = size,
             expectedPosition = position,
-        )
-    }
-}
-
-private const val LinuxCoordinateTolerance = 10
-
-private val CoordinateTolerance = if (isLinux) LinuxCoordinateTolerance else 0
-
-internal fun assertCoordinatesApproximatelyEqual(
-    expected: Point,
-    actual: Point,
-) {
-    if (((expected.x - actual.x).absoluteValue > CoordinateTolerance) ||
-        ((expected.y - actual.y).absoluteValue > CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> with absolute tolerance" +
-                " <$CoordinateTolerance>, actual <$actual>."
-        )
-    }
-}
-
-internal fun assertSizesApproximatelyEqual(
-    expected: Dimension,
-    actual: Dimension,
-) {
-    if (((expected.width - actual.width).absoluteValue > CoordinateTolerance) ||
-        ((expected.height - actual.height).absoluteValue > CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> with absolute tolerance" +
-                " <$CoordinateTolerance>, actual <$actual>."
-        )
-    }
-}
-
-internal fun assertCoordinatesNotApproximatelyEqual(
-    expected: Point,
-    actual: Point,
-) {
-    if (((expected.x - actual.x).absoluteValue <= CoordinateTolerance) &&
-        ((expected.y - actual.y).absoluteValue <= CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> to not equal actual <$actual> with absolute" +
-                " tolerance <$CoordinateTolerance>"
-        )
-    }
-}
-
-internal fun assertSizesNotApproximatelyEqual(
-    expected: Dimension,
-    actual: Dimension,
-) {
-    if (((expected.width - actual.width).absoluteValue <= CoordinateTolerance) &&
-        ((expected.height - actual.height).absoluteValue <= CoordinateTolerance)
-    ) {
-        throw AssertionError(
-            "Expected <$expected> to not equal actual <$actual> with absolute" +
-                " tolerance <$CoordinateTolerance>"
         )
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/v2/WindowV2StateTest.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.isLinux
 import androidx.compose.ui.isMacOs
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.toDpSize
+import androidx.compose.ui.unit.DpInsets
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
@@ -1018,6 +1019,10 @@ class WindowV2StateTest {
             Window(
                 state = windowState,
                 onCloseRequest = {},
+                // On Linux, insets are not known until the window is visible, but we set the
+                // bounds taking them into account before that
+                decoration =
+                    if (isLinux) WindowDecoration.Undecorated() else WindowDecoration.SystemDefault,
                 title = testName
             ) {
                 window = this.window
@@ -1026,8 +1031,8 @@ class WindowV2StateTest {
         }
         awaitIdle()
         assertEquals(
-            expectedWindowSizeSansInsets + window.insets.toDpInsets(),
-            windowState.bounds.size
+            expected = expectedWindowSizeSansInsets + window.insets.toDpInsets(),
+            actual = windowState.bounds.size
         )
     }
 


### PR DESCRIPTION
- Use JBR 21, not Corretto
- Use xvfb with OpenBox, an actual window manager
- Fix some tests that were failing because OpenBox has different insets after the window is made visible

## Testing
N/A

## Release Notes
N/A