### PR TITLE
Run magnifier test cases with NITI

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.UIKitNativeTextInputContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.findFirstDescendant
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.uikit.LocalNativeTextInputContext
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalComposeUiApi::class)
@@ -60,12 +61,12 @@ class TextFieldMagnifierTest {
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
-        var isUsingNativeTextInput: (() -> Boolean)? = null
+        var nativeTextInputContext: UIKitNativeTextInputContext? = null
 
         setContent {
-            val nativeTextInputContext = LocalNativeTextInputContext.current
+            val currentNativeTextInputContext = LocalNativeTextInputContext.current
             SideEffect {
-                isUsingNativeTextInput = { nativeTextInputContext.usingNativeTextInput() }
+                nativeTextInputContext = currentNativeTextInputContext
             }
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
@@ -77,9 +78,11 @@ class TextFieldMagnifierTest {
 
         waitForIdle()
 
-        waitUntilNativeTextInputMode(factory.useNativeTextInput) {
-            isUsingNativeTextInput?.invoke()
-        }
+        assertEquals(
+            expected = factory.useNativeTextInput,
+            actual = nativeTextInputContext?.usingNativeTextInput(),
+            message = "Text input mode should be ${factory.textInputModeName}"
+        )
 
         findNodeWithTag("textField").touchDown()
 
@@ -93,12 +96,12 @@ class TextFieldMagnifierTest {
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
-        var isUsingNativeTextInput: (() -> Boolean)? = null
+        var nativeTextInputContext: UIKitNativeTextInputContext? = null
 
         setContent {
-            val nativeTextInputContext = LocalNativeTextInputContext.current
+            val currentNativeTextInputContext = LocalNativeTextInputContext.current
             SideEffect {
-                isUsingNativeTextInput = { nativeTextInputContext.usingNativeTextInput() }
+                nativeTextInputContext = currentNativeTextInputContext
             }
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
@@ -110,9 +113,11 @@ class TextFieldMagnifierTest {
 
         waitForIdle()
 
-        waitUntilNativeTextInputMode(factory.useNativeTextInput) {
-            isUsingNativeTextInput?.invoke()
-        }
+        assertEquals(
+            expected = factory.useNativeTextInput,
+            actual = nativeTextInputContext?.usingNativeTextInput(),
+            message = "Text input mode should be ${factory.textInputModeName}"
+        )
 
         val touch = findNodeWithTag("textField").touchDown()
 
@@ -154,18 +159,6 @@ class TextFieldMagnifierTest {
 
         waitUntil {
             findFirstDescendant { it.isLoupeView } == null
-        }
-    }
-
-    private fun UIKitInstrumentedTest.waitUntilNativeTextInputMode(
-        useNativeTextInput: Boolean,
-        isUsingNativeTextInput: () -> Boolean?
-    ) {
-        waitUntil("Native text input context should be captured") {
-            isUsingNativeTextInput() != null
-        }
-        waitUntil("Native text input mode should be $useNativeTextInput") {
-            isUsingNativeTextInput() == useNativeTextInput
         }
     }
 
@@ -211,6 +204,8 @@ private class TextFieldMagnifierParam(
     val useNativeTextInput: Boolean,
     private val content: @Composable (FocusRequester) -> Unit
 ) {
+    val textInputModeName = if (useNativeTextInput) "NITI" else "non-NITI"
+
     @Composable
     operator fun invoke(focusRequester: FocusRequester) {
         content(focusRequester)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.UIKitNativeTextInputContext
+import androidx.compose.ui.platform.NativeTextInputContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
@@ -61,7 +61,7 @@ class TextFieldMagnifierTest {
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
-        var nativeTextInputContext: UIKitNativeTextInputContext? = null
+        var nativeTextInputContext: NativeTextInputContext? = null
 
         setContent {
             val currentNativeTextInputContext = LocalNativeTextInputContext.current
@@ -96,7 +96,7 @@ class TextFieldMagnifierTest {
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
-        var nativeTextInputContext: UIKitNativeTextInputContext? = null
+        var nativeTextInputContext: NativeTextInputContext? = null
 
         setContent {
             val currentNativeTextInputContext = LocalNativeTextInputContext.current

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -24,11 +24,14 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.findFirstDescendant
@@ -36,22 +39,34 @@ import androidx.compose.ui.test.utils.isLoupeView
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.uikit.LocalNativeTextInputContext
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
+
+@OptIn(InternalComposeUiApi::class)
 class TextFieldMagnifierTest {
 
-    private val params = listOf<TextFieldComposableFactory>(
-        { fr -> BFT(fr) },
-        { fr -> BFT2(fr) }
+    private val params = listOf(
+        TextFieldMagnifierParam(useNativeTextInput = false) { fr -> BTF(fr, false) },
+        TextFieldMagnifierParam(useNativeTextInput = false) { fr -> BFT2(fr, false) },
+        TextFieldMagnifierParam(useNativeTextInput = true) { fr -> BTF(fr, true) },
+        TextFieldMagnifierParam(useNativeTextInput = true) { fr -> BFT2(fr, true) },
     )
+
+    private val nonNativeParams = params.filterNot { it.useNativeTextInput }
 
     @Test
     fun testMagnifierShownOnTouchAndHold() = runUIKitInstrumentedTest(
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
+        var isUsingNativeTextInput: (() -> Boolean)? = null
 
         setContent {
+            val nativeTextInputContext = LocalNativeTextInputContext.current
+            SideEffect {
+                isUsingNativeTextInput = { nativeTextInputContext.usingNativeTextInput() }
+            }
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
                 factory(focusRequester)
@@ -61,6 +76,10 @@ class TextFieldMagnifierTest {
         focusRequester.requestFocus()
 
         waitForIdle()
+
+        waitUntilNativeTextInputMode(factory.useNativeTextInput) {
+            isUsingNativeTextInput?.invoke()
+        }
 
         findNodeWithTag("textField").touchDown()
 
@@ -74,8 +93,13 @@ class TextFieldMagnifierTest {
         params = params
     ) { factory ->
         val focusRequester = FocusRequester()
+        var isUsingNativeTextInput: (() -> Boolean)? = null
 
         setContent {
+            val nativeTextInputContext = LocalNativeTextInputContext.current
+            SideEffect {
+                isUsingNativeTextInput = { nativeTextInputContext.usingNativeTextInput() }
+            }
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
                 factory(focusRequester)
@@ -85,6 +109,10 @@ class TextFieldMagnifierTest {
         focusRequester.requestFocus()
 
         waitForIdle()
+
+        waitUntilNativeTextInputMode(factory.useNativeTextInput) {
+            isUsingNativeTextInput?.invoke()
+        }
 
         val touch = findNodeWithTag("textField").touchDown()
 
@@ -101,7 +129,7 @@ class TextFieldMagnifierTest {
 
     @Test
     fun testMagnifierHidesOnDragOutsideTextField() = runUIKitInstrumentedTest(
-        params = params
+        params = nonNativeParams // magnifier is not visible but its object still remains after dragging outside text field with NITI
     ) { factory ->
         val focusRequester = FocusRequester()
 
@@ -129,12 +157,25 @@ class TextFieldMagnifierTest {
         }
     }
 
+    private fun UIKitInstrumentedTest.waitUntilNativeTextInputMode(
+        useNativeTextInput: Boolean,
+        isUsingNativeTextInput: () -> Boolean?
+    ) {
+        waitUntil("Native text input context should be captured") {
+            isUsingNativeTextInput() != null
+        }
+        waitUntil("Native text input mode should be $useNativeTextInput") {
+            isUsingNativeTextInput() == useNativeTextInput
+        }
+    }
+
     private val textValue = "TEXT"
-    private val keyboardOptions = KeyboardOptions(
+    private fun keyboardOptions(useNativeTextInput: Boolean) = KeyboardOptions(
         platformImeOptions = PlatformImeOptions {
-            usingNativeTextInput(false)
+            usingNativeTextInput(useNativeTextInput)
         }
     )
+
     private fun modifier(focusRequester: FocusRequester): Modifier = Modifier
         .testTag("textField")
         .height(40.dp)
@@ -142,22 +183,36 @@ class TextFieldMagnifierTest {
         .focusRequester(focusRequester)
 
     @Composable
-    private fun BFT(
-        focusRequester: FocusRequester
+    private fun BTF(
+        focusRequester: FocusRequester,
+        useNativeTextInput: Boolean
     ) = BasicTextField(
         textValue,
         onValueChange = {},
-        keyboardOptions = keyboardOptions,
+        keyboardOptions = keyboardOptions(useNativeTextInput),
         modifier = modifier(focusRequester)
     )
 
     @Composable
     private fun BFT2(
-        focusRequester: FocusRequester
+        focusRequester: FocusRequester,
+        useNativeTextInput: Boolean
     ) {
         val state = remember { TextFieldState(textValue) }
-        BasicTextField(state, keyboardOptions = keyboardOptions, modifier = modifier(focusRequester))
+        BasicTextField(
+            state,
+            keyboardOptions = keyboardOptions(useNativeTextInput),
+            modifier = modifier(focusRequester)
+        )
     }
 }
 
-private typealias TextFieldComposableFactory = @Composable (FocusRequester) -> Unit
+private class TextFieldMagnifierParam(
+    val useNativeTextInput: Boolean,
+    private val content: @Composable (FocusRequester) -> Unit
+) {
+    @Composable
+    operator fun invoke(focusRequester: FocusRequester) {
+        content(focusRequester)
+    }
+}


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Run magnifier cases that are successfull with NITI, except dragging outside text field (does not pass because magnifier is not visible but its object still exists and it's no reliable way for now to verify it's not visible, so this case will remain only for non-niti. 
(Optional) Fixes [CMP-10685](https://youtrack.jetbrains.com/issue/CMP-10685) Run cases from iOS TextFieldMagnifierTest for NITI]

## Testing
N/A

## Google CLA
Sign the Google Contributor's License Agreement at https://cla.developers.google.com to let us upstream your code to Google's AOSP repository

## Release Notes
N/A