### PR TITLE
Support LinkAnnotation in CMP Web A11Y

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/AttributedStringDemo.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/AttributedStringDemo.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components.text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.mpp.demo.Screen
+
+@Composable
+fun AttributedStringDemo() {
+    var lastClickedLink by remember { mutableStateOf<String?>(null) }
+
+    val linkInteractionListener = LinkInteractionListener { link ->
+        lastClickedLink = when (link) {
+            is LinkAnnotation.Url -> link.url
+            is LinkAnnotation.Clickable -> link.tag
+            else -> "unknown"
+        }
+    }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = buildAnnotatedString {
+                append("LinkAnnotation can be included in an AnnotatedString. \nTry: \n- ")
+                withStyle(linkStyle) {
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = "compose",
+                            linkInteractionListener = linkInteractionListener
+                        )
+                    ) {
+                        append("clickable link")
+                    }
+                }
+                append(" - to trigger its interaction listener\n- ")
+                withStyle(urlLinkStyle) {
+                    withLink(
+                        LinkAnnotation.Url(
+                            url = "https://github.com/JetBrains/compose-multiplatform-core",
+                            linkInteractionListener = null // default
+                        )
+                    ) {
+                        append("URL link")
+                    }
+                }
+                append(" - it should open CMP core GitHub repository")
+            }
+        )
+
+        lastClickedLink?.let {
+            Text(
+                text = "Last clicked link: $it",
+                modifier = Modifier.padding(top = 16.dp)
+            )
+        }
+    }
+}
+
+private val linkStyle = SpanStyle(
+    color = Color(0xFF1565C0),
+    textDecoration = TextDecoration.Underline
+)
+
+private val urlLinkStyle = SpanStyle(
+    color = Color(0xFF6A1B9A),
+    textDecoration = TextDecoration.Underline
+)

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
@@ -26,4 +26,5 @@ val TextDemos = Screen.Selection(
     Screen.Example("LineHeightStyle") { LineHeightStyleDemo() },
     Screen.Example("TextDirection") { TextDirection() },
     Screen.Example("TextOverflow") { TextOverflow() },
+    Screen.Example("LinkAnnotation") { AttributedStringDemo() },
 )

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -20,6 +20,10 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.util.fastFilter
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachIndexed
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 
@@ -58,6 +62,7 @@ internal object AriaRoleId {
     const val List = 9
     const val Grid = 10
     const val Dialog = 11
+    const val Link = 12
 }
 
 internal fun SemanticsConfiguration.getRoleId(): Int {
@@ -85,6 +90,11 @@ internal fun SemanticsConfiguration.getRoleId(): Int {
     if (SemanticsActions.OnClick in this && roleId == AriaRoleId.Unknown) {
         // TODO: Not everything with OnClick is a button! For now default to button for unknown clickable roles
         roleId = Role.Button.toIntId()
+    }
+
+    if (this.contains(SemanticsProperties.LinkTestMarker)) {
+        // TODO: LinkAnnotation.Clickable is not a navigation link, consider `button` for it.
+        roleId = AriaRoleId.Link
     }
 
     if (this.contains(SemanticsProperties.Heading)) {
@@ -156,6 +166,9 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
             case 11: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role
                 roleValue = "dialog";
                 break;
+            case 12: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/link_role
+                roleValue = "link";
+                break;
             default:
                 break;
         }
@@ -187,4 +200,51 @@ internal fun Element.setInert(inert: Boolean) {
 private external interface CanToggleAttribute : JsAny {
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute
     fun toggleAttribute(attributeName: String, force: Boolean): Boolean
+}
+
+/**
+ * The text of a text node split around its link ranges, see [splitTextAndLinks].
+ */
+internal class TextAndLinksSplit(
+    /** The plain text parts surrounding the links: always `linkTexts.size + 1` items. */
+    val textParts: List<String>,
+    /** The text of every non-empty link range, in the order of appearance. */
+    val linkTexts: List<String>,
+) {
+    /**
+     * Returns true if the text has exactly [linksCount] non-empty link ranges, so [textParts] can
+     * be interleaved with the link children of the node. Otherwise, the node should expose the
+     * whole text instead.
+     */
+    fun matchesLinksCount(linksCount: Int) = linkTexts.size == linksCount
+}
+
+/**
+ * Splits [texts] into the plain text parts surrounding the link ranges and the texts of the link
+ * ranges themselves, so that every link range can be exposed by its own a11y node.
+ */
+internal fun splitTextAndLinks(texts: List<AnnotatedString>): TextAndLinksSplit {
+    val parts = mutableListOf<String>()
+    val linkTexts = mutableListOf<String>()
+    var pendingText = StringBuilder()
+
+    texts.fastForEachIndexed { index, text ->
+        if (index > 0) pendingText.append("\n")
+
+        var lastEnd = 0
+        text.getLinkAnnotations(0, text.length)
+            .fastFilter { it.start != it.end } // filter out links with empty text
+            .fastForEach { link ->
+                pendingText.append(text.text, lastEnd, link.start)
+                parts.add(pendingText.toString())
+                pendingText = StringBuilder()
+                linkTexts.add(text.text.substring(link.start, link.end))
+                lastEnd = link.end
+            }
+        pendingText.append(text.text, lastEnd, text.length)
+    }
+
+    parts.add(pendingText.toString())
+
+    return TextAndLinksSplit(textParts = parts, linkTexts = linkTexts)
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -258,22 +258,33 @@ internal class ComposeWebSemanticsListener(
 
             // `config` recreates the merged subtree on every call, so read it once
             val config = node.config
-
-            val reversedChildren = node.replacedChildren.asReversed()
-            dfsDeque.addAll(reversedChildren)
-            reversedChildren.fastForEach { nodeToParent[it.id] = node.id }
+            val children = node.replacedChildren
 
             // The parent is known here: it was recorded when this node was pushed to the deque.
             val htmlParent = nodeToParent[node.id]?.let { webNodes[it] } ?: webSemanticsRoot
 
-            syncNode(
-                semanticsNode = node,
-                config = config,
-                htmlParent = htmlParent,
-                rootPosition = rootPosition,
-                hasChildren = reversedChildren.isNotEmpty()
-            )
+            if (config.contains(SemanticsProperties.Text)) {
+                // Usually, the order of SemanticsNode children matches the mirroring a11y HTML.
+                // But for text with links we have to interleave text parts with links.
+                // We split text into parts: plain text fragments and links.
+                // That's why a text node doesn't push its children to the traversal queue.
+                // It handles its link children itself:
+                syncTextNode(node, config, children, htmlParent, rootPosition)
+            } else {
+                syncNode(node, config, htmlParent, rootPosition, children.isNotEmpty())
+                pushChildren(children, node.id)
+            }
         }
+    }
+
+    /**
+     * Pushes the [children] of the node [parentId] to the traversal deque, keeping the order of the
+     * semantics tree: the deque is LIFO, so the children are added in the reversed order.
+     */
+    private fun pushChildren(children: List<SemanticsNode>, parentId: Int) {
+        val reversedChildren = children.asReversed()
+        dfsDeque.addAll(reversedChildren)
+        reversedChildren.fastForEach { nodeToParent[it.id] = parentId }
     }
 
     /**
@@ -288,7 +299,8 @@ internal class ComposeWebSemanticsListener(
         htmlParent: HTMLElement,
         rootPosition: Offset,
         hasChildren: Boolean,
-    ) {
+        text: String? = null,
+    ): HTMLElement {
         val currentId = semanticsNode.id
         allNodesIds.add(currentId)
 
@@ -304,7 +316,7 @@ internal class ComposeWebSemanticsListener(
                 removeAllChildrenOf(htmlNode)
             }
 
-            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition)
+            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, text)
             htmlNode
         } else {
             nodes[currentId] = semanticsNode
@@ -315,12 +327,13 @@ internal class ComposeWebSemanticsListener(
             }
 
             webNodes[currentId] = htmlNode
-            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, justCreated = true)
+            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, text, justCreated = true)
             htmlNode
         }
 
         htmlParent.appendChild(htmlNode)
         elementToSemanticsNode[htmlNode] = semanticsNode
+        return htmlNode
     }
 
     /**
@@ -332,11 +345,11 @@ internal class ComposeWebSemanticsListener(
         config: SemanticsConfiguration,
         htmlNode: HTMLElement,
         rootOffset: Offset,
+        text: String?,
         justCreated: Boolean = false,
     ) {
-        if (config.contains(SemanticsProperties.Text)) {
-            val text = config[SemanticsProperties.Text]
-            htmlNode.innerText = text.fastJoinToString("\n") { it.text }
+        if (text != null) {
+            htmlNode.innerText = text
         }
 
         if (config.contains(SemanticsProperties.ContentDescription)) {
@@ -382,6 +395,103 @@ internal class ComposeWebSemanticsListener(
 
             setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width, height)
         }
+    }
+
+
+    /**
+     * Syncs a node with [SemanticsProperties.Text], attaching its link children right away instead
+     * of scheduling them for the regular traversal.
+     *
+     * A link doesn't have its own text in the semantics tree: the whole text (including the links)
+     * belongs to the text node, while every link range is a separate child node marked with
+     * [SemanticsProperties.LinkTestMarker]. Exposing it as is would read the link text twice,
+     * so the text is split and interleaved with the link nodes:
+     * ```
+     * Semantics nodes:                     HTML nodes:
+     *
+     * Text("Read the docs, please")        <div>
+     *  ├─ LinkTestMarker  // "Read"          <div role="link">Read</div>
+     *  └─ LinkTestMarker  // "the docs"      " "
+     *                                        <div role="link">the docs</div>
+     *                                        ", please"
+     *                                      </div>
+     * ```
+     * Note that the empty text parts (here: the one before the first link) are skipped.
+     *
+     * If the text parts don't surround the link children exactly (for example, a link clipped by
+     * `maxLines` doesn't produce a child node), this node exposes the whole text and the links keep
+     * their own text, so nothing is lost.
+     *
+     * [children] other than the links (a text node might be a merged node with arbitrary merging
+     * children) are pushed to the regular traversal and end up after the links.
+     */
+    private fun syncTextNode(
+        node: SemanticsNode,
+        config: SemanticsConfiguration,
+        children: List<SemanticsNode>,
+        htmlParent: HTMLElement,
+        rootPosition: Offset,
+    ) {
+        val texts = config[SemanticsProperties.Text]
+        val linksCount = children.count { it.config.contains(SemanticsProperties.LinkTestMarker) }
+
+        val split = if (linksCount == 0) null else splitTextAndLinks(texts)
+        // Null if the parts don't surround the link children exactly: the whole text is exposed then.
+        val textParts = split?.textParts?.takeIf { split.matchesLinksCount(linksCount) }
+
+        val htmlNode = syncNode(
+            semanticsNode = node,
+            config = config,
+            htmlParent = htmlParent,
+            rootPosition = rootPosition,
+            hasChildren = children.isNotEmpty(),
+            // The text parts are appended in between the link children below.
+            text = if (textParts != null) "" else texts.fastJoinToString("\n") { it.text },
+        )
+
+        var linkIndex = 0
+        // Non-link children are pushed together (after the loop) to keep their relative order.
+        var deferredChildren: MutableList<SemanticsNode>? = null
+
+        children.fastForEach { child ->
+            val childConfig = child.config
+            if (!childConfig.contains(SemanticsProperties.LinkTestMarker)) {
+                val deferred = deferredChildren ?: mutableListOf<SemanticsNode>().also {
+                    deferredChildren = it
+                }
+                deferred.add(child)
+                return@fastForEach
+            }
+
+            if (textParts != null) {
+                htmlNode.appendText(textParts[linkIndex])
+            }
+
+            val linkChildren = child.replacedChildren
+            syncNode(
+                semanticsNode = child,
+                config = childConfig,
+                htmlParent = htmlNode,
+                rootPosition = rootPosition,
+                hasChildren = linkChildren.isNotEmpty(),
+                text = split?.linkTexts?.getOrNull(linkIndex),
+            )
+            // A link node is expected to be a leaf, but don't rely on it.
+            pushChildren(linkChildren, child.id)
+
+            linkIndex++
+        }
+
+        if (textParts != null) {
+            htmlNode.appendText(textParts.last())
+        }
+
+        deferredChildren?.let { pushChildren(it, node.id) }
+    }
+
+    private fun HTMLElement.appendText(text: String?) {
+        if (text.isNullOrEmpty()) return
+        appendChild(document.createTextNode(text))
     }
 
     internal fun stop() {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LinkAnnotationA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/LinkAnnotationA11YTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.material.Text
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.get
+
+/**
+ * Describes the a11y content of an element as a flat string, where the nested elements are
+ * represented as `[role:text]`. Unlike `innerHTML`, it doesn't depend on the styles (position/size).
+ */
+private fun HTMLElement.describeA11YContent(): String = buildString {
+    val nodes = childNodes
+    repeat(nodes.length) { index ->
+        val node = nodes.item(index) ?: return@repeat
+        if (node is HTMLElement) {
+            append("[${node.getAttribute("role")}:${node.describeA11YContent()}]")
+        } else {
+            append(node.textContent)
+        }
+    }
+}
+
+/**
+ * Tests for the A11Y representation of [LinkAnnotation]s in a text:
+ * every link range is exposed as a separate node (created by `TextLinkScope`),
+ * while the surrounding plain text stays on the text node itself.
+ */
+class LinkAnnotationA11YTest : OnCanvasTests {
+
+    @Test
+    fun a11yLinkAnnotation() = runApplicationTest {
+        createComposeWindow {
+            Text(
+                buildAnnotatedString {
+                    append("Text before the ")
+                    withLink(LinkAnnotation.Url("https://www.example.com")) {
+                        append("link")
+                    }
+                    append(" and text after it")
+                }
+            )
+        }
+
+        awaitA11YChanges()
+
+        val ownerRoot = getA11YContainer()!!.children[0] as HTMLElement
+        val textNode = ownerRoot.children[0] as HTMLElement
+
+        assertEquals(
+            expected = "Text before the [link:link] and text after it",
+            actual = textNode.describeA11YContent()
+        )
+    }
+
+    @Test
+    fun a11yLinkAnnotationClickable() = runApplicationTest {
+        val clickedTags = mutableListOf<String>()
+
+        createComposeWindow {
+            Text(
+                buildAnnotatedString {
+                    append("Text before the ")
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = "CLICKABLE_TAG",
+                            linkInteractionListener = LinkInteractionListener { link ->
+                                clickedTags.add((link as LinkAnnotation.Clickable).tag)
+                            }
+                        )
+                    ) {
+                        append("clickable")
+                    }
+                    append(" and text after it")
+                }
+            )
+        }
+
+        awaitA11YChanges()
+
+        val textNode = getA11YContainer()!!.children[0]!!.children[0] as HTMLElement
+        assertEquals(
+            expected = "Text before the [link:clickable] and text after it",
+            actual = textNode.describeA11YContent()
+        )
+
+        val linkNode = textNode.children[0] as HTMLElement
+        assertEquals("link", linkNode.getAttribute("role"))
+
+        linkNode.click()
+        linkNode.click()
+        assertEquals(listOf("CLICKABLE_TAG", "CLICKABLE_TAG"), clickedTags)
+    }
+
+    @Test
+    fun a11yLinkAnnotationUrlWithCustomClickHandler() = runApplicationTest {
+        val clickedUrls = mutableListOf<String>()
+
+        createComposeWindow {
+            Text(
+                buildAnnotatedString {
+                    append("Text before the ")
+                    withLink(
+                        LinkAnnotation.Url(
+                            url = "https://www.example.com",
+                            linkInteractionListener = LinkInteractionListener { link ->
+                                clickedUrls.add((link as LinkAnnotation.Url).url)
+                            }
+                        )
+                    ) {
+                        append("link")
+                    }
+                    append(" and text after it")
+                }
+            )
+        }
+
+        awaitA11YChanges()
+
+        val textNode = getA11YContainer()!!.children[0]!!.children[0] as HTMLElement
+        assertEquals(
+            expected = "Text before the [link:link] and text after it",
+            actual = textNode.describeA11YContent()
+        )
+
+        val linkNode = textNode.children[0] as HTMLElement
+
+        // The custom listener takes precedence over opening the url by the platform UriHandler:
+        linkNode.click()
+        assertEquals(listOf("https://www.example.com"), clickedUrls)
+    }
+
+    @Test
+    fun a11yMultipleLinkAnnotations() = runApplicationTest {
+        val clicks = mutableListOf<String>()
+
+        createComposeWindow {
+            Text(
+                buildAnnotatedString {
+                    append("Start ")
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = "TAG1",
+                            linkInteractionListener = LinkInteractionListener {
+                                clicks.add("clickable1")
+                            }
+                        )
+                    ) {
+                        append("first")
+                    }
+                    append(" middle ")
+                    withLink(
+                        LinkAnnotation.Url(
+                            url = "https://www.example.com",
+                            linkInteractionListener = LinkInteractionListener {
+                                clicks.add("url")
+                            }
+                        )
+                    ) {
+                        append("second")
+                    }
+                    append(" end")
+                }
+            )
+        }
+
+        awaitA11YChanges()
+
+        val textNode = getA11YContainer()!!.children[0]!!.children[0] as HTMLElement
+        assertEquals(
+            expected = "Start [link:first] middle [link:second] end",
+            actual = textNode.describeA11YContent()
+        )
+
+        (textNode.children[1] as HTMLElement).click()
+        (textNode.children[0] as HTMLElement).click()
+        assertEquals(listOf("url", "clickable1"), clicks)
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/SplitTextAroundLinksTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/SplitTextAroundLinksTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.ui.platform.accessibility.splitTextAndLinks
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun url() = LinkAnnotation.Url("https://www.example.com")
+
+private fun textWithLinks(builder: AnnotatedString.Builder.() -> Unit) =
+    listOf(buildAnnotatedString(builder))
+
+class SplitTextAroundLinksTest {
+
+    @Test
+    fun textWithoutLinks() {
+        val split = splitTextAndLinks(listOf(AnnotatedString("A text without links")))
+
+        assertEquals(expected = listOf("A text without links"), actual = split.textParts)
+        assertEquals(expected = emptyList<String>(), actual = split.linkTexts)
+        assertTrue(split.matchesLinksCount(0))
+    }
+
+    @Test
+    fun linkInTheMiddle() {
+        val texts = textWithLinks {
+            append("Text before the ")
+            withLink(url()) { append("link") }
+            append(" and text after it")
+        }
+
+        assertEquals(
+            expected = listOf("Text before the ", " and text after it"),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun linkAtTheStartAndAtTheEnd() {
+        val texts = textWithLinks {
+            withLink(url()) { append("first") }
+            append(" middle ")
+            withLink(url()) { append("second") }
+        }
+
+        assertEquals(
+            expected = listOf("", " middle ", ""),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun adjacentLinks() {
+        val texts = textWithLinks {
+            append("start")
+            withLink(url()) { append("first") }
+            withLink(url()) { append("second") }
+            append("end")
+        }
+
+        assertEquals(
+            expected = listOf("start", "", "end"),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun theWholeTextIsALink() {
+        val texts = textWithLinks {
+            withLink(url()) { append("link") }
+        }
+
+        assertEquals(
+            expected = listOf("", ""),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun severalTextsAreJoinedWithLineBreak() {
+        val texts = listOf(
+            buildAnnotatedString {
+                append("first text with a ")
+                withLink(url()) { append("link") }
+            },
+            AnnotatedString("second text"),
+            buildAnnotatedString {
+                withLink(url()) { append("another link") }
+                append(" in the third text")
+            },
+        )
+
+        assertEquals(
+            expected = listOf("first text with a ", "\nsecond text\n", " in the third text"),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun emptyLinkRangesAreSkipped() {
+        val texts = textWithLinks {
+            append("start ")
+            // An empty link range doesn't produce a link node, so it's not counted:
+            withLink(url()) { }
+            append("middle ")
+            withLink(url()) { append("link") }
+            append(" end")
+        }
+
+        assertEquals(
+            expected = listOf("start middle ", " end"),
+            actual = splitTextAndLinks(texts).textParts
+        )
+    }
+
+    @Test
+    fun linkTextsAreExtracted() {
+        val texts = listOf(
+            buildAnnotatedString {
+                append("start ")
+                withLink(url()) { append("first") }
+            },
+            buildAnnotatedString {
+                withLink(url()) { append("second") }
+                append(" end")
+            },
+        )
+
+        assertEquals(
+            expected = listOf("first", "second"),
+            actual = splitTextAndLinks(texts).linkTexts
+        )
+    }
+
+    @Test
+    fun unexpectedLinksCountDoesNotMatch() {
+        val texts = textWithLinks {
+            append("Text before the ")
+            withLink(url()) { append("link") }
+            append(" and text after it")
+        }
+
+        val split = splitTextAndLinks(texts)
+
+        assertTrue(split.matchesLinksCount(1))
+        // The number of the link children doesn't match the number of the link ranges,
+        // so the text node must expose the whole text instead of interleaving the parts:
+        assertFalse(split.matchesLinksCount(2))
+    }
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9440/Web-Accessibility-Support-LinkAnnotation-in-AttributedString

Example:
```kotlin
Text(
    buildAnnotatedString {
        append("Text before the ")
        withLink(
            LinkAnnotation.Url(
                url = "https://www.example.com",
                linkInteractionListener = LinkInteractionListener { link ->
                    clickedUrls.add((link as LinkAnnotation.Url).url)
                }
            )
        ) {
            append("link")
        }
        append(" and text after it")
    }
)

// Result (no URL specified in the html because Compose handles the click event):

<div>Text before the <div role="link">link</div> and text after it</div>
```


## Testing
- Added new tests

## Release Notes
### Fixes - Web
- Support `LinkAnnotation` in a11y tree, so link nodes have `role=link`