### PR TITLE
[Cherry-pick] Substitute a pass-through filter for a tint that cannot change the color (#3319)

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaColorFilter.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaColorFilter.skiko.kt
@@ -31,8 +31,50 @@ fun ColorFilter.asSkiaColorFilter(): SkColorFilter = nativeColorFilter
  */
 fun SkColorFilter.asComposeColorFilter(): ColorFilter = ColorFilter(this)
 
-internal actual fun actualTintColorFilter(color: Color, blendMode: BlendMode): NativeColorFilter =
-    SkColorFilter.makeBlend(color.toArgb(), blendMode.toSkia())
+internal actual fun actualTintColorFilter(color: Color, blendMode: BlendMode): NativeColorFilter {
+    // TODO: https://github.com/JetBrains/skiko/pull/1272 - drop isNoOpBlend and the
+    //  pass-through filter once skiko reports the absent filter as null. Replace by this:
+    // SkColorFilter.makeBlend(color.toArgb(), blendMode.toSkia()) ?: PassThroughColorFilter
+    if (isNoOpBlend(color, blendMode)) return PassThroughColorFilter
+    return SkColorFilter.makeBlend(color.toArgb(), blendMode.toSkia())
+}
+
+/**
+ * Whether skia leaves the color untouched for this blend. Skia has no filter object for those and
+ * answers with none at all, which [NativeColorFilter] cannot carry, so a pass-through filter stands
+ * in for them.
+ *
+ * Decided on the 8 bit alpha that skia itself receives, so that an alpha which rounds to fully
+ * transparent or fully opaque is judged the way skia judges it.
+ */
+private fun isNoOpBlend(color: Color, blendMode: BlendMode): Boolean {
+    if (blendMode == BlendMode.Dst) return true
+    return when (color.toArgb() ushr 24) {
+        0 ->
+            blendMode == BlendMode.SrcOver ||
+                blendMode == BlendMode.DstOver ||
+                blendMode == BlendMode.DstOut ||
+                blendMode == BlendMode.SrcAtop ||
+                blendMode == BlendMode.Xor ||
+                blendMode == BlendMode.Darken
+        255 -> blendMode == BlendMode.DstIn
+        else -> false
+    }
+}
+
+/** Passes every channel through unchanged. */
+private val PassThroughColorFilter by lazy {
+    SkColorFilter.makeMatrix(
+        SkColorMatrix(
+            floatArrayOf(
+                1f, 0f, 0f, 0f, 0f,
+                0f, 1f, 0f, 0f, 0f,
+                0f, 0f, 1f, 0f, 0f,
+                0f, 0f, 0f, 1f, 0f,
+            )
+        )
+    )
+}
 
 /**
  * Remaps compose [ColorMatrix] to [org.jetbrains.skia.ColorMatrix] and returns [ColorFilter]

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoColorFilterTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoColorFilterTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.graphics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.jetbrains.skia.Surface
+
+class SkikoColorFilterTest {
+
+    @Test
+    fun tintWithABlendThatCannotChangeTheColorSucceeds() {
+        for ((color, blendMode) in blendsSkiaTreatsAsNoOps) {
+            assertNotNull(
+                ColorFilter.tint(color, blendMode).asSkiaColorFilter(),
+                "tint($color, $blendMode)"
+            )
+        }
+    }
+
+    @Test
+    fun tintWithABlendThatChangesTheColorSucceeds() {
+        for (blendMode in listOf(BlendMode.SrcAtop, BlendMode.SrcOver, BlendMode.DstIn)) {
+            assertNotNull(
+                ColorFilter.tint(Color.Red.copy(alpha = 0.5f), blendMode).asSkiaColorFilter(),
+                "tint(half transparent red, $blendMode)"
+            )
+        }
+    }
+
+    @Test
+    fun anAlphaRoundingDownToTransparentCountsAsTransparent() {
+        val almostTransparent = Color.Red.copy(alpha = 0.001f)
+
+        assertNotNull(ColorFilter.tint(almostTransparent, BlendMode.SrcAtop).asSkiaColorFilter())
+    }
+
+    @Test
+    fun aTintThatCannotChangeTheColorDrawsTheColorUnchanged() {
+        for ((color, blendMode) in blendsSkiaTreatsAsNoOps) {
+            assertEquals(
+                Color.Red,
+                drawRed(ColorFilter.tint(color, blendMode)),
+                "tint($color, $blendMode) should leave the drawn color alone"
+            )
+        }
+    }
+
+    @Test
+    fun aTintThatChangesTheColorIsStillApplied() {
+        assertEquals(Color.Blue, drawRed(ColorFilter.tint(Color.Blue, BlendMode.SrcIn)))
+    }
+
+    /** Fills a small surface with [Color.Red] through [colorFilter] and reads a pixel back. */
+    private fun drawRed(colorFilter: ColorFilter): Color {
+        val surface = Surface.makeRasterN32Premul(SIZE, SIZE)
+        val paint = Paint().apply {
+            color = Color.Red
+            this.colorFilter = colorFilter
+        }
+
+        surface.canvas.asComposeCanvas()
+            .drawRect(0f, 0f, SIZE.toFloat(), SIZE.toFloat(), paint)
+        surface.flushAndSubmit(true)
+
+        val pixels = surface.makeImageSnapshot().toComposeImageBitmap().toPixelMap()
+        return pixels[SIZE / 2, SIZE / 2]
+    }
+
+    private companion object {
+        const val SIZE = 4
+
+        /** Every color and blend pair for which skia reports no filter at all. */
+        val blendsSkiaTreatsAsNoOps = listOf(
+            Color.Red to BlendMode.Dst,
+            Color.Transparent to BlendMode.Dst,
+            Color.Transparent to BlendMode.SrcOver,
+            Color.Transparent to BlendMode.DstOver,
+            Color.Transparent to BlendMode.DstOut,
+            Color.Transparent to BlendMode.SrcAtop,
+            Color.Transparent to BlendMode.Xor,
+            Color.Transparent to BlendMode.Darken,
+            Color.Red to BlendMode.DstIn,
+        )
+    }
+}


### PR DESCRIPTION
[CMP-9226](https://youtrack.jetbrains.com/issue/CMP-9226) Crash when using a transparent tint with SrcAtop (Can't wrap nullptr)
[CMP-10677](https://youtrack.jetbrains.com/issue/CMP-10677) iOS: process aborts from `MetalRedrawer.draw` when a `Canvas` draws a gradient `Brush` under a per-draw `BlendModeColorFilter`

Note that this is an adoption, not 1-1 cherry-pick due to changes in structure in jb-main between these branches

## Release Notes
### Fixes - Multiple Platforms
- Fix crash in cases when skia returns null `ColorFilter` due to no-op parameter combination
