### PR TITLE
Fix iOS back swipe progress bounds

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/IosBackNavigationEventInput.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/navigationevent/IosBackNavigationEventInput.ios.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.width
+import androidx.compose.ui.util.fastCoerceIn
 import androidx.navigationevent.NavigationEvent
 import kotlin.math.abs
-import kotlin.math.max
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CPointed
 import kotlinx.cinterop.CPointer
@@ -231,11 +231,12 @@ internal class IosBackNavigationEventInput(
                         view.bounds.toDpRect().width.toPx()
                     }
 
-                    val progress = if (leftEdge) {
-                        max(0f, touch.x - initialGestureOffset.x) / width
+                    val distance = if (leftEdge) {
+                        touch.x - initialGestureOffset.x
                     } else {
-                        max(0f, initialGestureOffset.x - touch.x) / width
+                        initialGestureOffset.x - touch.x
                     }
+                    val progress = (distance / width).fastCoerceIn(0f, 1f)
                     dispatchOnEventProgressed(
                         recognizer,
                         NavigationEvent(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/swipeback/SwipeBackTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/swipeback/SwipeBackTest.kt
@@ -35,9 +35,14 @@ import androidx.compose.ui.test.UIKitInstrumentedTest
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.hold
+import androidx.compose.ui.test.utils.leftCenter
+import androidx.compose.ui.test.utils.moveToLocationOnWindow
+import androidx.compose.ui.test.utils.offsetBy
+import androidx.compose.ui.test.utils.rightCenter
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.navigationevent.NavigationEvent
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.NavigationEventTransitionState
@@ -129,6 +134,38 @@ internal abstract class SwipeBackTest(
         swipeBack.up()
 
         waitUntil("left edge back swipe should complete in LTR") {
+            backCompletedCount == 1
+        }
+    }
+
+    @Test
+    fun testBackSwipeProgressIsBoundedWhenTouchMovesPastWindowInLtr() = runUIKitInstrumentedTest {
+        var transitionState: NavigationEventTransitionState = NavigationEventTransitionState.Idle
+        var backCompletedCount = -1
+
+        setContent(layoutDirection = UITraitEnvironmentLayoutDirectionLeftToRight) {
+            SwipeBackTestContent(
+                onTransitionStateChanged = { transitionState = it },
+                onBackCompletedCountChanged = { backCompletedCount = it },
+            )
+        }
+
+        val swipeBack = touchDown(screenBounds.leftCenter(), fromEdge = true)
+        swipeBack.moveToLocationOnWindow(screenBounds.leftCenter().offsetBy(dx = 16.dp))
+
+        waitUntil("back swipe should be in progress") {
+            transitionState is InProgress
+        }
+
+        swipeBack.moveToLocationOnWindow(screenBounds.rightCenter().offsetBy(dx = 64.dp))
+
+        waitUntil("back swipe progress should be capped at one") {
+            (transitionState as? InProgress)?.latestEvent?.progress == 1f
+        }
+
+        swipeBack.up()
+
+        waitUntil("back swipe should complete") {
             backCompletedCount == 1
         }
     }


### PR DESCRIPTION
Clamp iOS back navigation gesture progress to the `[0f, 1f]` range.

Fixes [CMP-10696](https://youtrack.jetbrains.com/issue/CMP-10696) [iOS] Back gesture crashes with "Expecting fraction between 0 and 1": UIKitNavigationEventInput can report progress > 1

## Testing
Adds regression test `testBackSwipeProgressIsBoundedWhenTouchMovesPastWindowInLtr` to `SwipeBackTest`

## Release Notes
### Fixes - iOS
- Fix an issue where back-swipe progress could exceed its maximum when a gesture moved beyond the window bounds
