### PR TITLE
Refactor ComposeWebSemanticsListener: extract A11YImplementationUtils

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.accessibility
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsProperties
+import org.w3c.dom.Element
+import org.w3c.dom.HTMLElement
+
+internal fun setSizeAndPosition(
+    element: HTMLElement, left: Float, top: Float, width: Float, height: Float
+) {
+    // language=javascript
+    js(
+        """
+       element.style.left = "" + left + "px";
+       element.style.top = "" + top + "px";
+       element.style.width = "" + width + "px";
+       element.style.height = "" + height + "px";
+    """
+    )
+}
+
+internal object AriaRoleId {
+    const val Unknown = -1
+
+    // Mapped from [androidx.compose.ui.semantics.Role] values:
+    const val Button = 0
+    const val Checkbox = 1
+    const val Switch = 2
+    const val RadioButton = 3
+    const val Tab = 4
+    const val Image = 5
+    const val DropdownList = 6
+    const val ValuePicker = Unknown // TODO: Any web alternative?
+    const val Carousel = Unknown // TODO: Any web alternative?
+
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
+    // Other ARIA roles not specified explicitly by [androidx.compose.ui.semantics.Role]:
+    const val Heading = 7
+    const val TextBox = 8
+    const val List = 9
+    const val Grid = 10
+    const val Dialog = 11
+}
+
+internal fun SemanticsConfiguration.getRoleId(): Int {
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
+    // Unfortunately, Role value is private, so we map it here:
+    fun Role.toIntId(): Int = when (this) {
+        Role.Button -> AriaRoleId.Button
+        Role.Checkbox -> AriaRoleId.Checkbox
+        Role.Switch -> AriaRoleId.Switch
+        Role.RadioButton -> AriaRoleId.RadioButton
+        Role.Tab -> AriaRoleId.Tab
+        Role.Image -> AriaRoleId.Image
+        Role.DropdownList -> AriaRoleId.DropdownList
+        Role.ValuePicker -> AriaRoleId.Unknown // TODO: Any web alternative?
+        Role.Carousel -> AriaRoleId.Unknown // TODO: Any web alternative?
+        else -> AriaRoleId.Unknown
+    }
+
+    var roleId = -1
+
+    if (this.contains(SemanticsProperties.Role)) {
+        roleId = this[SemanticsProperties.Role].toIntId()
+    }
+
+    if (this.contains(SemanticsActions.OnClick)) {
+        // TODO: Not everything with OnClick is a button!!!
+        roleId = Role.Button.toIntId()
+    }
+
+    if (this.contains(SemanticsProperties.Heading)) {
+        roleId = AriaRoleId.Heading
+    }
+
+    if (this.contains(SemanticsProperties.EditableText)) {
+        roleId = AriaRoleId.TextBox
+    }
+
+    if (this.contains(SemanticsProperties.CollectionInfo)) {
+        val info = this.get(SemanticsProperties.CollectionInfo)
+        roleId = if (info.columnCount > 1 && info.rowCount > 1) {
+            AriaRoleId.Grid
+        } else {
+            AriaRoleId.List
+        }
+    }
+
+    // Checked last: a layer's structural role outranks whatever its content looks like.
+    if (this.contains(SemanticsProperties.IsDialog)) {
+        roleId = AriaRoleId.Dialog
+    }
+
+    return roleId
+}
+
+// To avoid passing a Kotlin string to JS, we pass an int instead and map it to String on the JS side.
+// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
+internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
+    // language=javascript
+    js(
+        """
+        var roleValue = "";
+        switch (ariaRoleId) {
+            case 0: // Role.Button
+                roleValue = "button";
+                break;
+            case 1: // Role.Checkbox
+                roleValue = "checkbox";
+                break;
+            case 2: // Role.Switch
+                roleValue = "switch";
+                break;
+            case 3: // Role.RadioButton
+                roleValue = "radio";
+                break;
+            case 4: // Role.Tab
+                roleValue = "tab";
+                break;
+            case 5: // Role.Image
+                roleValue = "img";
+                break;
+            case 6: // Role.DropdownList
+                roleValue = "menu";
+                break;
+            case 7: // heading https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role
+                roleValue = "heading";
+                break;
+            case 8: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role
+                roleValue = "textbox";
+                break;
+            case 9: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role
+                roleValue = "list";
+                break;
+            case 10: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role
+                roleValue = "grid";
+                break;
+            case 11: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role
+                roleValue = "dialog";
+                break;
+            default:
+                break;
+        }
+        if (roleValue.length > 0) { 
+            element.setAttribute("role", roleValue);
+        } else {
+            element.removeAttribute("role");
+        }
+    """
+    )
+}
+
+internal fun removeAllChildrenOf(element: HTMLElement) {
+    // language=javascript
+    js("element.replaceChildren()")
+}
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert
+ *  When an element is inert, it along with all of the element's descendants,
+ *  including normally interactive elements such as links, buttons, and form controls are disabled
+ *  because they cannot receive focus or be clicked.
+ */
+internal fun Element.setInert(inert: Boolean) {
+    val element = this.unsafeCast<CanToggleAttribute>()
+    element.toggleAttribute("inert", inert)
+}
+
+private external interface CanToggleAttribute : JsAny {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute
+    fun toggleAttribute(attributeName: String, force: Boolean): Boolean
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -76,14 +76,14 @@ internal fun SemanticsConfiguration.getRoleId(): Int {
         else -> AriaRoleId.Unknown
     }
 
-    var roleId = -1
+    var roleId = AriaRoleId.Unknown
 
     if (this.contains(SemanticsProperties.Role)) {
         roleId = this[SemanticsProperties.Role].toIntId()
     }
 
-    if (this.contains(SemanticsActions.OnClick)) {
-        // TODO: Not everything with OnClick is a button!!!
+    if (SemanticsActions.OnClick in this && roleId == AriaRoleId.Unknown) {
+        // TODO: Not everything with OnClick is a button! For now default to button for unknown clickable roles
         roleId = Role.Button.toIntId()
     }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -21,7 +21,6 @@ import androidx.collection.MutableScatterMap
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.PlatformContext
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -29,7 +28,6 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastJoinToString
-import kotlin.js.js
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +39,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
 
@@ -199,7 +196,7 @@ internal class ComposeWebSemanticsListener(
         allNodesIds.clear()
 
         semanticsOwners.fastForEach {
-            syncSemanticsWithWebA11Y(it, allNodesIds)
+            syncSemanticsWithWebA11Y(it)
         }
 
         val removedIds = mutableSetOf<Int>()
@@ -243,10 +240,7 @@ internal class ComposeWebSemanticsListener(
     /**
      * Sync the tree corresponding to the [semanticsOwner] and populate [allNodesIds] - a set of node ids.
      */
-    private fun syncSemanticsWithWebA11Y(
-        semanticsOwner: SemanticsOwner,
-        allNodesIds: MutableIntSet
-    ) {
+    private fun syncSemanticsWithWebA11Y(semanticsOwner: SemanticsOwner) {
         fun SemanticsNode.isValid() = layoutNode.let { it.isPlaced && it.isAttached }
 
         val root = semanticsOwner.rootSemanticsNode
@@ -261,53 +255,80 @@ internal class ComposeWebSemanticsListener(
 
         while (!dfsDeque.isEmpty()) {
             val node = dfsDeque.removeLast()
-            val currentId = node.id
-            allNodesIds.add(currentId)
 
             // `config` recreates the merged subtree on every call, so read it once
             val config = node.config
 
-            val children = node.replacedChildren.asReversed()
-            dfsDeque.addAll(children)
-            children.fastForEach { it -> nodeToParent[it.id] = currentId }
+            val reversedChildren = node.replacedChildren.asReversed()
+            dfsDeque.addAll(reversedChildren)
+            reversedChildren.fastForEach { nodeToParent[it.id] = node.id }
 
-            val htmlNode = if (nodes[currentId] != null) {
-                nodes[currentId] = node
-                val htmlNode = webNodes[currentId] ?: error("Node $currentId not found")
+            // The parent is known here: it was recorded when this node was pushed to the deque.
+            val htmlParent = nodeToParent[node.id]?.let { webNodes[it] } ?: webSemanticsRoot
 
-                if (children.isNotEmpty()) {
-                    // To ensure the correct order of nested nodes, we remove all of them.
-                    // I assume it's more efficient to remove and re-add them than to insert the nodes at specific positions.
-                    // Also, the code is more simple with this approach.
-                    // They are added below.
-                    removeAllChildrenOf(htmlNode)
-                }
-
-                syncNode(node, config, htmlNode, rootPosition)
-                htmlNode
-            } else {
-                nodes[currentId] = node
-                val htmlNode = document.createElement("div") as HTMLElement
-                htmlNode.style.apply {
-                    position = "fixed"
-                    whiteSpace = "pre"
-                }
-
-                webNodes[currentId] = htmlNode
-                syncNode(node, config, htmlNode, rootPosition, true)
-                htmlNode
-            }
-
-            // find the parent node and attach to it
-            val parentId = nodeToParent[currentId]
-            val htmlParent = parentId?.let { webNodes[it] } ?: webSemanticsRoot
-            htmlParent.appendChild(htmlNode)
-            elementToSemanticsNode[htmlNode] = node
+            syncNode(
+                semanticsNode = node,
+                config = config,
+                htmlParent = htmlParent,
+                rootPosition = rootPosition,
+                hasChildren = reversedChildren.isNotEmpty()
+            )
         }
     }
 
+    /**
+     * Creates (or reuses) the HTML node corresponding to [semanticsNode], syncs its state and
+     * attaches it to [htmlParent].
+     *
+     * @param hasChildren whether the node has semantics children
+     */
     private fun syncNode(
-        sn: SemanticsNode,
+        semanticsNode: SemanticsNode,
+        config: SemanticsConfiguration,
+        htmlParent: HTMLElement,
+        rootPosition: Offset,
+        hasChildren: Boolean,
+    ) {
+        val currentId = semanticsNode.id
+        allNodesIds.add(currentId)
+
+        val htmlNode = if (nodes[currentId] != null) {
+            nodes[currentId] = semanticsNode
+            val htmlNode = webNodes[currentId] ?: error("Node $currentId not found")
+
+            if (hasChildren) {
+                // To ensure the correct order of nested nodes, we remove all of them.
+                // I assume it's more efficient to remove and re-add them than to insert the nodes at specific positions.
+                // Also, the code is more simple with this approach.
+                // They are added back when they are synced.
+                removeAllChildrenOf(htmlNode)
+            }
+
+            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition)
+            htmlNode
+        } else {
+            nodes[currentId] = semanticsNode
+            val htmlNode = document.createElement("div") as HTMLElement
+            htmlNode.style.apply {
+                position = "fixed"
+                whiteSpace = "pre"
+            }
+
+            webNodes[currentId] = htmlNode
+            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, justCreated = true)
+            htmlNode
+        }
+
+        htmlParent.appendChild(htmlNode)
+        elementToSemanticsNode[htmlNode] = semanticsNode
+    }
+
+    /**
+     * Writes the state of [semanticsNode] onto [htmlNode]:
+     * the text, the ARIA attributes and role, the size and the position.
+     */
+    private fun syncNodeProperties(
+        semanticsNode: SemanticsNode,
         config: SemanticsConfiguration,
         htmlNode: HTMLElement,
         rootOffset: Offset,
@@ -329,8 +350,7 @@ internal class ComposeWebSemanticsListener(
         }
 
         if (config.contains(SemanticsProperties.EditableText)) {
-            val text = config[SemanticsProperties.EditableText].text
-            htmlNode.innerText = text
+            htmlNode.innerText = config[SemanticsProperties.EditableText].text
 
             if (justCreated) {
                 htmlNode.setAttribute("contenteditable", "true")
@@ -354,8 +374,8 @@ internal class ComposeWebSemanticsListener(
             htmlNode.removeAttribute("aria-modal")
         }
 
-        val density = sn.layoutNode.density
-        sn.boundsInRoot.let { rect ->
+        val density = semanticsNode.layoutNode.density
+        semanticsNode.boundsInRoot.let { rect ->
             val newPosition = rootOffset + rect.topLeft.div(density.density)
             val width = rect.width.div(density.density)
             val height = rect.height.div(density.density)
@@ -363,7 +383,6 @@ internal class ComposeWebSemanticsListener(
             setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width, height)
         }
     }
-
 
     internal fun stop() {
         if (!hasStarted || hasStopped) return
@@ -384,170 +403,4 @@ internal class ComposeWebSemanticsListener(
         removeAllChildrenOf(webSemanticsRoot)
         hasStopped = true
     }
-}
-
-private fun setSizeAndPosition(
-    element: HTMLElement, left: Float, top: Float, width: Float, height: Float
-) {
-    // language=javascript
-    js(
-        """
-       element.style.left = "" + left + "px";
-       element.style.top = "" + top + "px";
-       element.style.width = "" + width + "px";
-       element.style.height = "" + height + "px";
-    """
-    )
-}
-
-internal object AriaRoleId {
-    const val Unknown = -1
-
-    // Mapped from [androidx.compose.ui.semantics.Role] values:
-    const val Button = 0
-    const val Checkbox = 1
-    const val Switch = 2
-    const val RadioButton = 3
-    const val Tab = 4
-    const val Image = 5
-    const val DropdownList = 6
-    const val ValuePicker = Unknown // TODO: Any web alternative?
-    const val Carousel = Unknown // TODO: Any web alternative?
-
-    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
-    // Other ARIA roles not specified explicitly by [androidx.compose.ui.semantics.Role]:
-    const val Heading = 7
-    const val TextBox = 8
-    const val List = 9
-    const val Grid = 10
-    const val Dialog = 11
-}
-
-internal fun SemanticsConfiguration.getRoleId(): Int {
-    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
-    // Unfortunately, Role value is private, so we map it here:
-    fun Role.toIntId(): Int = when (this) {
-        Role.Button -> AriaRoleId.Button
-        Role.Checkbox -> AriaRoleId.Checkbox
-        Role.Switch -> AriaRoleId.Switch
-        Role.RadioButton -> AriaRoleId.RadioButton
-        Role.Tab -> AriaRoleId.Tab
-        Role.Image -> AriaRoleId.Image
-        Role.DropdownList -> AriaRoleId.DropdownList
-        Role.ValuePicker -> AriaRoleId.Unknown // TODO: Any web alternative?
-        Role.Carousel -> AriaRoleId.Unknown // TODO: Any web alternative?
-        else -> AriaRoleId.Unknown
-    }
-
-    var roleId = -1
-
-    if (this.contains(SemanticsProperties.Role)) {
-        roleId = this[SemanticsProperties.Role].toIntId()
-    }
-
-    if (this.contains(SemanticsActions.OnClick)) {
-        // TODO: Not everything with OnClick is a button!!!
-        roleId = Role.Button.toIntId()
-    }
-
-    if (this.contains(SemanticsProperties.Heading)) {
-        roleId = AriaRoleId.Heading
-    }
-
-    if (this.contains(SemanticsProperties.EditableText)) {
-        roleId = AriaRoleId.TextBox
-    }
-
-    if (this.contains(SemanticsProperties.CollectionInfo)) {
-        val info = this.get(SemanticsProperties.CollectionInfo)
-        roleId = if (info.columnCount > 1 && info.rowCount > 1) {
-            AriaRoleId.Grid
-        } else {
-            AriaRoleId.List
-        }
-    }
-
-    // Checked last: a layer's structural role outranks whatever its content looks like.
-    if (this.contains(SemanticsProperties.IsDialog)) {
-        roleId = AriaRoleId.Dialog
-    }
-
-    return roleId
-}
-
-// To avoid passing a Kotlin string to JS, we pass an int instead and map it to String on the JS side.
-// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles
-internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
-    // language=javascript
-    js(
-        """
-        var roleValue = "";
-        switch (ariaRoleId) {
-            case 0: // Role.Button
-                roleValue = "button";
-                break;
-            case 1: // Role.Checkbox
-                roleValue = "checkbox";
-                break;
-            case 2: // Role.Switch
-                roleValue = "switch";
-                break;
-            case 3: // Role.RadioButton
-                roleValue = "radio";
-                break;
-            case 4: // Role.Tab
-                roleValue = "tab";
-                break;
-            case 5: // Role.Image
-                roleValue = "img";
-                break;
-            case 6: // Role.DropdownList
-                roleValue = "menu";
-                break;
-            case 7: // heading https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role
-                roleValue = "heading";
-                break;
-            case 8: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role
-                roleValue = "textbox";
-                break;
-            case 9: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role
-                roleValue = "list";
-                break;
-            case 10: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role
-                roleValue = "grid";
-                break;
-            case 11: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role
-                roleValue = "dialog";
-                break;
-            default:
-                break;
-        }
-        if (roleValue.length > 0) { 
-            element.setAttribute("role", roleValue);
-        } else {
-            element.removeAttribute("role");
-        }
-    """
-    )
-}
-
-private fun removeAllChildrenOf(element: HTMLElement) {
-    // language=javascript
-    js("element.replaceChildren()")
-}
-
-/**
- * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert
- *  When an element is inert, it along with all of the element's descendants,
- *  including normally interactive elements such as links, buttons, and form controls are disabled
- *  because they cannot receive focus or be clicked.
- */
-private fun Element.setInert(inert: Boolean) {
-    val element = this.unsafeCast<CanToggleAttribute>()
-    element.toggleAttribute("inert", inert)
-}
-
-private external interface CanToggleAttribute : JsAny {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute
-    fun toggleAttribute(attributeName: String, force: Boolean): Boolean
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yNodePositioningTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yNodePositioningTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.w3c.dom.HTMLElement
+
+/**
+ * A11Y elements are positioned with absolute (root-relative) coordinates while being nested
+ * according to the semantics tree, so a node's rendered rect must not depend on its depth.
+ * Positioning them with `transform` breaks this: a transformed element becomes the containing
+ * block for its `position: fixed` descendants, so every level re-applies its ancestors' offsets.
+ */
+class A11yNodePositioningTest : OnCanvasTests {
+
+    @Test
+    fun nestedNodeIsRenderedAtTheSameRectAsAnEquivalentFlatNode() = runApplicationTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize()) {
+                Box(Modifier.offset(40.dp, 40.dp).testTag("outer")) {
+                    Box(Modifier.offset(30.dp, 30.dp).testTag("middle")) {
+                        Box(Modifier.offset(20.dp, 20.dp).size(50.dp).testTag("nested"))
+                    }
+                }
+                Box(Modifier.offset(90.dp, 90.dp).size(50.dp).testTag("flat"))
+            }
+        }
+        awaitA11YChanges()
+
+        assertSameRect("nested", "flat")
+    }
+
+    @Test
+    fun childOfAnOffsetNodeIsNotShiftedByItsParentOffsetTwice() = runApplicationTest {
+        createComposeWindow {
+            Box(Modifier.fillMaxSize()) {
+                Box(Modifier.offset(40.dp, 40.dp).size(50.dp).testTag("parent")) {
+                    Box(Modifier.size(50.dp).testTag("child"))
+                }
+            }
+        }
+        awaitA11YChanges()
+
+        assertSameRect("child", "parent")
+    }
+
+    /**
+     * Asserts that two nodes occupying the same Compose bounds are rendered at the same rect.
+     * Comparing two elements keeps the assert independent of density and page offset.
+     */
+    private fun assertSameRect(testTag: String, expectedTestTag: String) {
+        // Sub-pixel tolerance for device pixel ratio rounding.
+        val epsilon = 1.0
+        val actual = a11yElement(testTag).getBoundingClientRect()
+        val expected = a11yElement(expectedTestTag).getBoundingClientRect()
+
+        assertTrue(expected.width > 0.0 && expected.height > 0.0, "'$expectedTestTag' has no rect")
+
+        assertEquals(expected.left, actual.left, epsilon, "'$testTag' left")
+        assertEquals(expected.top, actual.top, epsilon, "'$testTag' top")
+        assertEquals(expected.width, actual.width, epsilon, "'$testTag' width")
+        assertEquals(expected.height, actual.height, epsilon, "'$testTag' height")
+    }
+
+    // A11Y elements get their TestTag as `id`.
+    private fun a11yElement(testTag: String): HTMLElement = assertNotNull(
+        getShadowRoot().getElementById(testTag) as? HTMLElement,
+        "no a11y element for '$testTag' in ${getA11YContainer()?.innerHTML}"
+    )
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -37,6 +38,9 @@ import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -498,6 +502,35 @@ class CfWA11YTest : OnCanvasTests {
 
         assertEquals("textbox", textField.getAttribute("role"))
         assertEquals("Hello, World!", textField.innerText)
+    }
+
+    @Test
+    fun clickableNodeKeepsItsExplicitRole() = runApplicationTest {
+        createComposeWindow {
+            Column {
+                Box(
+                    Modifier.testTag("checkbox").size(24.dp)
+                        .semantics { role = Role.Checkbox }
+                        .clickable { }
+                )
+                Box(
+                    Modifier.testTag("tab").size(24.dp)
+                        .semantics { role = Role.Tab }
+                        .clickable { }
+                )
+                Box(Modifier.testTag("clickable").size(24.dp).clickable { })
+            }
+        }
+
+        awaitA11YChanges()
+
+        fun role(testTag: String) =
+            assertNotNull(getShadowRoot().getElementById(testTag) as? HTMLElement, testTag)
+                .getAttribute("role")
+
+        assertEquals("checkbox", role("checkbox"))
+        assertEquals("tab", role("tab"))
+        assertEquals("button", role("clickable"))
     }
 
     @Test // A reproducer for https://youtrack.jetbrains.com/issue/CMP-10226

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/accessibility/A11yRoleIdTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/accessibility/A11yRoleIdTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.accessibility
+
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.editableText
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.text.AnnotatedString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class A11yRoleIdTest {
+
+    @Test
+    fun noRoleAndNoClickIsUnknown() {
+        assertEquals(AriaRoleId.Unknown, config { }.getRoleId())
+    }
+
+    @Test
+    fun clickableWithoutRoleFallsBackToButton() {
+        assertEquals(AriaRoleId.Button, config { onClick { true } }.getRoleId())
+    }
+
+    @Test
+    fun explicitRoleIsMapped() {
+        assertEquals(AriaRoleId.Checkbox, config { role = Role.Checkbox }.getRoleId())
+        assertEquals(AriaRoleId.Switch, config { role = Role.Switch }.getRoleId())
+        assertEquals(AriaRoleId.RadioButton, config { role = Role.RadioButton }.getRoleId())
+        assertEquals(AriaRoleId.Tab, config { role = Role.Tab }.getRoleId())
+        assertEquals(AriaRoleId.Image, config { role = Role.Image }.getRoleId())
+        assertEquals(AriaRoleId.DropdownList, config { role = Role.DropdownList }.getRoleId())
+    }
+
+    @Test
+    fun explicitRoleIsNotOverriddenByOnClick() {
+        listOf(
+            Role.Checkbox to AriaRoleId.Checkbox,
+            Role.Switch to AriaRoleId.Switch,
+            Role.RadioButton to AriaRoleId.RadioButton,
+            Role.Tab to AriaRoleId.Tab,
+            Role.Image to AriaRoleId.Image,
+            Role.DropdownList to AriaRoleId.DropdownList,
+        ).forEach { (role, expectedRoleId) ->
+            assertEquals(
+                expectedRoleId,
+                config {
+                    this.role = role
+                    onClick { true }
+                }.getRoleId(),
+                "clickable $role"
+            )
+        }
+    }
+
+    @Test
+    fun clickableRoleWithoutAriaMappingFallsBackToButton() {
+        assertEquals(
+            AriaRoleId.Button,
+            config {
+                role = Role.ValuePicker
+                onClick { true }
+            }.getRoleId()
+        )
+    }
+
+    @Test
+    fun structuralRolesWinOverClickableFallback() {
+        assertEquals(AriaRoleId.Heading, config { heading(); onClick { true } }.getRoleId())
+        assertEquals(AriaRoleId.Dialog, config { dialog(); onClick { true } }.getRoleId())
+        assertEquals(
+            AriaRoleId.TextBox,
+            config { editableText = AnnotatedString("text"); onClick { true } }.getRoleId()
+        )
+    }
+
+    @Test
+    fun structuralRolesWinOverExplicitRole() {
+        assertEquals(
+            AriaRoleId.Heading,
+            config { role = Role.Button; heading() }.getRoleId()
+        )
+        assertEquals(
+            AriaRoleId.Dialog,
+            config { role = Role.Button; dialog() }.getRoleId()
+        )
+    }
+
+    @Test
+    fun collectionInfoMapsToListOrGrid() {
+        assertEquals(
+            AriaRoleId.List,
+            config { collectionInfo = CollectionInfo(rowCount = 5, columnCount = 1) }.getRoleId()
+        )
+        assertEquals(
+            AriaRoleId.Grid,
+            config { collectionInfo = CollectionInfo(rowCount = 5, columnCount = 5) }.getRoleId()
+        )
+        assertEquals(
+            AriaRoleId.List,
+            config {
+                collectionInfo = CollectionInfo(rowCount = 5, columnCount = 1)
+                onClick { true }
+            }.getRoleId()
+        )
+    }
+
+    private fun config(block: SemanticsPropertyReceiver.() -> Unit) =
+        SemanticsConfiguration().apply(block)
+}


### PR DESCRIPTION
Pure refactoring of the Web a11y implementation, no behavior change. 
It prepares the files for the upcoming `LinkAnnotation` support - https://github.com/JetBrains/compose-multiplatform-core/pull/3331

- Moved the toplevel functions out of `ComposeWebSemanticsListener.kt` into a new `A11YImplementationUtils.kt`
- Extracted the body of the traversal loop into `syncNode(...)`: it creates or reuses the HTML node, removes the stale children, syncs the state and attaches the node to its HTML parent.


## Testing
- Added new tests for the extracted parts

## Release Notes
N/A