### PR TITLE
Increased timeout for iOS Instrumented Tests 

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -170,7 +170,7 @@ jobs:
           simulator-os: ${{ matrix.simulator_os }}
 
       - name: Run iOS Instrumented
-        timeout-minutes: 30
+        timeout-minutes: 40
         shell: bash
         working-directory: compose/ui/ui/src/uikitInstrumentedTest/launcher
         env:


### PR DESCRIPTION
Increased timeout to 40 minutes for the iOS instrumented tests

## Release Notes
N/A
