### PR TITLE
GitHub Actions. Fix rate limit

### DIFF
--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -7,6 +7,8 @@ runs:
       with:
         java-version: '21'
         distribution: 'jetbrains'
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2


### PR DESCRIPTION
jetbrains JDK accesses GitHub, and it requires a GitHub token. See https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#jetbrains

## Release Notes
N/A