### PR TITLE
Refactor ComposeWebSemanticsListener

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -33,7 +33,9 @@ import kotlin.js.js
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
@@ -55,15 +57,21 @@ internal class ComposeWebSemanticsListener(
     private companion object {
         const val MAX_TIME_IN_DEBOUNCE_MS = 1000L
         const val DEBOUNCE_MS = 100L
-        const val DATA_SEMANTICS_ID_KEY = "data-semantics-id"
     }
 
+    private var hasStarted = false
+    private var hasStopped = false
+    private val startJob = Job()
 
     /**
      * @param coroutineScope The [CoroutineScope] used to run this listener,
      * typically the composition scope so the listener follows the composition lifecycle.
      */
     internal fun start(coroutineScope: CoroutineScope) {
+        check(!hasStopped) { "ComposeWebSemanticsListener can't be started after it was stopped" }
+        if (hasStarted) return
+        hasStarted = true
+
         // Here we do the following:
         // - Every invalidation doesn't trigger an a11y tree sync immediately, but only after the changes have settled (debounce 100ms).
         // - We track the time spent in "debounce", so eventually it must sync the a11y tree despite no pause in invalidation events (the changes couldn't settle).
@@ -81,12 +89,15 @@ internal class ComposeWebSemanticsListener(
                  |---------- 1200ms ---------|             |--- 100 ms ---| -> sync after changes settle
                                              | No forced sync here, because the debouncing has just started
          */
-        coroutineScope.launch {
+        coroutineScope.launch(
+            context = startJob,
+            start = CoroutineStart.UNDISPATCHED
+        ) {
             var timeSpentDebouncing = 0L
             var lastDebouncedTime = 0L
             var lastSyncTime = currentTimeMillis()
 
-            launch {
+            launch(start = CoroutineStart.UNDISPATCHED) {
                 invalidationChannel.receiveAsFlow().collect {
                     val currentTime = currentTimeMillis()
 
@@ -111,7 +122,7 @@ internal class ComposeWebSemanticsListener(
             }
 
             @OptIn(FlowPreview::class)
-            launch {
+            launch(start = CoroutineStart.UNDISPATCHED) {
                 // debounce until the Semantics changes settled for at least 100ms
                 syncTriggerChannel.receiveAsFlow().debounce(DEBOUNCE_MS.milliseconds).collect {
                     val currentTime = currentTimeMillis()
@@ -160,25 +171,25 @@ internal class ComposeWebSemanticsListener(
     private val nodes = MutableScatterMap<Int, SemanticsNode>()
     private val nodeToParent = MutableScatterMap<Int, Int>()
     private val webNodes = MutableScatterMap<Int, HTMLElement>()
+    private val elementToSemanticsNode = MutableScatterMap<HTMLElement, SemanticsNode>()
 
     // A reusable set of node ids for sync purposes
     private val allNodesIds = MutableIntSet()
 
     /**
-     * Event delegation: Single shared click listener for all a11y nodes
+     * Event delegation: Single shared click listener for all a11y nodes with SemanticsActions.OnClick.
+     * It's expected to be triggered by A11Y tools and tests (element.click()), not by pointer input.
      */
     private val onClick: (Event) -> Unit = onClick@ { event ->
-        val element = (event.target as? Element)
-            ?.closest("[$DATA_SEMANTICS_ID_KEY]")
+        val semanticsNode = (event.target as? HTMLElement)
+            ?.let { elementToSemanticsNode[it] }
             ?: return@onClick
-        val semanticsId = element.getAttribute(DATA_SEMANTICS_ID_KEY)?.toIntOrNull() ?: return@onClick
-        val config = nodes[semanticsId]?.config ?: return@onClick
 
-        if (config.contains(SemanticsProperties.Disabled)) {
-            return@onClick
-        }
+        val config = semanticsNode.config
 
-        if (config.contains(SemanticsActions.OnClick)) {
+        if (!config.contains(SemanticsProperties.Disabled) &&
+            config.contains(SemanticsActions.OnClick)
+        ) {
             config[SemanticsActions.OnClick].action?.invoke()
         }
     }
@@ -201,7 +212,10 @@ internal class ComposeWebSemanticsListener(
         }
 
         removedIds.forEach {
-            webNodes.remove(it)
+            val htmlNode = webNodes.remove(it)
+            if (htmlNode != null) {
+                elementToSemanticsNode.remove(htmlNode)
+            }
             nodes.remove(it)
             nodeToParent.remove(it)
         }
@@ -288,6 +302,7 @@ internal class ComposeWebSemanticsListener(
             val parentId = nodeToParent[currentId]
             val htmlParent = parentId?.let { webNodes[it] } ?: webSemanticsRoot
             htmlParent.appendChild(htmlNode)
+            elementToSemanticsNode[htmlNode] = node
         }
     }
 
@@ -298,12 +313,6 @@ internal class ComposeWebSemanticsListener(
         rootOffset: Offset,
         justCreated: Boolean = false,
     ) {
-        if (justCreated) {
-            // Mark the element with the semantics node ID for click event delegation lookup.
-            // https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes
-            htmlNode.setAttribute(DATA_SEMANTICS_ID_KEY, sn.id.toString())
-        }
-
         if (config.contains(SemanticsProperties.Text)) {
             val text = config[SemanticsProperties.Text]
             htmlNode.innerText = text.fastJoinToString("\n") { it.text }
@@ -353,6 +362,27 @@ internal class ComposeWebSemanticsListener(
 
             setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width, height)
         }
+    }
+
+
+    internal fun stop() {
+        if (!hasStarted || hasStopped) return
+
+        webSemanticsRoot.removeEventListener("click", onClick)
+
+        dfsDeque.clear()
+        nodes.clear()
+        nodeToParent.clear()
+        webNodes.clear()
+        elementToSemanticsNode.clear()
+        allNodesIds.clear()
+
+        invalidationChannel.close()
+        syncTriggerChannel.close()
+        startJob.cancel()
+
+        removeAllChildrenOf(webSemanticsRoot)
+        hasStopped = true
     }
 }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -23,6 +23,7 @@ import androidx.collection.mutableIntObjectMapOf
 import androidx.collection.mutableIntSetOf
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
@@ -235,6 +236,10 @@ internal class ComposeWindow(
 
     @VisibleForTesting
     internal val archComponentsOwner = DefaultArchitectureComponentsOwner()
+
+    @VisibleForTesting
+    internal val webSemanticsListener: ComposeWebSemanticsListener?
+        get() = platformContext.semanticsOwnerListener as? ComposeWebSemanticsListener
 
     private val navigationEventInput = BackNavigationEventInput()
 
@@ -637,16 +642,17 @@ internal class ComposeWindow(
                         }
                     }
 
-                    val webSemanticsListener = platformContext.semanticsOwnerListener as? ComposeWebSemanticsListener
-                    if (webSemanticsListener != null) {
-                        LaunchedEffect(Unit) {
-                            coroutineScope {
-                                // The initial composition would create a lot of noisy invalidations,
-                                // so it makes sense to start the listener here - after the initial composition.
-                                // The composition's coroutine scope ties the listener's lifetime to the composition.
-                                webSemanticsListener.start(this)
-                            }
+                    LaunchedEffect(Unit) {
+                        coroutineScope {
+                            // The initial composition would create a lot of noisy invalidations,
+                            // so it makes sense to start the listener here - after the initial composition.
+                            // The composition's coroutine scope ties the listener's lifetime to the composition.
+                            webSemanticsListener?.start(this)
                         }
+                    }
+
+                    DisposableEffect(Unit) {
+                        onDispose { webSemanticsListener?.stop() }
                     }
                 }
             )
@@ -713,6 +719,7 @@ internal class ComposeWindow(
         archComponentsOwner.navigationEventDispatcherOwner
             .navigationEventDispatcher.removeInput(navigationEventInput)
 
+        webSemanticsListener?.stop()
         webOutOfFrameExecutor?.dispose()
         scene.close()
         frameRecomposer.close()
@@ -724,6 +731,7 @@ internal class ComposeWindow(
         // modern browsers supposed to garbage collect all events on the element disposed
         // but actually we never can be sure dom element was collected in first place
         canvasEvents.dispose()
+
         isDisposed = true
     }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -21,8 +21,10 @@
 package androidx.compose.ui.platform.a11y
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -35,12 +37,16 @@ import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -564,6 +570,111 @@ class CfWA11YTest : OnCanvasTests {
 
         text.click()
         assertEquals(2, clickCounter, "Re-added clickable text must fire click action")
+    }
+
+    @Test
+    fun clickOnNestedClickableBox() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
+        var outerClickCounter = 0
+        var innerClickCounter = 0
+
+        createComposeWindow {
+            // A clickable Box is a "merging" semantics node (shouldMergeDescendantSemantics == true),
+            // so it survives the outer clickable's descendant-merge and stays as a separate
+            // nested a11y node (the same way a Button stays separate inside a clickable Row).
+            Box(
+                modifier = Modifier
+                    .testTag("outerBox")
+                    .clickable { outerClickCounter++ }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .padding(40.dp)
+                        .testTag("innerBox")
+                        .clickable { innerClickCounter++ }
+                ) {
+                    Text("Nested text")
+                }
+            }
+        }
+
+        awaitA11YChanges()
+
+        val a11yContainer = getA11YContainer()!!
+        val outerBox = getShadowRoot().getElementById("outerBox") as? HTMLElement
+        assertTrue(a11yContainer.contains(outerBox))
+        assertNotNull(outerBox, "Outer clickable box must be present in the a11y tree")
+        assertEquals("button", outerBox.getAttribute("role"))
+
+        val innerBox = getShadowRoot().getElementById("innerBox") as? HTMLElement
+        assertTrue(a11yContainer.contains(innerBox))
+        assertNotNull(innerBox, "Nested clickable box must be present in the a11y tree")
+        assertEquals("button", innerBox.getAttribute("role"))
+        assertTrue(outerBox.contains(innerBox), "Nested box must be nested inside the outer box a11y node")
+
+        // A click where event.target is the nested clickable element must fire
+        // the INNER click action (the innermost clickable wins), not the outer one
+        innerBox.click()
+        assertEquals(1, innerClickCounter, "Clicking the nested box must fire its own click action")
+        assertEquals(0, outerClickCounter, "Clicking the nested box must not fire the outer click action")
+
+        // A click where event.target is the outer element fires the outer click action
+        outerBox.click()
+        assertEquals(1, outerClickCounter, "Clicking the outer box must fire its own click action")
+        assertEquals(1, innerClickCounter, "Clicking the outer box must not fire the nested click action")
+    }
+
+    @Test
+    fun stopRemovesClickListenerAndStopsA11YUpdates() = runApplicationTest {
+        assertEquals(0, getContainer().childElementCount, "No content expected before a composition")
+        var clickCounter = 0
+        var showButton2 by mutableStateOf(false)
+
+        createComposeWindow {
+            Button(onClick = { clickCounter++ }) {
+                Text("Button1")
+            }
+            if (showButton2) {
+                Button(onClick = {}) {
+                    Text("Button2")
+                }
+            }
+        }
+
+        awaitA11YChanges()
+
+        val a11yContainer = getA11YContainer()!!
+        val button1 = a11yContainer.children[0]!!.children[0] as HTMLElement
+        assertEquals("button", button1.getAttribute("role"))
+
+        button1.click()
+        assertEquals(1, clickCounter, "Click must fire before stop()")
+
+        val listener = getComposeWindowOrNull()!!.webSemanticsListener
+        assertNotNull(listener, "A11Y semantics listener must be present")
+
+        listener.stop()
+        // stop() must be idempotent
+        listener.stop()
+        assertTrue(a11yContainer.innerHTML.isEmpty(), "A11Y tree must cleared after stop()")
+
+        // A stopped listener must not be restartable
+        assertFailsWith<IllegalStateException> {
+            // The scope doesn't matter: start() must throw before using it
+            listener.start(CoroutineScope(EmptyCoroutineContext))
+        }
+
+        assertEquals(0, a11yContainer.childElementCount, "A11Y tree must be cleared from the DOM after stop()")
+
+        button1.click()
+        assertEquals(1, clickCounter, "Click listener must be removed after stop()")
+
+        // The A11Y tree must not be updated after stop() even though the semantics still change
+        showButton2 = true
+        awaitIdle()
+        // Wait longer than the 100ms debounce: a running listener would have synced the tree by now
+        realDelay(300)
+        assertTrue(a11yContainer.innerHTML.isEmpty(), "A11Y tree must not be synced after stop()")
     }
 
     @Test // https://youtrack.jetbrains.com/issue/CMP-8614


### PR DESCRIPTION
Changes:
- get rid of `element.closest()` - use a Map instead
- introduce `fun stop()` in ComposeWebSemanticsListener to cancel all corouties and clear all collections

## Testing
Added new unit tests

## Release Notes
N/A