### PR TITLE
Fix iOS TextField cursor placement on CJK punctuation

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
@@ -255,12 +255,16 @@ internal fun String.isWhitespaceOrPunctuation(offset: Int): Boolean {
 /**
  * Returns whether iOS cursor placement should remain at the character boundary instead of
  * applying Cupertino's Latin word adjustment. This helper lives in `skikoMain` alongside the
- * shared Cupertino cursor adjustment, but its production callers are iOS-only.
+ * shared Cupertino cursor adjustment, but its production callers are iOS-only. Whitespace is
+ * excluded so that Cupertino's existing whitespace placement remains unchanged.
  */
 internal fun String.requiresCharacterLevelCursorPlacement(index: Int): Boolean {
     if (index !in indices) return false
 
-    return when (codePointAt(index)) {
+    val codePoint = codePointAt(index)
+    if (codePoint.isWhitespace()) return false
+
+    return when (codePoint) {
         in 0x2E80..0x312F, // CJK radicals, punctuation, Hiragana, Katakana, and Bopomofo.
         in 0x3130..0x318F, // Hangul compatibility jamo.
         in 0x31A0..0x31FF, // Bopomofo extended and Katakana phonetic extensions.

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
@@ -253,8 +253,9 @@ internal fun String.isWhitespaceOrPunctuation(offset: Int): Boolean {
 }
 
 /**
- * CJK scripts and full-width forms use character-level cursor placement on iOS. Applying
- * Cupertino's Latin word adjustment to them can move the cursor to a later whitespace.
+ * Returns whether iOS cursor placement should remain at the character boundary instead of
+ * applying Cupertino's Latin word adjustment. This helper lives in `skikoMain` alongside the
+ * shared Cupertino cursor adjustment, but its production callers are iOS-only.
  */
 internal fun String.requiresCharacterLevelCursorPlacement(index: Int): Boolean {
     if (index !in indices) return false

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/StringHelpers.skiko.kt
@@ -253,6 +253,30 @@ internal fun String.isWhitespaceOrPunctuation(offset: Int): Boolean {
 }
 
 /**
+ * CJK scripts and full-width forms use character-level cursor placement on iOS. Applying
+ * Cupertino's Latin word adjustment to them can move the cursor to a later whitespace.
+ */
+internal fun String.requiresCharacterLevelCursorPlacement(index: Int): Boolean {
+    if (index !in indices) return false
+
+    return when (codePointAt(index)) {
+        in 0x2E80..0x312F, // CJK radicals, punctuation, Hiragana, Katakana, and Bopomofo.
+        in 0x3130..0x318F, // Hangul compatibility jamo.
+        in 0x31A0..0x31FF, // Bopomofo extended and Katakana phonetic extensions.
+        in 0x3400..0x4DBF, // CJK unified ideographs extension A.
+        in 0x4E00..0x9FFF, // CJK unified ideographs.
+        in 0xAC00..0xD7AF, // Hangul syllables and jamo extensions.
+        in 0xF900..0xFAFF, // CJK compatibility ideographs.
+        in 0xFE30..0xFE4F, // CJK compatibility forms.
+        in 0xFF00..0xFFEF, // Half-width and full-width forms.
+        in 0x20000..0x3134F, // Supplementary CJK ideographs.
+        -> true
+
+        else -> false
+    }
+}
+
+/**
  * Returns the midpoint position in the string considering Unicode symbols.
  *
  * This function calculates the midpoint position in the given string, taking into account Unicode symbols.

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
@@ -93,6 +93,8 @@ internal fun determineCursorDesiredOffset(
             textLayoutResult.getLineEnd(lineNumber)
         }
 
+        currentText.requiresCharacterLevelCursorPlacement(offset) -> offset
+
         currentText.isWhitespaceOrPunctuation(offset) -> findNextNonWhitespaceSymbolsSubsequenceStartOffset(
             offset,
             currentText

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CharacterLevelCursorPlacementTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CharacterLevelCursorPlacementTest.kt
@@ -41,6 +41,11 @@ class CharacterLevelCursorPlacementTest {
     }
 
     @Test
+    fun ideographicSpace_doesNotRequireCharacterLevelCursorPlacement() {
+        assertFalse("\u3000".requiresCharacterLevelCursorPlacement(0))
+    }
+
+    @Test
     fun latinAsciiPunctuationAndEmoji_keepCupertinoWordPlacement() {
         assertFalse("a".requiresCharacterLevelCursorPlacement(0))
         assertFalse(",".requiresCharacterLevelCursorPlacement(0))

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CharacterLevelCursorPlacementTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CharacterLevelCursorPlacementTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CharacterLevelCursorPlacementTest {
+    @Test
+    fun cjkPunctuation_requiresCharacterLevelCursorPlacement() {
+        val text = "a\u3001\u3002\uFF01z"
+
+        assertTrue(text.requiresCharacterLevelCursorPlacement(1))
+        assertTrue(text.requiresCharacterLevelCursorPlacement(2))
+        assertTrue(text.requiresCharacterLevelCursorPlacement(3))
+    }
+
+    @Test
+    fun cjkScriptsAndFullWidthForms_requireCharacterLevelCursorPlacement() {
+        assertTrue("\u4E2D".requiresCharacterLevelCursorPlacement(0))
+        assertTrue("\u3042".requiresCharacterLevelCursorPlacement(0))
+        assertTrue("\u30A2".requiresCharacterLevelCursorPlacement(0))
+        assertTrue("\uD55C".requiresCharacterLevelCursorPlacement(0))
+        assertTrue("\uFF21".requiresCharacterLevelCursorPlacement(0))
+        assertTrue("\uD840\uDC00".requiresCharacterLevelCursorPlacement(0))
+    }
+
+    @Test
+    fun latinAsciiPunctuationAndEmoji_keepCupertinoWordPlacement() {
+        assertFalse("a".requiresCharacterLevelCursorPlacement(0))
+        assertFalse(",".requiresCharacterLevelCursorPlacement(0))
+        assertFalse("\uD83D\uDE42".requiresCharacterLevelCursorPlacement(0))
+    }
+
+    @Test
+    fun invalidIndex_doesNotRequireCharacterLevelCursorPlacement() {
+        assertFalse("\u4E2D".requiresCharacterLevelCursorPlacement(-1))
+        assertFalse("\u4E2D".requiresCharacterLevelCursorPlacement(1))
+    }
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
@@ -96,6 +96,21 @@ class CupertinoTextFieldDelegateTest : SkikoComposeTestBase() {
     }
 
     @Test
+    fun determineCursorDesiredOffset_tap_on_ideographic_spaces() {
+        val text = "tap\u3000\u3000next"
+        val spaceOffset = text.indexOf('\u3000')
+
+        val actual =
+            determineCursorDesiredOffset(
+                offset = spaceOffset,
+                textLayoutResult = createSimpleTextLayoutResult(text),
+                currentText = text,
+            )
+
+        assertEquals(text.indexOf("next"), actual)
+    }
+
+    @Test
     fun determineCursorDesiredOffset_tap_in_the_first_half_of_word() {
         val givenOffset = 23
         val desiredOffset = 19

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
@@ -81,6 +81,21 @@ class CupertinoTextFieldDelegateTest : SkikoComposeTestBase() {
     }
 
     @Test
+    fun determineCursorDesiredOffset_tap_on_cjk_punctuation() {
+        val text = "tap\u3001" + "\u540E".repeat(120) + " html"
+        val punctuationOffset = text.indexOf('\u3001')
+
+        val actual =
+            determineCursorDesiredOffset(
+                offset = punctuationOffset,
+                textLayoutResult = createSimpleTextLayoutResult(text),
+                currentText = text,
+            )
+
+        assertEquals(punctuationOffset, actual)
+    }
+
+    @Test
     fun determineCursorDesiredOffset_tap_in_the_first_half_of_word() {
         val givenOffset = 23
         val desiredOffset = 19


### PR DESCRIPTION
Tapping CJK punctuation in an iOS TextField can move the caret to a later
whitespace instead of keeping it near the tapped character.

For example, tapping `、` at offset `6` in the reproduction attached to
CMP-10699 moves the selection to offset `130`.

`determineCursorDesiredOffset` treats punctuation as part of Cupertino's
Latin word-snapping behavior. CJK punctuation therefore enters
`findNextNonWhitespaceSymbolsSubsequenceStartOffset` and may scan across
the following CJK text until it reaches the next whitespace.

Keep character-level cursor placement for CJK scripts and full-width forms
before applying the existing Latin word adjustment. Both
`BasicTextField(TextFieldValue)` and `BasicTextField(TextFieldState)` use
this shared iOS path. Android behavior is unchanged.

Fixes https://youtrack.jetbrains.com/issue/CMP-10699

## Testing

- Added a regression test for tapping U+3001 IDEOGRAPHIC COMMA.
- Added tests covering CJK scripts, full-width forms, Latin punctuation,
  emoji, supplementary CJK characters, and invalid offsets.
- Ran:
  `./gradlew :compose:foundation:foundation:iosSimulatorArm64Test`
- Verified with the reproducer on iPhone 14 / iOS 26.0:
  the selection remains at offset `6` instead of jumping to `130`.

## Release Notes

### Fixes - iOS

- Fixed the TextField caret jumping to a later whitespace when tapping
  CJK punctuation.

## Google CLA

Signed the Google Contributor License Agreement.
