### PR TITLE
[Cherry-pick] Pass TransformedTextFieldState to expect textFieldOverlay()

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/BasicTextField.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/BasicTextField.android.kt
@@ -17,7 +17,7 @@
 package androidx.compose.foundation.text
 
 import androidx.compose.foundation.interaction.InteractionSource
-import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.internal.TransformedTextFieldState
 import androidx.compose.ui.Modifier
 
 /**
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
  * codes, etc.).
  */
 internal actual fun Modifier.textFieldOverlay(
-    state: TextFieldState,
+    transformedState: TransformedTextFieldState,
     keyboardOptions: KeyboardOptions,
     interactionSource: InteractionSource,
 ): Modifier = this

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
@@ -453,7 +453,7 @@ internal fun BasicTextField(
             )
             .pointerHoverIcon(PointerIcon.Text)
             .addContextMenuComponents(textFieldSelectionState, coroutineScope)
-            .textFieldOverlay(state, keyboardOptions, interactionSource)
+            .textFieldOverlay(transformedState, keyboardOptions, interactionSource)
 
     Box(decorationModifiers, propagateMinConstraints = true) {
         ContextMenuArea(textFieldSelectionState, enabled) {
@@ -564,7 +564,7 @@ internal fun BasicTextField(
  * codes, etc.).
  */
 internal expect fun Modifier.textFieldOverlay(
-    state: TextFieldState,
+    transformedState: TransformedTextFieldState,
     keyboardOptions: KeyboardOptions,
     interactionSource: InteractionSource,
 ): Modifier

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/BasicTextField.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/BasicTextField.skiko.kt
@@ -17,12 +17,11 @@
 package androidx.compose.foundation.text
 
 import androidx.compose.foundation.interaction.InteractionSource
-import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.internal.TransformedTextFieldState
 import androidx.compose.ui.Modifier
 
-// TODO https://youtrack.jetbrains.com/issue/CMP-10340/Implement-textFieldOverlay
 internal actual fun Modifier.textFieldOverlay(
-    state: TextFieldState,
+    transformedState: TransformedTextFieldState,
     keyboardOptions: KeyboardOptions,
     interactionSource: InteractionSource,
 ): Modifier {


### PR DESCRIPTION
Extends the capability of the internal `Modifier.textFieldOverlay` hook in order to provide access to transformed value of the `BasicTextField`.

Related Change-Id: I7ec1c64619e646a72f0beb38e0fd2ac4d6266b1d

Test: BasicTextFieldTest, CoreTextField
Change-Id: I689097763598b610167c3fc2b5635a78a0f5afa2

## Release Notes
N/A