### PR TITLE
Introduce `awaitSkikoRuntimeReady` in `ui-test` to handle Skiko runtime initialization in JS.

### DIFF
--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/SkikoRuntime.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/SkikoRuntime.desktop.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlinx.coroutines.test.TestResult
+
+/** Skiko loads its native library eagerly on the JVM, so there is nothing to wait for. */
+internal actual fun onSkikoReady(block: () -> TestResult): TestResult = block()

--- a/compose/ui/ui-test/src/jsMain/kotlin/androidx/compose/ui/test/SkikoRuntime.js.kt
+++ b/compose/ui/ui-test/src/jsMain/kotlin/androidx/compose/ui/test/SkikoRuntime.js.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlinx.coroutines.test.TestResult
+import org.jetbrains.skiko.InternalSkikoApi
+import org.jetbrains.skiko.wasm.awaitSkiko
+
+/**
+ * Chains the test onto the promise of the Skiko runtime loading. `TestResult` is a `Promise` on
+ * Kotlin/JS, and the promise returned by `then` is resolved only when the promise returned by
+ * [block] is, so the test runner still waits for the test itself to complete.
+ */
+@OptIn(InternalSkikoApi::class, ExperimentalWasmJsInterop::class)
+internal actual fun onSkikoReady(block: () -> TestResult): TestResult =
+    awaitSkiko.then { block() }.unsafeCast<TestResult>()

--- a/compose/ui/ui-test/src/nativeMain/kotlin/androidx/compose/ui/test/SkikoRuntime.nativeMain.kt
+++ b/compose/ui/ui-test/src/nativeMain/kotlin/androidx/compose/ui/test/SkikoRuntime.nativeMain.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlinx.coroutines.test.TestResult
+
+/** Skiko is statically linked into the binary, so there is nothing to wait for. */
+internal actual fun onSkikoReady(block: () -> TestResult): TestResult = block()

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -226,7 +226,8 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
             Job()
     )
 
-    private val surface = Surface.makeRasterN32Premul(width, height)
+    // Lazy on purpose: on JS Skia is only usable after onSkikoReady
+    private val surface by lazy { Surface.makeRasterN32Premul(width, height) }
     private val size = IntSize(width, height)
 
     @InternalComposeUiApi
@@ -260,21 +261,23 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
                 .plus(runTestContext)
                 .plus(testDispatcher)
 
-        // Note: on web this call returns immediately (it returns a Promise),
-        return runTest(
-            timeout = testTimeout,
-            context = combinedRunTestCoroutineContext
-        ) {
-            composeRootRegistry.withRegistry {
-                withScene {
-                    withRenderLoop {
-                        // MonotonicFrameClock is necessary. See the CL for details:
-                        // https://android-review.googlesource.com/c/platform/frameworks/support/+/3284298
-                        // > Anything that might result in animation may require the MonotonicFrameClock,
-                        // > and to get the timing right it should be the clock provided by the Recomposer's effect context
-                        // It's covered by SkikoComposeUiTestTest.canDriveAnimationsFromTest.
-                        frameRecomposer.withMonotonicFrameClock {
-                            block()
+        return onSkikoReady {
+            // Note: on web this call returns immediately (it returns a Promise),
+            runTest(
+                timeout = testTimeout,
+                context = combinedRunTestCoroutineContext
+            ) {
+                composeRootRegistry.withRegistry {
+                    withScene {
+                        withRenderLoop {
+                            // MonotonicFrameClock is necessary. See the CL for details:
+                            // https://android-review.googlesource.com/c/platform/frameworks/support/+/3284298
+                            // > Anything that might result in animation may require the MonotonicFrameClock,
+                            // > and to get the timing right it should be the clock provided by the Recomposer's effect context
+                            // It's covered by SkikoComposeUiTestTest.canDriveAnimationsFromTest.
+                            frameRecomposer.withMonotonicFrameClock {
+                                block()
+                            }
                         }
                     }
                 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/SkikoRuntime.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/SkikoRuntime.skikoMain.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlinx.coroutines.test.TestResult
+
+/**
+ * Invokes [block] as soon as the Skiko (Skia) runtime is initialized and it's safe to call Skia APIs.
+ *
+ * On most platforms the Skiko binaries are linked/loaded eagerly, so [block] is invoked directly. On
+ * the Kotlin/JS target, however, `skiko.wasm` is fetched and instantiated asynchronously, and its
+ * native symbols are published to the global scope only when that is done. Any Skia call made before
+ * that fails with `ReferenceError: org_jetbrains_skia_... is not defined`, which is why the test
+ * framework has to wait, the same way `ComposeViewport`/`CanvasBasedWindow` implicitly wait for
+ * Skiko before starting an application.
+ *
+ * The waiting has to happen *outside* of `kotlinx.coroutines.test.runTest`: an extra suspension
+ * point inside the test body would change the dispatching semantics observed by the test (e.g. it
+ * would make an `UnconfinedTestDispatcher` queue eagerly launched coroutines instead of running them
+ * immediately).
+ */
+internal expect fun onSkikoReady(block: () -> TestResult): TestResult

--- a/compose/ui/ui-test/src/wasmJsMain/kotlin/androidx/compose/ui/test/SkikoRuntime.wasmJs.kt
+++ b/compose/ui/ui-test/src/wasmJsMain/kotlin/androidx/compose/ui/test/SkikoRuntime.wasmJs.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlinx.coroutines.test.TestResult
+
+/**
+ * Skiko is imported as an ES module (`skiko.mjs`) and instantiated before any Kotlin code runs, so
+ * Skia is already usable here and there is nothing to wait for.
+ */
+internal actual fun onSkikoReady(block: () -> TestResult): TestResult = block()


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-4906

## Release Notes
### Fixes - Web
- Fixed `1nMakeRasterN32Premul is not defined` when running `runComposeUiTest` with JS
