### PR TITLE
Disable Swing double-buffering at the window level to reduce memory footprint

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -94,7 +94,7 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ) : super(owner, "", modalityType, graphicsConfiguration) {
         composePanel = createComposePanel(skiaLayerAnalytics, savedState, coroutineContext)
-        contentPane.add(composePanel)
+        init()
     }
 
     /**
@@ -120,7 +120,7 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ) : super(owner, "", modal, graphicsConfiguration) {
         composePanel = createComposePanel(skiaLayerAnalytics, savedState, coroutineContext)
-        contentPane.add(composePanel)
+        init()
     }
 
     /**
@@ -202,6 +202,11 @@ class ComposeDialog : JDialog, ComposeDesktopEntryPoint {
     constructor() : this(
         owner = null as Frame?,
     )
+
+    private fun init() {
+        disableDoubleBuffering()  // To reduce memory use
+        contentPane.add(composePanel)
+    }
 
     internal var rootForTestListener
         get() = composePanel.rootForTestListener

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -94,6 +94,7 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     var isClearFocusOnMouseDownEnabled: Boolean by composePanel::isClearFocusOnMouseDownEnabled
 
     init {
+        disableDoubleBuffering()  // To reduce memory use
         contentPane.add(composePanel)
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -198,6 +198,11 @@ internal class SwingInteropViewGroup(
             }
         }
         isFocusCycleRoot = true
+
+        // `true` is already the default in JPanel, but setting it explicitly because we disable
+        // double buffering at the root (ComposeWindow, ComposeDialog), so we need it enabled here
+        // or else Swing interop won't be double-buffered.
+        isDoubleBuffered = true
     }
 
     override fun getPreferredSize(): Dimension {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -27,6 +27,7 @@ import java.awt.EventQueue
 import java.awt.Graphics
 import java.awt.Rectangle
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.JComponent
 import javax.swing.JLayeredPane
 import javax.swing.RootPaneContainer
 import kotlin.math.ceil
@@ -183,4 +184,12 @@ internal class DebouncingEdtExecutor {
             }
         }
     }
+}
+
+/**
+ * Disables double-buffering for the given window.
+ */
+internal fun RootPaneContainer.disableDoubleBuffering() {
+    rootPane.isDoubleBuffered = false
+    (contentPane as? JComponent)?.isDoubleBuffered = false
 }


### PR DESCRIPTION
Disable Swing double-buffering at the window level to reduce memory footprint.

This prevents Swing from allocating an extra window-sized buffer which is typically not needed when using `ComposeWindow` or `ComposeDialog`.

Saves on the order of a few tens of MB, depending on window size.

Improves https://youtrack.jetbrains.com/issue/CMP-10428/Reduce-desktop-memory-footprint

## Testing
Tested manually by showing a large window and observing memory usage.

## Release Notes
### Features - Desktop
- Disabled Swing double buffering to reduce memory footprint.
