### PR TITLE
Mirror default Navigation3 push/pop transitions on iOS in RTL layouts

### DIFF
--- a/navigation3/navigation3-ui/build-fork.gradle
+++ b/navigation3/navigation3-ui/build-fork.gradle
@@ -96,6 +96,12 @@ androidXMultiplatform {
             dependsOn(nonAndroidTest)
         }
 
+        iosTest {
+            dependencies {
+                implementation(project(":compose:ui:ui-test"))
+            }
+        }
+
         webMain {
             dependsOn(nonAndroidMain)
         }

--- a/navigation3/navigation3-ui/src/iosMain/kotlin/androidx/navigation3/ui/NavDisplay.ios.kt
+++ b/navigation3/navigation3-ui/src/iosMain/kotlin/androidx/navigation3/ui/NavDisplay.ios.kt
@@ -40,11 +40,11 @@ public actual fun <T : Any> defaultTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
         slideIntoContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Left,
+            towards = AnimatedContentTransitionScope.SlideDirection.Start,
             animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND, easing = IosTransitionEasing),
         ),
         slideOutOfContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Left,
+            towards = AnimatedContentTransitionScope.SlideDirection.Start,
             targetOffset = { it / 4 },
             animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND, easing = IosTransitionEasing),
         ) + veilOut(
@@ -58,14 +58,14 @@ public actual fun <T : Any> defaultPopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
         slideIntoContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Right,
+            towards = AnimatedContentTransitionScope.SlideDirection.End,
             initialOffset = { it / 4 },
             animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND, easing = IosTransitionEasing),
         ) + unveilIn(
             animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND, easing = IosTransitionEasing)
         ),
         slideOutOfContainer(
-            towards = AnimatedContentTransitionScope.SlideDirection.Right,
+            towards = AnimatedContentTransitionScope.SlideDirection.End,
             animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND, easing = IosTransitionEasing),
         ),
     )

--- a/navigation3/navigation3-ui/src/iosTest/kotlin/androidx/navigation3/ui/NavDisplayLayoutDirectionTest.kt
+++ b/navigation3/navigation3-ui/src/iosTest/kotlin/androidx/navigation3/ui/NavDisplayLayoutDirectionTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation3.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.navigation3.runtime.NavEntry
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+// Like a native UINavigationController, the default push must enter from the trailing edge
+// (physical right in LTR, physical left in RTL) and the default pop must reveal the previous
+// entry from the leading edge.
+@OptIn(ExperimentalTestApi::class)
+class NavDisplayLayoutDirectionTest {
+
+    @Test
+    fun defaultPushEntersFromTrailingEdgeInLtr() {
+        val incomingLeft = incomingEdgeOffset(LayoutDirection.Ltr, pop = false)
+        assertTrue(
+            incomingLeft > 0f,
+            "LTR push should enter from the right edge (left bound > 0), was $incomingLeft",
+        )
+    }
+
+    @Test
+    fun defaultPushEntersFromTrailingEdgeInRtl() {
+        val incomingLeft = incomingEdgeOffset(LayoutDirection.Rtl, pop = false)
+        assertTrue(
+            incomingLeft < 0f,
+            "RTL push should enter from the left edge (left bound < 0), was $incomingLeft",
+        )
+    }
+
+    @Test
+    fun defaultPopRevealsPreviousEntryFromLeadingEdgeInLtr() {
+        val incomingLeft = incomingEdgeOffset(LayoutDirection.Ltr, pop = true)
+        assertTrue(
+            incomingLeft < 0f,
+            "LTR pop should reveal the previous entry from the left (left bound < 0), " +
+                "was $incomingLeft",
+        )
+    }
+
+    @Test
+    fun defaultPopRevealsPreviousEntryFromLeadingEdgeInRtl() {
+        val incomingLeft = incomingEdgeOffset(LayoutDirection.Rtl, pop = true)
+        assertTrue(
+            incomingLeft > 0f,
+            "RTL pop should reveal the previous entry from the right (left bound > 0), " +
+                "was $incomingLeft",
+        )
+    }
+
+    private fun incomingEdgeOffset(layoutDirection: LayoutDirection, pop: Boolean): Float {
+        var extreme = 0f
+        runComposeUiTest {
+            val backStack =
+                if (pop) mutableStateListOf(FIRST, SECOND) else mutableStateListOf(FIRST)
+            setContent {
+                CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                    NavDisplay(backStack) { key ->
+                        NavEntry(key) { Box(Modifier.fillMaxSize().testTag(key.toString())) }
+                    }
+                }
+            }
+            waitForIdle()
+            mainClock.autoAdvance = false
+            val incoming = if (pop) FIRST else SECOND
+            runOnIdle { if (pop) backStack.removeAt(backStack.lastIndex) else backStack.add(SECOND) }
+            repeat(16) {
+                mainClock.advanceTimeBy(8)
+                extreme = maxByAbs(extreme, incomingLeftBoundOrZero(incoming))
+            }
+        }
+        return extreme
+    }
+
+    private fun ComposeUiTest.incomingLeftBoundOrZero(tag: String): Float {
+        val nodes = onAllNodesWithTag(tag).fetchSemanticsNodes(atLeastOneRootRequired = false)
+        if (nodes.isEmpty()) return 0f
+        return onAllNodesWithTag(tag)[0].getUnclippedBoundsInRoot().left.value
+    }
+
+    private fun maxByAbs(a: Float, b: Float): Float = if (abs(b) > abs(a)) b else a
+
+    private companion object {
+        const val FIRST = "first"
+        const val SECOND = "second"
+    }
+}


### PR DESCRIPTION
The iOS `defaultTransitionSpec()` and `defaultPopTransitionSpec()` in `NavDisplay.ios.kt` slide using the physical `SlideDirection.Left`/`Right`, which ignore the composition's `LayoutDirection`. In an RTL layout (Arabic/Hebrew locales) a push therefore enters from the physical right — exactly as in LTR — while a native `UINavigationController` push mirrors and enters from the left. To an RTL user the default push animation reads as a back navigation.

This replaces `Left`/`Right` with the direction-aware `Start`/`End`:

- push: incoming slides toward `Start`; outgoing slides toward `Start` with the existing `it / 4` parallax and `veilOut`
- pop: the mirror with `End`, keeping `initialOffset = { it / 4 }` and `unveilIn`

`Start`/`End` resolve through `LayoutDirection` and flip the computed offsets automatically, so the offset lambdas, duration, and easing are untouched. LTR behavior is pixel-identical (`Start` == `Left`, `End` == `Right` in LTR). `defaultPredictivePopTransitionSpec()` is already direction-aware via the swipe edge parameter (made RTL-correct for the gesture in #3196) and is not changed. The other platform actuals are unaffected: the Android default is a fade, and desktop/macOS/web use `EnterTransition.None` / `ExitTransition.None`.

Adds `NavDisplayLayoutDirectionTest` in a new `iosTest` source set for `:navigation3:navigation3-ui`, asserting the incoming entry's edge for default push and pop under both LTR and RTL (frame-stepped clock, unclipped bounds). The ui-test dependency is wired the same way `:navigation:navigation-compose` wires `project(":compose:ui:ui-test")` for its compose tests.

Fixes: https://youtrack.jetbrains.com/issue/CMP-10703/Navigation3-default-push-pop-transitions-on-iOS-are-not-mirrored-in-RTL-layouts

## Testing

- Regression test: `NavDisplayLayoutDirectionTest` (iosTest) — default push/pop enter edges under LTR and RTL. Run on an iOS simulator against the currently published `navigation3-ui` defaults, both LTR cases pass and both RTL cases fail (push incoming appears a full width off the right edge, pop incoming a quarter width off the left), demonstrating the test catches the bug; with this change all four pass.
- Manually reproduced on a physical iPhone with an Arabic locale: before the change a push enters from the right in RTL; after, it enters from the left, matching UIKit.
- Spec-level verification against Compose Multiplatform 1.12.0: the same `ContentTransform`s driven through `AnimatedContent` under LTR and RTL — `Left`/`Right` specs animate identically in both directions, `Start`/`End` specs keep LTR unchanged and mirror in RTL.

## Release Notes

### Fixes - iOS

- Default Navigation3 push and pop transitions now follow the layout direction: in RTL layouts a push enters from the left edge and a pop reveals the previous entry from the right edge, matching native `UINavigationController` behavior