### PR TITLE
Suppress the use of the deprecated test APIs.

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -379,6 +379,7 @@ class ContextMenuTest {
         assertEquals("Item 1", clickedItem)
     }
 
+    @Suppress("DEPRECATION")
     private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = androidx.compose.ui.test.runComposeUiTest {
         DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {
             block()

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/HoverableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/HoverableTest.kt
@@ -46,6 +46,7 @@ class HoverableTest {
     // when listening to it via InteractionSource.collectHoveredAsState.
     // https://youtrack.jetbrains.com/issue/COMPOSE-666/Hover-does-not-trigger-on-an-element-that-appears-on-the-cursor
     @OptIn(ExperimentalComposeUiApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun collectHoveredAsStateReceivesSyntheticEnter() = runComposeUiTest {
         var isInnerBoxHovered = false

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.MouseInjectionScope
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
@@ -95,10 +94,10 @@ import org.junit.runner.RunWith
 
 
 @Suppress("WrapUnaryOperator")
-@OptIn(ExperimentalTestApi::class)
 @RunWith(Theories::class)
 class ScrollbarTest {
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ComposeUiTest
@@ -35,18 +34,17 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
-import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlin.test.assertFalse
-import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Test
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
 internal class TooltipAreaTest {
 
     // https://youtrack.jetbrains.com/issue/CMP-2821
+    @Suppress("DEPRECATION")
     @Test
     fun simpleTooltipIsShown() = runComposeUiTest {
         setContent {
@@ -65,6 +63,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is hidden when the tooltip area is pressed.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipHiddenOnPress() = runComposeUiTest {
         setContent {
@@ -86,6 +85,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is hidden when the mouse leaves the tooltip area.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipHiddenOnExit() = runComposeUiTest {
         setContent {
@@ -161,6 +161,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is shown after the given delay and not beforehand.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipShownAfterDelay() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -181,6 +182,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is re-shown after press -> release -> move
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipReshownOnMove() = runComposeUiTest {
         setContent {
@@ -209,6 +211,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is hidden on exit, even if the pointer is "inside" the tooltip area.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipHiddenOnExitEvenIfPointerInside() = runComposeUiTest {
         setContent {
@@ -230,6 +233,7 @@ internal class TooltipAreaTest {
     /**
      * Verify that the tooltip is hidden when the pointer exits into an overlapping element.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun tooltipHiddenOnExitIntoOverlappingElement() = runComposeUiTest {
         setContent {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,6 +63,7 @@ class DesktopScrollableTest {
     private fun scrollPage(bounds: Dp) = bounds.value * density.density
 
     @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
+    @Suppress("DEPRECATION")
     @Test
     fun `linux, scroll vertical`() = runSkikoComposeUiTest(
         size = size,
@@ -108,6 +108,7 @@ class DesktopScrollableTest {
     }
 
     @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
+    @Suppress("DEPRECATION")
     @Test
     fun `windows, scroll vertical`() = runSkikoComposeUiTest(
         size = size,
@@ -151,6 +152,7 @@ class DesktopScrollableTest {
         assertThat(context.offset).isWithin(0.1f).of(-2 * scrollLineWindows(20.dp))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `windows, scroll one page vertical`() = runSkikoComposeUiTest(
         size = size,
@@ -184,6 +186,7 @@ class DesktopScrollableTest {
         assertThat(context.offset).isWithin(0.1f).of(-scrollPage(20.dp))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `macOS, scroll vertical`() = runSkikoComposeUiTest(
         size = size,
@@ -217,6 +220,7 @@ class DesktopScrollableTest {
         assertThat(context.offset).isWithin(0.1f).of(5.5f * scrollLineMacOs())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `scroll with different orientation`() = runSkikoComposeUiTest(
         size = size,
@@ -251,6 +255,7 @@ class DesktopScrollableTest {
     }
 
     @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
+    @Suppress("DEPRECATION")
     @Test
     fun multipleScrollingModifiers() = runSkikoComposeUiTest(
         size = size,
@@ -300,6 +305,7 @@ class DesktopScrollableTest {
         assertThat(horizontalContext.offset).isWithin(0.1f).of(5f * scrollLineLinux(10.dp))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun smoothScrollingDisabled() = runSkikoComposeUiTest(
         size = size,
@@ -342,6 +348,7 @@ class DesktopScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollableDisabled() = runSkikoComposeUiTest(
         size = size,

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
@@ -52,6 +52,7 @@ import org.junit.Test
 
 class TextSelectionTests {
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 
@@ -70,7 +71,6 @@ class TextSelectionTests {
         return this
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.textFieldSemanticInteraction(
         initialValue: String = "",
         semanticNodeContext: SemanticsNodeInteraction.(state: MutableState<TextFieldValue>) -> SemanticsNodeInteraction
@@ -98,7 +98,6 @@ class TextSelectionTests {
     }
 
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.selectLineStart(keyboardInteraction: KeyInjectionScope.() -> Unit) {
         textFieldSemanticInteraction("line 1\nline 2\nline 3\nline 4\nline 5") { state ->
             performKeyInput {
@@ -115,7 +114,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.selectTextStart(keyboardInteraction: KeyInjectionScope.() -> Unit) {
         textFieldSemanticInteraction("line 1\nline 2\nline 3\nline 4\nline 5") { state ->
             performKeyInput {
@@ -129,7 +127,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.selectTextEnd(keyboardInteraction: KeyInjectionScope.() -> Unit) {
         textFieldSemanticInteraction("line 1\nline 2\nline 3\nline 4\nline 5") { state ->
             performKeyInput {
@@ -145,7 +142,6 @@ class TextSelectionTests {
                 }
         }
     }
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.selectLineEnd(keyboardInteraction: KeyInjectionScope.() -> Unit) {
         textFieldSemanticInteraction("line 1\nline 2\nline 3\nline 4\nline 5") { state ->
             performKeyInput {
@@ -242,7 +238,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.deleteAllFromKeyBoard(
         initialText: String, deleteAllInteraction: KeyInjectionScope.() -> Unit
     ) {
@@ -268,7 +263,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun DesktopPlatform.selectAllTest(selectAllInteraction: KeyInjectionScope.() -> Unit) {
         textFieldSemanticInteraction("Select this text") { state ->
             performKeyInput(selectAllInteraction)
@@ -301,7 +295,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsInSelectionContainerSelectsWord() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)
@@ -348,7 +341,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsInTextFieldSelectsWord() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)
@@ -395,7 +387,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsWithoutTextDoesNotCrash() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)
@@ -419,7 +410,6 @@ class TextSelectionTests {
         assertNull(selectionState.selection)
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsAtEmptySpaceDoesNotCrash() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)
@@ -464,7 +454,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsInSelectionDoesNotCancelExistingSelection() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)
@@ -503,7 +492,6 @@ class TextSelectionTests {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun rightClickOnMacOsInTextFieldSelectionDoesNotCancelExistingSelection() {
         assumeTrue(DesktopPlatform.Current == DesktopPlatform.MacOS)

--- a/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/gestures/MacosScrollableTest.kt
+++ b/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/gestures/MacosScrollableTest.kt
@@ -43,6 +43,7 @@ class MacosScrollableTest {
     private val density = Density(2f)
     private val scrollLine = density.density * 10f
 
+    @Suppress("DEPRECATION")
     @Test
     fun `scroll by pixels vertically`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
@@ -63,6 +64,7 @@ class MacosScrollableTest {
         assertEquals(10F, context.offset, 0.1F)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `scroll by lines vertically`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
@@ -84,6 +86,7 @@ class MacosScrollableTest {
         assertEquals(3F * scrollLine, context.offset, 0.1F)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `scroll by pixels horizontally`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
@@ -105,6 +108,7 @@ class MacosScrollableTest {
         assertEquals(5F, context.offset, 0.1F)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `scroll by lines horizontally`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()

--- a/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/test/selection/SelectionTests.macos.kt
+++ b/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/test/selection/SelectionTests.macos.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.assertThat
 import androidx.compose.foundation.isEqualTo
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
@@ -39,7 +38,8 @@ import kotlin.test.Test
 
 class SelectionMacosTests {
 
-    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `select using Shift_End and Shift_Home combinations`() = runSkikoComposeUiTest {
         val state = mutableStateOf(TextFieldValue("line 1\nline 2\nline 3\nline 4\nline 5"))
@@ -82,7 +82,8 @@ class SelectionMacosTests {
         assertThat(state.value.selection).isEqualTo(TextRange(1, 0))
     }
 
-    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `Ctrl + Backspace on an empty line`() = runSkikoComposeUiTest {
         val state = mutableStateOf(TextFieldValue(""))

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalTestApi::class)
 class ClickableFocusTest {
+    @Suppress("DEPRECATION")
     @Test
     fun focus_is_requested_when_click_with_mouse_on_clickable() = runComposeUiTest {
         if (!isRequestFocusOnClickEnabled()) return@runComposeUiTest
@@ -88,6 +89,7 @@ class ClickableFocusTest {
         onNodeWithTag("box1").assertIsFocused()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focus_is_requested_when_click_with_mouse_on_toggleable() = runComposeUiTest {
         if (!isRequestFocusOnClickEnabled()) return@runComposeUiTest
@@ -109,6 +111,7 @@ class ClickableFocusTest {
         onNodeWithTag("box1").assertIsFocused()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focus_is_requested_when_click_with_mouse_on_selectable() = runComposeUiTest {
         if (!isRequestFocusOnClickEnabled()) return@runComposeUiTest
@@ -130,6 +133,7 @@ class ClickableFocusTest {
         onNodeWithTag("box1").assertIsFocused()
     }
 
+    @Suppress("DEPRECATION")
     private fun focus_indication_is_hidden_when_click_with_mouse_and_shown_after_Tab(
         content: @Composable (indication1: TestFocusIndicationNodeFactory, indication2: TestFocusIndicationNodeFactory) -> Unit
     ) = runComposeUiTest {
@@ -275,6 +279,7 @@ class ClickableFocusTest {
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun mouseClickOutsideClearsFocusWithClearFocusOnMouseDownEnabled() {
         val prevClearFocusOnMouseDownEnabled = ComposeUiFlags.isClearFocusOnMouseDownEnabled

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableKeyTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableKeyTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class ClickableKeyTest {
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_enter_key() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -68,6 +69,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_enter_key_and_shift() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -112,6 +114,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_enter_key_and_alt() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -156,6 +159,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_enter_key_and_ctrl() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -200,6 +204,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_enter_key_and_meta() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -244,6 +249,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_numpad_enter_key() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -276,6 +282,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_numpad_enter_key_and_shift() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -320,6 +327,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_numpad_enter_key_and_alt() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -364,6 +372,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_numpad_enter_key_and_ctrl() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -408,6 +417,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_numpad_enter_key_and_meta() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -452,6 +462,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_spacebar_key() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -484,6 +495,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_spacebar_key_and_shift() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -528,6 +540,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_spacebar_key_and_alt() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -572,6 +585,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_spacebar_key_and_ctrl() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -616,6 +630,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_clickable_with_spacebar_key_and_meta() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -660,6 +675,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_toggleable_with_enter_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -725,6 +741,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(9)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_selectable_with_enter_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -790,6 +807,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(9)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_toggleable_with_numpad_enter_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -855,6 +873,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(9)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_selectable_with_numpad_enter_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -920,6 +939,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(9)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_toggleable_with_spacebar_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -985,6 +1005,7 @@ class ClickableKeyTest {
         assertThat(clicksCount).isEqualTo(9)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun trigger_selectable_with_spacebar_key_too() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
@@ -171,6 +171,7 @@ class OnClickTest : SkikoComposeTestBase() {
         assertThat(clicksCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @OptIn(ExperimentalTestApi::class)
     private fun testDoubleClick(
         pointerMatcher: PointerMatcher,
@@ -236,6 +237,7 @@ class OnClickTest : SkikoComposeTestBase() {
     )
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     private fun testLongClick(
         pointerMatcher: PointerMatcher,
         button: PointerButton

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class)
 class ToggleableTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun toggleable_by_Space_button() = runComposeUiTest {
         var state: Boolean by mutableStateOf(false)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BackgroundTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BackgroundTest.kt
@@ -80,6 +80,7 @@ class BackgroundTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_colorRect() = runSkikoComposeUiTest(sceneSize) {
         setContent {
@@ -105,6 +106,7 @@ class BackgroundTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_brushRect() = runSkikoComposeUiTest(sceneSize) {
         setContent {
@@ -133,6 +135,7 @@ class BackgroundTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_colorCircle() = runSkikoComposeUiTest(sceneSize) {
         setContent {
@@ -156,6 +159,7 @@ class BackgroundTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_brushCircle() = runSkikoComposeUiTest(sceneSize) {
         setContent {
@@ -182,6 +186,7 @@ class BackgroundTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_rtl_initially() = runSkikoComposeUiTest(sceneSize) {
         setContent {
@@ -210,6 +215,7 @@ class BackgroundTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun background_rtl_after_switch() = runSkikoComposeUiTest(sceneSize) {
         val direction = mutableStateOf(LayoutDirection.Ltr)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BorderTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BorderTest.kt
@@ -79,6 +79,7 @@ class BorderTest {
     private var shape: Shape? = null
 
     private val sceneSize = Size(40f, 40f)
+    @Suppress("DEPRECATION")
     private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) =
         runSkikoComposeUiTest(sceneSize) {
             params.forEach {
@@ -230,6 +231,7 @@ class BorderTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun border_triangle_shape() = runSkikoComposeUiTest(Size(100f, 100f)) {
         val testTag = "testTag"
@@ -267,6 +269,7 @@ class BorderTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun border_non_simple_rounded_rect() = runSkikoComposeUiTest(Size(50f, 50f)) {
         val topleft = 0f
@@ -393,6 +396,7 @@ class BorderTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun border_generic_shape_color_to_brush() = runSkikoComposeUiTest(Size(20f, 20f)) {
         // Verify that rendering with a solid color initially then with a gradient
@@ -483,6 +487,7 @@ class BorderTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun border_test_with_fixed_size_generic_shape() = runSkikoComposeUiTest(Size(80f, 40f)) {
         val testTag = "testTag"

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/CanvasTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/CanvasTest.kt
@@ -17,7 +17,6 @@
 package androidx.compose.foundation.copyPasteAndroidTests
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.assertPixelColor
 import androidx.compose.foundation.assertShape
 import androidx.compose.foundation.background
@@ -52,6 +51,7 @@ class CanvasTest {
     private val boxHeight = 100
     private val containerSize = boxWidth
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCanvas() = runSkikoComposeUiTest(Size(containerSize * 2f, containerSize * 2f)) {
         val strokeWidth = 5.0f
@@ -154,7 +154,7 @@ class CanvasTest {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun canvas_contentDescription() = runSkikoComposeUiTest {
         val testTag = "canvas"
@@ -168,6 +168,7 @@ class CanvasTest {
         onNodeWithTag(testTag).assertContentDescriptionEquals(contentDescription)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canvas_noSize_emptyCanvas() = runSkikoComposeUiTest {
         setContentForSizeAssertions {
@@ -179,6 +180,7 @@ class CanvasTest {
             .assertWidthIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canvas_exactSizes() = runSkikoComposeUiTest {
         setContentForSizeAssertions {
@@ -199,6 +201,7 @@ class CanvasTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canvas_exactSizes_drawCircle() = runSkikoComposeUiTest(Size(100f, 100f)) {
         setContentForSizeAssertions {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/DraggableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/DraggableTest.kt
@@ -84,6 +84,7 @@ class DraggableTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_horizontalDrag() = runSkikoComposeUiTest {
         var total = 0f
@@ -123,6 +124,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_verticalDrag() = runSkikoComposeUiTest {
         var total = 0f
@@ -163,6 +165,7 @@ class DraggableTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_dragWithPrimaryMouseButton() = runSkikoComposeUiTest {
         var total = 0f
@@ -203,6 +206,7 @@ class DraggableTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_dragWithSecondaryMouseButton() = runSkikoComposeUiTest {
         var total = 0f
@@ -233,6 +237,7 @@ class DraggableTest {
         release(MouseButton.Secondary)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_verticalDrag_newState() = runSkikoComposeUiTest {
         var total = 0f
@@ -272,6 +277,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_startStop() = runSkikoComposeUiTest {
         var startTrigger = 0
@@ -300,6 +306,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_disabledWontCallLambda() = runSkikoComposeUiTest {
         var total = 0f
@@ -333,6 +340,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_velocityProxy() = runSkikoComposeUiTest {
         var velocityTriggered = 0f
@@ -358,6 +366,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_startWithoutSlop_ifAnimating() = runSkikoComposeUiTest {
         var total = 0f
@@ -379,6 +388,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_cancel_callsDragStop() = runSkikoComposeUiTest {
         var total = 0f
@@ -408,6 +418,7 @@ class DraggableTest {
 
     // regression test for b/176971558
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_immediateStart_callsStopWithoutSlop() = runSkikoComposeUiTest {
         var total = 0f
@@ -435,6 +446,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_callsDragStop_whenNewState() = runSkikoComposeUiTest {
         var total = 0f
@@ -465,6 +477,7 @@ class DraggableTest {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_resumesNormally_whenInterruptedWithHigherPriority() = runSkikoComposeUiTest {
         kotlinx.coroutines.test.runTest(UnconfinedTestDispatcher()) {
@@ -511,7 +524,7 @@ class DraggableTest {
         }
     }
 
-
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_noNestedDrag()= runSkikoComposeUiTest {
         var innerDrag = 0f
@@ -551,6 +564,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_interactionSource() = runSkikoComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -600,6 +614,7 @@ class DraggableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun draggable_interactionSource_resetWhenDisposed() = runSkikoComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -660,6 +675,7 @@ class DraggableTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: the test fails on skiko targets
     fun draggable_cancelMidDown_shouldContinueWithNextDown() = runSkikoComposeUiTest {
@@ -695,6 +711,7 @@ class DraggableTest {
         assertThat(total).isGreaterThan(0f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: doesn't pass on skiko targets
     fun testInspectableValue() = runSkikoComposeUiTest {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusGroupTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusGroupTest.kt
@@ -16,19 +16,17 @@
 
 package androidx.compose.foundation.copyPasteAndroidTests
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.assertThat
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.assertThat
-import androidx.compose.foundation.isTrue
 import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isTrue
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection.Companion.Enter
 import androidx.compose.ui.focus.FocusDirection.Companion.Exit
@@ -47,12 +45,13 @@ import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 class FocusGroupTest {
 
     private val initialFocus = FocusRequester()
     private lateinit var focusManager: FocusManager
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusGroup_withNonFocusableContent_isNotFocusable() = runSkikoComposeUiTest {
         // Arrange.
@@ -76,6 +75,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(isFocused).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusGroup_withFocusableContent_isNotFocusable() = runSkikoComposeUiTest {
         // Arrange.
@@ -99,6 +99,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(isFocused).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusGroup_canBeMadeFocusableUsingFocusProperties() = runSkikoComposeUiTest {
         // Arrange.
@@ -123,6 +124,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemWithFocusGroup_canBeMadeFocusable() = runSkikoComposeUiTest {
         // Arrange.
@@ -151,6 +153,7 @@ class FocusGroupTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun oneDimensionalFocusSearch_traversesCurrentFocusGroupBeforeNextGroup() = runSkikoComposeUiTest {
         // Arrange.
@@ -175,6 +178,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun oneDimensionalFocusSearch_flowsOverToNextGroup() = runSkikoComposeUiTest {
         // Arrange.
@@ -199,6 +203,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun oneDimensionalFocusSearch_flowsOverToNextFocusGroupParent() = runSkikoComposeUiTest {
         // Arrange.
@@ -228,6 +233,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun oneDimensionalFocusSearch_wrapsAroundToFirstGroup() = runSkikoComposeUiTest {
         // Arrange.
@@ -252,6 +258,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_Enter() = runSkikoComposeUiTest {
         // Arrange.
@@ -272,13 +279,13 @@ class FocusGroupTest {
         }
 
         // Act.
-        @OptIn(ExperimentalComposeUiApi::class)
         runOnIdle { focusManager.moveFocus(Enter) }
 
         // Assert.
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_Exit() = runSkikoComposeUiTest {
         // Arrange.
@@ -299,13 +306,13 @@ class FocusGroupTest {
         }
 
         // Act.
-        @OptIn(ExperimentalComposeUiApi::class)
         runOnIdle { focusManager.moveFocus(Exit) }
 
         // Assert.
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_skipsChildrenIfTheyAreNotInDirectionOfSearch() = runSkikoComposeUiTest {
         // Arrange.
@@ -330,6 +337,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_returnsNextFocusGroupParentIfItIsFocusable() = runSkikoComposeUiTest {
         // Arrange.
@@ -359,6 +367,7 @@ class FocusGroupTest {
         runOnIdle { assertThat(expectedFocus.isFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_acrossFocusableFocusGroups_skipsChildren() = runSkikoComposeUiTest {
         // Arrange.
@@ -394,6 +403,7 @@ class FocusGroupTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun twoDimensionalFocusSearch_acrossFocusableFocusGroups_whenChildIsInitiallyFocused() = runSkikoComposeUiTest {
         // Arrange.
@@ -453,7 +463,6 @@ class FocusGroupTest {
         modifier: Modifier = Modifier,
         noinline content: @Composable BoxScope.() -> Unit = {}
     ) {
-        @OptIn(ExperimentalFoundationApi::class)
         Box(modifier.focusGroup(), content)
     }
 }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusableBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusableBoundsTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.foundation.copyPasteAndroidTests
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.assertThat
 import androidx.compose.foundation.containsAtLeast
 import androidx.compose.foundation.containsExactlyInOrder
@@ -31,7 +30,6 @@ import androidx.compose.foundation.onFocusedBoundsChanged
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
@@ -49,7 +47,7 @@ import androidx.compose.ui.unit.IntOffset
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalTestApi::class)
 class FocusableBoundsTest {
 
     private lateinit var parentCoordinates: LayoutCoordinates
@@ -57,6 +55,7 @@ class FocusableBoundsTest {
     private val size = 10f
     private val sizeDp = with(Density(1f)) { 10f.toDp() }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenChildGainsFocus() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -85,6 +84,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusMovesBetweenChildren() = runSkikoComposeUiTest {
         val (focusRequester1, focusRequester2) = FocusRequester.createRefs()
@@ -131,6 +131,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusedBoundsMoves() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -176,6 +177,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedChildPositioned_notNotified_whenFocusableChildEntersComposition() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -208,6 +210,7 @@ class FocusableBoundsTest {
     }
 
     @Ignore // b/278258427
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusedBoundsLeavesComposition() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -243,6 +246,7 @@ class FocusableBoundsTest {
     }
 
     @Ignore // b/278258427
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusedBoundsIsDisabled() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -278,6 +282,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusCleared() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -313,6 +318,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenFocusMovesOutsideObserver() = runSkikoComposeUiTest {
         val (focusRequester1, focusRequester2) = FocusRequester.createRefs()
@@ -355,6 +361,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onFocusedBoundsPositioned_notified_whenMultipleObservers() = runSkikoComposeUiTest {
         val focusRequester = FocusRequester()
@@ -395,6 +402,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Ignore
     // TODO(shish) does not work with StrongSkippingMode enabled
     @Test
@@ -439,6 +447,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Ignore
     // TODO(shish) does not work with StrongSkippingMode enabled
     @Test
@@ -495,6 +504,7 @@ class FocusableBoundsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Ignore
     // TODO(shish) does not work with StrongSkippingMode enabled
     @Test

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/FocusableTest.kt
@@ -16,10 +16,18 @@
 
 package androidx.compose.foundation.copyPasteAndroidTests
 
-import androidx.compose.foundation.*
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.containsExactlyInOrder
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.hasSize
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isEmpty
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isNull
+import androidx.compose.foundation.isTrue
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
@@ -29,10 +37,19 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.relocation.BringIntoViewResponder
 import androidx.compose.foundation.relocation.bringIntoViewResponder
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.*
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReusableContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.*
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -44,7 +61,16 @@ import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.isFocusable
+import androidx.compose.ui.test.isNotFocusable
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlin.test.AfterTest
@@ -54,7 +80,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 class FocusableTest {
     private val focusTag = "myFocusable"
 
@@ -68,6 +94,7 @@ class FocusableTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_defaultSemantics() = runSkikoComposeUiTest {
         setContent {
@@ -84,6 +111,7 @@ class FocusableTest {
             .assert(isFocusable())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_disabledSemantics() = runSkikoComposeUiTest {
         setContent {
@@ -99,6 +127,7 @@ class FocusableTest {
             .assert(isNotFocusable())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_focusAcquire() = runSkikoComposeUiTest {
         val (focusRequester, otherFocusRequester) = FocusRequester.createRefs()
@@ -138,6 +167,7 @@ class FocusableTest {
             .assertIsNotFocused()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_interactionSource() = runSkikoComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -196,6 +226,7 @@ class FocusableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_interactionSource_resetWhenDisposed() = runSkikoComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -252,7 +283,7 @@ class FocusableTest {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_pins_whenItIsFocused() = runSkikoComposeUiTest {
         // Arrange.
@@ -286,7 +317,7 @@ class FocusableTest {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_unpins_whenItIsUnfocused() = runSkikoComposeUiTest {
         // Arrange.
@@ -330,6 +361,7 @@ class FocusableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_inspectorValue() = runSkikoComposeUiTest {
         val modifier = Modifier.focusable()
@@ -344,6 +376,7 @@ class FocusableTest {
             )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_requestsBringIntoView_whenFocused() = runSkikoComposeUiTest {
         val requestedRects = mutableListOf<Rect?>()
@@ -380,6 +413,7 @@ class FocusableTest {
 
     // This test also verifies that the internal API autoInvalidateRemovedNode()
     // is called when a modifier node is disposed.
+    @Suppress("DEPRECATION")
     @Test
     fun removingFocusableFromLazyList_clearsFocus() = runSkikoComposeUiTest {
         // Arrange.
@@ -418,6 +452,7 @@ class FocusableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removingFocusableFromSubcomposeLayout_clearsFocus() = runSkikoComposeUiTest {
         // Arrange.
@@ -456,7 +491,7 @@ class FocusableTest {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun focusable_updatePinnableContainer_staysPinned() = runSkikoComposeUiTest {
         // Arrange.
@@ -504,6 +539,7 @@ class FocusableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reusingFocusedItem_itemIsNotFocusedAnymore() = runSkikoComposeUiTest {
         // Arrange.
@@ -541,6 +577,7 @@ class FocusableTest {
         onNodeWithTag(focusTag).assertIsNotFocused()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun movableContent_movedContentBecomesUnfocused() = runSkikoComposeUiTest {
         var moveContent by mutableStateOf(false)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.assertModifierIsPure
 import androidx.compose.foundation.assertThat
@@ -105,8 +104,6 @@ import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.materialize
-import androidx.compose.ui.node.ModifierNodeElement
-import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
@@ -157,8 +154,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.test.IgnoreIosTarget
-import kotlinx.test.IgnoreJsTarget
-import kotlinx.test.IgnoreWasmTarget
 
 @OptIn(ExperimentalTestApi::class)
 class ScrollableTest {
@@ -187,6 +182,7 @@ class ScrollableTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll() = runComposeUiTest {
         var total = 0f
@@ -232,6 +228,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -266,6 +263,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll_2d_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -300,6 +298,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollableHorizontal_diagonalScroll_2d_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -357,6 +356,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isEqualTo(0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_horizontalScroll_mouseWheel_badMotionEvent() = runComposeUiTest {
@@ -383,6 +383,7 @@ class ScrollableTest {
      * at least one child within the scrollable must be focusable. (This matches the behavior in
      * Views.)
      */
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll_keyboardPageUpAndDown() = runComposeUiTest {
         var scrollAmount = 0f
@@ -445,6 +446,7 @@ class ScrollableTest {
         runOnIdle { assertThat(scrollAmount).isGreaterThan(0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll_reverse() = runComposeUiTest {
         var total = 0f
@@ -494,6 +496,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_horizontalScroll_reverse_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -531,6 +534,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_verticalScroll() = runComposeUiTest {
         var total = 0f
@@ -576,6 +580,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_verticalScroll_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -609,6 +614,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_verticalScroll_mouseWheel_badMotionEvent() = runComposeUiTest {
@@ -637,6 +643,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollableVertical_diagonalScroll_2d_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -703,6 +710,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isZero() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedDiagonalScroll_mouseWheel_triggersOnAngle() = runComposeUiTest {
         var totalVerticalScroll = 0f
@@ -801,6 +809,7 @@ class ScrollableTest {
      * at least one child within the scrollable must be focusable. (This matches the behavior in
      * Views.)
      */
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_verticalScroll_keyboardPageUpAndDown() = runComposeUiTest {
         var scrollAmount = 0f
@@ -862,6 +871,7 @@ class ScrollableTest {
         runOnIdle { assertThat(scrollAmount).isGreaterThan(0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_verticalScroll_reversed() = runComposeUiTest {
         var total = 0f
@@ -911,6 +921,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_verticalScroll_reversed_mouseWheel() = runComposeUiTest {
         var total = 0f
@@ -949,6 +960,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isLessThan(0.01f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_disabledWontCallLambda() = runComposeUiTest {
         val enabled = mutableStateOf(true)
@@ -990,6 +1002,7 @@ class ScrollableTest {
         runOnIdle { assertThat(total).isEqualTo(prevTotal) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_startWithoutSlop_ifFlinging() = runComposeUiTest {
@@ -1030,6 +1043,7 @@ class ScrollableTest {
         assertThat(total).isEqualTo(expected)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_blocksDownEvents_ifFlingingCaught() = runComposeUiTest {
@@ -1082,6 +1096,7 @@ class ScrollableTest {
         // shouldn't assert in clickable lambda
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_snappingScrolling() = runComposeUiTest {
         var total = 0f
@@ -1107,6 +1122,7 @@ class ScrollableTest {
         assertEquals(total, 800f, 0.001f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_explicitDisposal() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -1159,6 +1175,7 @@ class ScrollableTest {
         assertThat(total).isEqualTo(prevTotal)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedDrag() = runComposeUiTest {
         var innerDrag = 0f
@@ -1221,6 +1238,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_childPartialConsumptionForMouseWheel() = runComposeUiTest {
         var innerDrag = 0f
@@ -1280,6 +1298,7 @@ class ScrollableTest {
      * at least one child within the scrollable must be focusable. (This matches the behavior in
      * Views.)
      */
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_childPartialConsumptionForKeyboardPageUpAndDown() = runComposeUiTest {
         var innerDrag = 0f
@@ -1354,6 +1373,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_childPartialConsumptionForSemantics_horizontal() = runComposeUiTest {
         var innerDrag = 0f
@@ -1407,6 +1427,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_childPartialConsumptionForSemantics_vertical() = runComposeUiTest {
         var innerDrag = 0f
@@ -1456,6 +1477,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun focusScroll_nestedScroll_childPartialConsumptionForSemantics() = runComposeUiTest {
@@ -1491,6 +1513,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFling() = runComposeUiTest {
         var innerDrag = 0f
@@ -1550,6 +1573,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScrollAbove_respectsPreConsumption() = runComposeUiTest {
         var value = 0f
@@ -1612,6 +1636,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_nestedScrollAbove_proxiesPostCycles() = runComposeUiTest {
@@ -1682,6 +1707,7 @@ class ScrollableTest {
         waitForIdle()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-2965
     fun scrollable_nestedScrollAbove_reversed_proxiesPostCycles() = runComposeUiTest {
@@ -1753,6 +1779,7 @@ class ScrollableTest {
         waitForIdle()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScrollBelow_listensDispatches() = runComposeUiTest {
         var value = 0f
@@ -1818,6 +1845,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_allowParentWhenDisabled() = runComposeUiTest {
         var childValue = 0f
@@ -1875,6 +1903,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedScroll_disabledConnectionNoOp() = runComposeUiTest {
         var childValue = 0f
@@ -1952,6 +1981,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFlingCancellation_shouldPreventDeltasFromPropagating() = runComposeUiTest {
         var childDeltas = 0f
@@ -2007,7 +2037,7 @@ class ScrollableTest {
         assertThat(childDeltas).isEqualTo(dragged - touchSlop)
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFling_shouldCancelWhenHitTheBounds_ifRemoved() = runComposeUiTest {
 
@@ -2051,7 +2081,7 @@ class ScrollableTest {
         runOnIdle { assertThat(latestScroll).isEqualTo(Offset.Zero) }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFling_shouldContinueSendingDeltasWhenHitBounds() = runComposeUiTest {
 
@@ -2088,6 +2118,7 @@ class ScrollableTest {
         assertThat(flingDeltas.y).isNonZero()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFling_parentShouldFlingWithVelocityLeft() = runComposeUiTest {
         var postFlingCalled = false
@@ -2155,6 +2186,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_nestedFling_parentShouldFlingWithVelocityLeft_whenInnerDisappears() = runComposeUiTest {
         var postFlingCalled = false
@@ -2215,6 +2247,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_bothOrientations_proxiesPostFling() = runComposeUiTest {
         val velocityFlung = 5000f
@@ -2274,6 +2307,7 @@ class ScrollableTest {
         waitForIdle()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_interactionSource() = runComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -2320,6 +2354,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_interactionSource_resetWhenDisposed() = runComposeUiTest {
         val interactionSource = MutableInteractionSource()
@@ -2377,6 +2412,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_flingBehaviourCalled_whenVelocity0() = runComposeUiTest {
         var total = 0f
@@ -2415,6 +2451,7 @@ class ScrollableTest {
         assertThat(flingVelocity).isGreaterThan(-0.01f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_flingBehaviourCalled() = runComposeUiTest {
         var total = 0f
@@ -2449,6 +2486,7 @@ class ScrollableTest {
         assertEquals(1000f, flingVelocity, 5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_flingBehaviourCalled_reversed() = runComposeUiTest {
         var total = 0f
@@ -2484,6 +2522,7 @@ class ScrollableTest {
         assertEquals(flingVelocity, -1000f, 5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_flingBehaviourCalled_correctScope() = runComposeUiTest {
         var total = 0f
@@ -2528,6 +2567,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_flingBehaviourCalled_reversed_correctScope() = runComposeUiTest {
         var total = 0f
@@ -2573,6 +2613,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_scrollByWorksWithRepeatableAnimations() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -2651,6 +2692,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_cancellingAnimateScrollUpdatesIsScrollInProgress() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -2686,6 +2728,7 @@ class ScrollableTest {
         runOnIdle { assertThat(controller.isScrollInProgress).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_preemptingAnimateScrollUpdatesIsScrollInProgress() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -2728,6 +2771,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_multiDirectionsShouldPropagateOrthogonalAxisToNextParentWithSameDirection() = runComposeUiTest {
         var innerDelta = 0f
@@ -2785,6 +2829,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun nestedScrollable_noFlingContinuationInCrossAxis_shouldAllowClicksOnCrossAxis_scrollable() = runComposeUiTest {
         var clicked = 0
@@ -2819,6 +2864,7 @@ class ScrollableTest {
 
     // b/179417109 Double checks that in a nested scroll cycle, the parent post scroll
     // consumption is taken into consideration.
+    @Suppress("DEPRECATION")
     @Test
     fun dispatchScroll_shouldReturnConsumedDeltaInNestedScrollChain() = runComposeUiTest {
         var consumedInner = 0f
@@ -2896,6 +2942,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testInspectorValue() = runComposeUiTest {
         val controller = ScrollableState(consumeScrollDelta = { it })
@@ -2918,6 +2965,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun producingEqualMaterializedModifierAfterRecomposition() = runComposeUiTest {
         val state = ScrollableState { it }
@@ -2943,6 +2991,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun focusStaysInScrollableEvenThoughThereIsACloserItemOutside() = runComposeUiTest {
         lateinit var focusManager: FocusManager
@@ -2970,6 +3019,7 @@ class ScrollableTest {
         runOnIdle { assertThat(nextItemIsFocused).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun verticalScrollable_assertVelocityCalculationIsSimilarInsideOutsideVelocityTracker() = runComposeUiTest {
         // arrange
@@ -3011,6 +3061,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontalScrollable_assertVelocityCalculationIsSimilarInsideOutsideVelocityTracker() = runComposeUiTest {
         // arrange
@@ -3052,6 +3103,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun disableSystemAnimations_defaultFlingBehaviorShouldContinueToWork() = runComposeUiTest {
 
@@ -3088,6 +3140,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun defaultFlingBehavior_useScrollMotionDurationScale() = runComposeUiTest {
 
@@ -3144,6 +3197,7 @@ class ScrollableTest {
         runOnIdle { assertThat(defaultFlingBehavior?.lastAnimationCycleCount).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollable_noMomentum_shouldChangeScrollStateAfterRelease() = runComposeUiTest {
         val scrollState = ScrollState(0)
@@ -3171,6 +3225,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun defaultScrollableState_scrollByWithNan_shouldFilterOutNan() = runComposeUiTest {
         val controller = ScrollableState {
@@ -3196,6 +3251,7 @@ class ScrollableTest {
         onNodeWithTag(scrollableBoxTag).performTouchInput { swipeLeft() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun equalInputs_shouldResolveToEquals() = runComposeUiTest {
         val state = ScrollableState { 0f }
@@ -3209,6 +3265,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollableState_checkLastScrollDirection() = runComposeUiTest {
         val controller = ScrollableState { it }
@@ -3271,6 +3328,7 @@ class ScrollableTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun enabledChange_semanticsShouldBeCleared() = runComposeUiTest {
         var enabled by mutableStateOf(true)
@@ -3307,6 +3365,7 @@ class ScrollableTest {
             .assert(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollByOffset))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @IgnoreIosTarget // Fling behavior on iOS does not use screen density
     fun onDensityChange_shouldUpdateFlingBehavior() = runComposeUiTest {
@@ -3343,6 +3402,7 @@ class ScrollableTest {
         runOnIdle { assertThat(flingDelta).isNotEqualTo(previousDelta) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onNestedFlingCancelled_shouldResetFlingState() = runComposeUiTest {
         mainClock.autoAdvance = false

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyArrangementsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyArrangementsTest.kt
@@ -84,6 +84,7 @@ class LazyArrangementsTest {
 
     // cases when we have not enough items to fill min constraints:
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_defaultArrangementIsTop() = runSkikoComposeUiTest {
         setContent {
@@ -100,18 +101,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Top)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_centerArrangement() = runSkikoComposeUiTest {
         composeVerticalGridWith(Arrangement.Center)
         assertArrangementForTwoItems(Arrangement.Center)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_bottomArrangement() = runSkikoComposeUiTest {
         composeVerticalGridWith(Arrangement.Bottom)
         assertArrangementForTwoItems(Arrangement.Bottom)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -119,6 +123,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(arrangement)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_defaultArrangementIsStart() = runSkikoComposeUiTest {
         setContent {
@@ -135,18 +140,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Start, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_centerArrangement() = runSkikoComposeUiTest {
         composeHorizontalWith(Arrangement.Center, LayoutDirection.Ltr)
         assertArrangementForTwoItems(Arrangement.Center, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_endArrangement() = runSkikoComposeUiTest {
         composeHorizontalWith(Arrangement.End, LayoutDirection.Ltr)
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -154,18 +162,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(arrangement, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_rtl_startArrangement() = runSkikoComposeUiTest {
         composeHorizontalWith(Arrangement.Center, LayoutDirection.Rtl)
         assertArrangementForTwoItems(Arrangement.Center, LayoutDirection.Rtl)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_rtl_endArrangement() = runSkikoComposeUiTest {
         composeHorizontalWith(Arrangement.End, LayoutDirection.Rtl)
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Rtl)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_rtl_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -175,6 +186,7 @@ class LazyArrangementsTest {
 
     // wrap content and spacing
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_spacing_affects_wrap_content() = runSkikoComposeUiTest {
         setContent {
@@ -194,6 +206,7 @@ class LazyArrangementsTest {
             .assertHeightIsEqualTo(itemSize * 3)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_spacing_affects_wrap_content() = runSkikoComposeUiTest {
         setContent {
@@ -215,6 +228,7 @@ class LazyArrangementsTest {
 
     // spacing added when we have enough items to fill the viewport
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_spacing_scrolledToTheTop() = runSkikoComposeUiTest {
         setContent {
@@ -236,6 +250,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(itemSize * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_spacing_scrolledToTheBottom() = runSkikoComposeUiTest {
         setContent {
@@ -262,6 +277,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(itemSize * 2.5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_spacing_scrolledToTheStart() = runSkikoComposeUiTest {
         setContent {
@@ -283,6 +299,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(itemSize * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_spacing_scrolledToTheEnd() = runSkikoComposeUiTest {
         setContent {
@@ -309,6 +326,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(itemSize * 2.5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_scrollingByExactlyTheItemSizePlusSpacer_switchesTheFirstVisibleItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -348,6 +366,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_scrollingByExactlyTheItemSizePlusHalfTheSpacer_staysOnTheSameItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -388,6 +407,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_scrollingByExactlyTheItemSizePlusSpacer_switchesTheFirstVisibleItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -427,6 +447,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_scrollingByExactlyTheItemSizePlusHalfTheSpacer_staysOnTheSameItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -469,6 +490,7 @@ class LazyArrangementsTest {
 
     // with reverseLayout == true
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_defaultArrangementIsBottomWithReverseLayout() = runSkikoComposeUiTest {
         setContent {
@@ -486,6 +508,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Bottom, reverseLayout = true)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_defaultArrangementIsEndWithReverseLayout() = runSkikoComposeUiTest {
         setContent {
@@ -505,6 +528,7 @@ class LazyArrangementsTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_whenArrangementChanges() = runSkikoComposeUiTest {
         var arrangement by mutableStateOf(Arrangement.Top)
@@ -529,6 +553,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Bottom)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_whenArrangementChanges() = runSkikoComposeUiTest {
         var arrangement by mutableStateOf(Arrangement.Start)
@@ -553,6 +578,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_negativeSpacing_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyGridState()
@@ -595,6 +621,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_negativeSpacing_negative_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyGridState()
@@ -637,6 +664,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun vertical_negativeSpacingLargerThanItem_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyGridState(firstVisibleItemIndex = 2)
@@ -665,6 +693,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun horizontal_negativeSpacingLargerThanItem_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyGridState(firstVisibleItemIndex = 2)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridSlotsReuseTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridSlotsReuseTest.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.runSkikoComposeUiTest
@@ -45,11 +44,9 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.test.IgnoreJsTarget
 
 @OptIn(ExperimentalTestApi::class)
 class LazyGridSlotsReuseTest {
@@ -58,6 +55,7 @@ class LazyGridSlotsReuseTest {
     private val itemsSizePx = 30f
     private val itemsSizeDp = with(density) { itemsSizePx.toDp() }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll1ItemScrolledOffItemIsKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -79,6 +77,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("1").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll2ItemsScrolledOffItemsAreKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -103,6 +102,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("2").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun checkMaxItemsKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -132,6 +132,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("${DefaultMaxItemsToRetain + 1}").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll3Items2OfScrolledOffItemsAreKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -172,6 +173,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("4").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun doMultipleScrollsOneByOne() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -213,6 +215,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("5").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollBackwardOnce() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -243,6 +246,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("9").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollBackwardOneByOne() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -276,6 +280,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("7").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollingBackReusesTheSameSlot() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -346,6 +351,7 @@ class LazyGridSlotsReuseTest {
         onRoot().fetchSemanticsNode().assertLayoutDeactivatedById(id3)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun differentContentTypes() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -388,6 +394,7 @@ class LazyGridSlotsReuseTest {
         onNodeWithTag("${startOfType1 + DefaultMaxItemsToRetain}").assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun differentTypesFromDifferentItemCalls() = runSkikoComposeUiTest {
         lateinit var state: LazyGridState
@@ -447,4 +454,4 @@ class LazyGridSlotsReuseTest {
     }
 }
 
-private val DefaultMaxItemsToRetain = 7
+private const val DefaultMaxItemsToRetain = 7

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridSpanTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridSpanTest.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalTestApi::class)
 class LazyGridSpanTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun spans() = runSkikoComposeUiTest {
         val columns = 4
@@ -119,6 +120,7 @@ class LazyGridSpanTest {
             .assertLeftPositionInRootIsEqualTo(columnWidth)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun spansWithHorizontalSpacing() = runSkikoComposeUiTest {
         val columns = 4
@@ -159,6 +161,7 @@ class LazyGridSpanTest {
             .assertWidthIsEqualTo(columnWidth * 3 + spacing * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun spansMultipleBlocks() = runSkikoComposeUiTest {
         val columns = 4
@@ -215,6 +218,7 @@ class LazyGridSpanTest {
             .assertWidthIsEqualTo(columnWidth)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun spansLineBreak() = runSkikoComposeUiTest {
         val columns = 4
@@ -272,6 +276,7 @@ class LazyGridSpanTest {
             .assertWidthIsEqualTo(columnWidth * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun spansCalculationDoesntCrash() = runSkikoComposeUiTest {
         // regression from b/222530458

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridsIndexedTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridsIndexedTest.kt
@@ -37,6 +37,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class LazyGridsIndexedTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyVerticalGridShowsIndexedItems() = runSkikoComposeUiTest {
         val items = (1..4).map { it.toString() }
@@ -64,6 +65,7 @@ class LazyGridsIndexedTest {
             .assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun verticalGridWithIndexesComposedWithCorrectIndexAndItem() = runSkikoComposeUiTest {
         val items = (0..1).map { it.toString() }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridsReverseLayoutTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyGridsReverseLayoutTest.kt
@@ -52,6 +52,7 @@ class LazyGridsReverseLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun verticalGrid_reverseLayout() = runSkikoComposeUiTest {
         setContent {
@@ -80,6 +81,7 @@ class LazyGridsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_emitTwoElementsAsOneItem() = runSkikoComposeUiTest {
         setContent {
@@ -121,6 +123,7 @@ class LazyGridsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun verticalGrid_whenParameterChanges() = runSkikoComposeUiTest {
         var reverse by mutableStateOf(true)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazySemanticsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazySemanticsTest.kt
@@ -63,6 +63,7 @@ class LazySemanticsTest {
     private fun tag(index: Int): String = "tag_$index"
     private fun key(index: Int): String = "key_$index"
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemSemantics_verticalGrid() = runSkikoComposeUiTest {
         setContent {
@@ -77,6 +78,7 @@ class LazySemanticsTest {
         runTest()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemsSemantics_verticalGrid() = runSkikoComposeUiTest {
         setContent {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/layout/LazyLayoutTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/layout/LazyLayoutTest.kt
@@ -66,6 +66,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
 class LazyLayoutTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun recompositionWithTheSameInputDoesntCauseRemeasure() = runSkikoComposeUiTest {
         val counter = mutableStateOf(0)
@@ -101,6 +102,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(remeasureCount).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun measureAndPlaceTwoItems() = runSkikoComposeUiTest {
         val itemProvider =
@@ -124,6 +126,7 @@ class LazyLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun measureAndPlaceMultipleLayoutsInOneItem() = runSkikoComposeUiTest {
         val itemProvider =
@@ -150,6 +153,7 @@ class LazyLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatingitemProvider() = runSkikoComposeUiTest {
         var itemProvider by
@@ -180,6 +184,7 @@ class LazyLayoutTest {
         onNodeWithTag("1").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun stateBaseditemProvider() = runSkikoComposeUiTest {
         var itemCount by mutableStateOf(1)
@@ -213,6 +218,7 @@ class LazyLayoutTest {
         assertThat(getDefaultLazyLayoutKey(0)).isNotEqualTo(0)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun prefetchItem() = runSkikoComposeUiTest {
         val constraints = Constraints.fixed(50, 50)
@@ -262,6 +268,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(measureCount).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun prefetchItem_reportMeasuredSizeAfterPremeasure() = runSkikoComposeUiTest {
         val constraints = Constraints.fixed(50, 50)
@@ -306,6 +313,7 @@ class LazyLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun prefetchItemWithContentType() = runSkikoComposeUiTest {
         val constraints = Constraints.fixed(50, 50)
@@ -355,6 +363,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(measureCount).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cancelPrefetchedItem() = runSkikoComposeUiTest {
         var composed = false
@@ -383,6 +392,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(composed).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun prefetchItemWithCustomExecutor() = runSkikoComposeUiTest {
         val itemProvider =
@@ -467,6 +477,7 @@ class LazyLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keptForReuseItemIsDisposedWhenCanceled() = runSkikoComposeUiTest {
         val needChild = mutableStateOf(true)
@@ -496,6 +507,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(composed).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun nodeIsReusedWithoutExtraRemeasure() = runSkikoComposeUiTest {
         var indexToCompose by mutableStateOf<Int?>(0)
@@ -536,6 +548,7 @@ class LazyLayoutTest {
     }
 
     @Ignore // TODO(b/369188686)
+    @Suppress("DEPRECATION")
     @Test
     fun nodeIsReusedWhenRemovedFirst() = runSkikoComposeUiTest {
         var itemCount by mutableStateOf(1)
@@ -575,6 +588,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(remeasuresCount).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun skippingItemBlockWhenKeyIsObservableButDidntChange() = runSkikoComposeUiTest {
         val stateList = mutableStateListOf(0)
@@ -609,6 +623,7 @@ class LazyLayoutTest {
         runOnIdle { assertThat(itemCalls).isEqualTo(1) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun subcomposeNodeContentIsResetWhenReused() = runSkikoComposeUiTest {
         var indexToCompose by mutableStateOf(0)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyArrangementsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyArrangementsTest.kt
@@ -81,6 +81,7 @@ class LazyArrangementsTest {
 
     // cases when we have not enough items to fill min constraints:
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_defaultArrangementIsTop() = runSkikoComposeUiTest {
         setContent {
@@ -96,18 +97,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Top)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_centerArrangement() = runSkikoComposeUiTest {
         composeColumnWith(Arrangement.Center)
         assertArrangementForTwoItems(Arrangement.Center)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_bottomArrangement() = runSkikoComposeUiTest {
         composeColumnWith(Arrangement.Bottom)
         assertArrangementForTwoItems(Arrangement.Bottom)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -115,6 +119,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(arrangement)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_defaultArrangementIsStart() = runSkikoComposeUiTest {
         setContent {
@@ -130,18 +135,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Start, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_centerArrangement() = runSkikoComposeUiTest {
         composeRowWith(Arrangement.Center, LayoutDirection.Ltr)
         assertArrangementForTwoItems(Arrangement.Center, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_endArrangement() = runSkikoComposeUiTest {
         composeRowWith(Arrangement.End, LayoutDirection.Ltr)
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -149,18 +157,21 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(arrangement, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_rtl_startArrangement() = runSkikoComposeUiTest {
         composeRowWith(Arrangement.Center, LayoutDirection.Rtl)
         assertArrangementForTwoItems(Arrangement.Center, LayoutDirection.Rtl)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_rtl_endArrangement() = runSkikoComposeUiTest {
         composeRowWith(Arrangement.End, LayoutDirection.Rtl)
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Rtl)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_rtl_spacedArrangementNotFillingViewport() = runSkikoComposeUiTest {
         val arrangement = Arrangement.spacedBy(10.dp)
@@ -170,6 +181,7 @@ class LazyArrangementsTest {
 
     // wrap content and spacing
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_spacing_affects_wrap_content() = runSkikoComposeUiTest {
         setContent {
@@ -188,6 +200,7 @@ class LazyArrangementsTest {
             .assertHeightIsEqualTo(itemSize * 3)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_spacing_affects_wrap_content() = runSkikoComposeUiTest {
         setContent {
@@ -208,6 +221,7 @@ class LazyArrangementsTest {
 
     // spacing added when we have enough items to fill the viewport
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_spacing_scrolledToTheTop() = runSkikoComposeUiTest {
         setContent {
@@ -228,6 +242,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(itemSize * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_spacing_scrolledToTheBottom() = runSkikoComposeUiTest {
         setContent {
@@ -253,6 +268,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(itemSize * 2.5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_spacing_scrolledToTheStart() = runSkikoComposeUiTest {
         setContent {
@@ -273,6 +289,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(itemSize * 2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_spacing_scrolledToTheEnd() = runSkikoComposeUiTest {
         setContent {
@@ -298,6 +315,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(itemSize * 2.5f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_scrollingByExactlyTheItemSizePlusSpacer_switchesTheFirstVisibleItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -336,6 +354,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_scrollingByExactlyTheItemSizePlusHalfTheSpacer_staysOnTheSameItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -375,6 +394,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_scrollingByExactlyTheItemSizePlusSpacer_switchesTheFirstVisibleItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -413,6 +433,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_scrollingByExactlyTheItemSizePlusHalfTheSpacer_staysOnTheSameItem() = runSkikoComposeUiTest {
         val itemSizePx = 30
@@ -452,6 +473,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_defaultArrangementIsBottomWithReverseLayout() = runSkikoComposeUiTest {
         setContent {
@@ -468,6 +490,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Bottom, reverseLayout = true)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_defaultArrangementIsEndWithReverseLayout() = runSkikoComposeUiTest {
         setContent {
@@ -486,6 +509,7 @@ class LazyArrangementsTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_whenArrangementChanges() = runSkikoComposeUiTest {
         var arrangement by mutableStateOf(Arrangement.Top)
@@ -509,6 +533,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.Bottom)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_whenArrangementChanges() = runSkikoComposeUiTest {
         var arrangement by mutableStateOf(Arrangement.Start)
@@ -532,6 +557,7 @@ class LazyArrangementsTest {
         assertArrangementForTwoItems(Arrangement.End, LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_negativeSpacing_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyListState()
@@ -575,6 +601,7 @@ class LazyArrangementsTest {
             .assertTopPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_negativeSpacing_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyListState()
@@ -618,6 +645,7 @@ class LazyArrangementsTest {
             .assertLeftPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_negativeSpacingLargerThanItem_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyListState(firstVisibleItemIndex = 2)
@@ -645,6 +673,7 @@ class LazyArrangementsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_negativeSpacingLargerThanItem_itemsVisible() = runSkikoComposeUiTest {
         val state = LazyListState(firstVisibleItemIndex = 2)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyColumnTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyColumnTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.isEqualTo
 import androidx.compose.foundation.isFalse
 import androidx.compose.foundation.isLessThan
-import androidx.compose.foundation.isNotEqualTo
 import androidx.compose.foundation.isTrue
 import androidx.compose.foundation.isWithin1PixelFrom
 import androidx.compose.foundation.layout.Box
@@ -89,6 +88,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun compositionsAreDisposed_whenDataIsChanged() = runSkikoComposeUiTest {
         var composed = 0
@@ -133,6 +133,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun compositionsAreDisposed_whenLazyListIsDisposed() = runSkikoComposeUiTest {
         var emitLazyList by mutableStateOf(true)
@@ -174,6 +175,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removeItemsTest() = runSkikoComposeUiTest {
         var itemCount by mutableStateOf(3)
@@ -201,6 +203,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun changeItemsCountAndScrollImmediately() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -233,6 +236,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun changingDataTest() = runSkikoComposeUiTest {
         val dataLists = listOf(
@@ -299,6 +303,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnAlignmentCenterHorizontally() = runSkikoComposeUiTest {
         prepareLazyColumnsItemsAlignment(Alignment.CenterHorizontally)
@@ -310,6 +315,7 @@ class LazyColumnTest {
             .assertPositionInRootIsEqualTo(15.dp, 50.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnAlignmentStart() = runSkikoComposeUiTest {
         prepareLazyColumnsItemsAlignment(Alignment.Start)
@@ -321,6 +327,7 @@ class LazyColumnTest {
             .assertPositionInRootIsEqualTo(0.dp, 50.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnAlignmentEnd() = runSkikoComposeUiTest {
         prepareLazyColumnsItemsAlignment(Alignment.End)
@@ -332,6 +339,7 @@ class LazyColumnTest {
             .assertPositionInRootIsEqualTo(30.dp, 50.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun flingAnimationStopsOnFingerDown() = runSkikoComposeUiTest {
         val items by mutableStateOf((1..20).toList())
@@ -375,6 +383,7 @@ class LazyColumnTest {
         assertThat(state.firstVisibleItemScrollOffset).isEqualTo(itemOffsetWhenInterrupting)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removalWithMutableStateListOf() = runSkikoComposeUiTest {
         val items = mutableStateListOf("1", "2", "3")
@@ -403,6 +412,7 @@ class LazyColumnTest {
             .assertIsNotPlaced()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun recompositionOrder() = runSkikoComposeUiTest {
         val outerState = mutableStateOf(0)
@@ -431,6 +441,7 @@ class LazyColumnTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrolledAwayItemIsNotDisplayedAnymore() = runSkikoComposeUiTest(Size(10f, 10f)) {
         lateinit var state: LazyListState
@@ -477,6 +488,7 @@ class LazyColumnTest {
             }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun wrappedNestedLazyRowDisplayCorrectContent() = runSkikoComposeUiTest {
         lateinit var state: LazyListState

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyCustomKeysTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyCustomKeysTest.kt
@@ -55,6 +55,7 @@ class LazyCustomKeysTest {
         100.toDp()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemsWithKeysAreLaidOutCorrectly() = runSkikoComposeUiTest {
         val list = listOf(MyClass(0), MyClass(1), MyClass(2))
@@ -70,6 +71,7 @@ class LazyCustomKeysTest {
         assertItems("0", "1", "2")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removing_statesAreMoved() = runSkikoComposeUiTest {
         var list by mutableStateOf(listOf(MyClass(0), MyClass(1), MyClass(2)))
@@ -89,6 +91,7 @@ class LazyCustomKeysTest {
         assertItems("0", "2")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_statesAreMoved_list() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -98,6 +101,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_statesAreMoved_list_indexed() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -107,6 +111,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_statesAreMoved_array() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -117,6 +122,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_statesAreMoved_array_indexed() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -127,6 +133,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_statesAreMoved_itemsWithCount() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -136,6 +143,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun fullyReplacingTheList() = runSkikoComposeUiTest {
         var list by mutableStateOf(listOf(MyClass(0), MyClass(1), MyClass(2)))
@@ -156,6 +164,7 @@ class LazyCustomKeysTest {
         assertItems("3", "4", "5", "6")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keepingOneItem() = runSkikoComposeUiTest {
         var list by mutableStateOf(listOf(MyClass(0), MyClass(1), MyClass(2)))
@@ -176,6 +185,7 @@ class LazyCustomKeysTest {
         assertItems("1")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keepingOneItemAndAddingMore() = runSkikoComposeUiTest {
         var list by mutableStateOf(listOf(MyClass(0), MyClass(1), MyClass(2)))
@@ -196,6 +206,7 @@ class LazyCustomKeysTest {
         assertItems("1", "3")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mixingKeyedItemsAndNot() = runSkikoComposeUiTest {
         testReordering { list ->
@@ -208,6 +219,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatingTheDataSetIsCorrectlyApplied() = runSkikoComposeUiTest {
         val state = mutableStateOf(emptyList<Int>())
@@ -235,6 +247,7 @@ class LazyCustomKeysTest {
         assertItems("2", "4", "6", "1", "3", "5")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reordering_usingMutableStateListOf() = runSkikoComposeUiTest {
         val list = mutableStateListOf(MyClass(0), MyClass(1), MyClass(2))
@@ -254,6 +267,7 @@ class LazyCustomKeysTest {
         assertItems("0", "2", "1")
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keysInLazyListItemInfoAreCorrect() = runSkikoComposeUiTest {
         val list = listOf(MyClass(0), MyClass(1), MyClass(2))
@@ -275,6 +289,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keysInLazyListItemInfoAreCorrectAfterReordering() = runSkikoComposeUiTest {
         var list by mutableStateOf(listOf(MyClass(0), MyClass(1), MyClass(2)))
@@ -300,6 +315,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun addingItemsBeforeWithoutKeysIsMaintainingTheIndex() = runSkikoComposeUiTest {
         var list by mutableStateOf((10..15).toList())
@@ -323,6 +339,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun addingItemsBeforeKeepingThisItemFirst() = runSkikoComposeUiTest {
         var list by mutableStateOf((10..15).toList())
@@ -349,6 +366,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun addingItemsRightAfterKeepingThisItemFirst() = runSkikoComposeUiTest {
         var list by mutableStateOf((0..5).toList() + (10..15).toList())
@@ -375,6 +393,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun addingItemsBeforeWhileCurrentItemIsNotInTheBeginning() = runSkikoComposeUiTest {
         var list by mutableStateOf((10..30).toList())
@@ -401,6 +420,7 @@ class LazyCustomKeysTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removingTheCurrentItemMaintainsTheIndex() = runSkikoComposeUiTest {
         var list by mutableStateOf((0..20).toList())

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListAnimateItemPlacementTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListAnimateItemPlacementTest.kt
@@ -19,7 +19,6 @@ package androidx.compose.foundation.copyPasteAndroidTests.lazy.list
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.assertThat
 import androidx.compose.foundation.assertWithMessage
 import androidx.compose.foundation.gestures.scrollBy
@@ -77,7 +76,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 @Ignore // TODO: the tests fail on desktop
 class LazyListAnimateItemPlacementTest {
 
@@ -102,6 +101,7 @@ class LazyListAnimateItemPlacementTest {
     
     private val density = Density(1f)
 
+    @Suppress("DEPRECATION")
     private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) = runSkikoComposeUiTest {
         params().forEach {
             config = it

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.BeyondBoundsLayout
@@ -63,7 +62,7 @@ import androidx.compose.ui.unit.LayoutDirection.Rtl
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 class LazyListBeyondBoundsTest {
 
     // We need to wrap the inline class parameter in another class because Java can't instantiate
@@ -98,6 +97,7 @@ class LazyListBeyondBoundsTest {
     private lateinit var lazyListState: LazyListState
     private lateinit var scope: CoroutineScope
 
+    @Suppress("DEPRECATION")
     private fun runParametrizedTest(test: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
         ParamsToTest.forEach {
             param = it

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListFocusMoveTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListFocusMoveTest.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusDirection.Companion.Down
@@ -63,7 +62,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 @Ignore // TODO: the tests fail or get stuck time from time - flaky
 // Fails with:
 // Compose Runtime internal error.
@@ -99,6 +98,7 @@ class LazyListFocusMoveTest {
     private lateinit var lazyListState: LazyListState
     private lateinit var focusManager: FocusManager
 
+    @Suppress("DEPRECATION")
     private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) = runSkikoComposeUiTest {
         initParameters().forEach {
             param = it

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListHeadersTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListHeadersTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.foundation.copyPasteAndroidTests.lazy.list
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -47,11 +46,12 @@ import kotlinx.coroutines.launch
 import kotlinx.test.IgnoreJsTarget
 import kotlinx.test.IgnoreWasmTarget
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 class LazyListHeadersTest {
 
     private val LazyListTag = "LazyList"
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnShowsHeader() = runSkikoComposeUiTest {
         val items = (1..2).map { it.toString() }
@@ -93,6 +93,7 @@ class LazyListHeadersTest {
             .assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnShowsHeadersOnScroll() = runSkikoComposeUiTest {
         val items = (1..2).map { it.toString() }
@@ -145,6 +146,7 @@ class LazyListHeadersTest {
             .assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @IgnoreJsTarget
     @IgnoreWasmTarget
@@ -193,6 +195,7 @@ class LazyListHeadersTest {
             .assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowShowsHeader() = runSkikoComposeUiTest {
         val items = (1..2).map { it.toString() }
@@ -234,6 +237,7 @@ class LazyListHeadersTest {
             .assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowShowsHeadersOnScroll() = runSkikoComposeUiTest {
         val items = (1..2).map { it.toString() }
@@ -286,6 +290,7 @@ class LazyListHeadersTest {
             .assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowHeaderIsReplaced() = runSkikoComposeUiTest {
         val items = (1..2).map { it.toString() }
@@ -332,6 +337,7 @@ class LazyListHeadersTest {
             .assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun headerIsDisplayedWhenItIsFullyInContentPadding() = runSkikoComposeUiTest {
         val headerTag = "header"

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListSlotsReuseTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListSlotsReuseTest.kt
@@ -54,6 +54,7 @@ class LazyListSlotsReuseTest {
     private val itemsSizePx = 30f
     private val itemsSizeDp = with(density) { itemsSizePx.toDp() }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll1ItemScrolledOffItemIsKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -77,6 +78,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("1").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll2ItemsScrolledOffItemsAreKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -103,6 +105,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("2").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun checkMaxItemsKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -131,6 +134,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("${DefaultMaxItemsToRetain + 1}").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scroll3Items2OfScrolledOffItemsAreKeptForReuse() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -173,6 +177,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("4").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun doMultipleScrollsOneByOne() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -216,6 +221,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("5").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollBackwardOnce() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -248,6 +254,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("9").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollBackwardOneByOne() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -283,6 +290,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("7").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun scrollingBackReusesTheSameSlot() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -358,6 +366,7 @@ class LazyListSlotsReuseTest {
         onRoot().fetchSemanticsNode().assertLayoutDeactivatedById(id3)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun differentContentTypes() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -396,6 +405,7 @@ class LazyListSlotsReuseTest {
         onNodeWithTag("${startOfType1 + DefaultMaxItemsToRetain}").assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun differentTypesFromDifferentItemCalls() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -455,4 +465,4 @@ class LazyListSlotsReuseTest {
     }
 }
 
-private val DefaultMaxItemsToRetain = 7
+private const val DefaultMaxItemsToRetain = 7

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListsIndexedTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListsIndexedTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class LazyListsIndexedTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyColumnShowsIndexedItems() = runSkikoComposeUiTest {
         val items = (1..4).map { it.toString() }
@@ -68,6 +69,7 @@ class LazyListsIndexedTest {
             .assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun columnWithIndexesComposedWithCorrectIndexAndItem() = runSkikoComposeUiTest {
         val items = (0..1).map { it.toString() }
@@ -89,6 +91,7 @@ class LazyListsIndexedTest {
             .assertTopPositionInRootIsEqualTo(100.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowShowsIndexedItems() = runSkikoComposeUiTest {
         val items = (1..4).map { it.toString() }
@@ -117,6 +120,7 @@ class LazyListsIndexedTest {
             .assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun rowWithIndexesComposedWithCorrectIndexAndItem() = runSkikoComposeUiTest {
         val items = (0..1).map { it.toString() }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListsReverseLayoutTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListsReverseLayoutTest.kt
@@ -65,6 +65,7 @@ class LazyListsReverseLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_emitTwoElementsAsOneItem_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -84,6 +85,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_emitTwoItems_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -105,6 +107,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_initialScrollPositionIs0() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -126,6 +129,7 @@ class LazyListsReverseLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_scrollInWrongDirectionDoesNothing() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -157,6 +161,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: the test is failing
     fun column_scrollForwardHalfWay() = runSkikoComposeUiTest {
@@ -191,6 +196,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize + scrolled)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_scrollForwardTillTheEnd() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -225,6 +231,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_emitTwoElementsAsOneItem_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -244,6 +251,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_emitTwoItems_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -265,6 +273,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_initialScrollPositionIs0() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -286,6 +295,7 @@ class LazyListsReverseLayoutTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_scrollInWrongDirectionDoesNothing() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -318,6 +328,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: the test is failing
     fun row_scrollForwardHalfWay() = runSkikoComposeUiTest {
@@ -353,6 +364,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize + scrolled)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_scrollForwardTillTheEnd() = runSkikoComposeUiTest {
         lateinit var state: LazyListState
@@ -388,6 +400,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_rtl_emitTwoElementsAsOneItem_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -409,6 +422,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_rtl_emitTwoItems_positionedReversed() = runSkikoComposeUiTest {
         setContent {
@@ -432,6 +446,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: the test is failing
     fun row_rtl_scrollForwardHalfWay() = runSkikoComposeUiTest {
@@ -469,6 +484,7 @@ class LazyListsReverseLayoutTest {
             .assertLeftPositionInRootIsEqualTo(itemSize * 2 - scrolled)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun column_whenParameterChanges() = runSkikoComposeUiTest {
         var reverse by mutableStateOf(true)
@@ -498,6 +514,7 @@ class LazyListsReverseLayoutTest {
             .assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun row_whenParameterChanges() = runSkikoComposeUiTest {
         var reverse by mutableStateOf(true)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyRowTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyRowTest.kt
@@ -89,6 +89,7 @@ class LazyRowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowAlignmentCenterVertically() = runSkikoComposeUiTest {
         prepareLazyRowForAlignment(Alignment.CenterVertically)
@@ -100,6 +101,7 @@ class LazyRowTest {
             .assertPositionInRootIsEqualTo(50.dp, 15.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowAlignmentTop() = runSkikoComposeUiTest {
         prepareLazyRowForAlignment(Alignment.Top)
@@ -111,6 +113,7 @@ class LazyRowTest {
             .assertPositionInRootIsEqualTo(50.dp, 0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun lazyRowAlignmentBottom() = runSkikoComposeUiTest {
         prepareLazyRowForAlignment(Alignment.Bottom)
@@ -122,6 +125,7 @@ class LazyRowTest {
             .assertPositionInRootIsEqualTo(50.dp, 30.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: the test is failing
     fun scrollsLeftInRtl() = runSkikoComposeUiTest {
@@ -151,6 +155,7 @@ class LazyRowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun laysOutRtlCorrectlyWithLargerRow() = runSkikoComposeUiTest {
         val rowWidth = with(density) { 300.toDp() }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazySemanticsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazySemanticsTest.kt
@@ -63,6 +63,7 @@ class LazySemanticsTest {
     private fun key(index: Int): String = "key_$index"
     
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemSemantics_column() = runSkikoComposeUiTest {
         setContent {
@@ -77,6 +78,7 @@ class LazySemanticsTest {
         runTest()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemsSemantics_column() = runSkikoComposeUiTest {
         setContent {
@@ -89,6 +91,7 @@ class LazySemanticsTest {
         runTest()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemSemantics_row() = runSkikoComposeUiTest {
         setContent {
@@ -103,6 +106,7 @@ class LazySemanticsTest {
         runTest()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun itemsSemantics_row() = runSkikoComposeUiTest {
         setContent {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/BasicTextDensityTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/BasicTextDensityTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class BasicTextDensityTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun simpleParagraph_densityChange() = runSkikoComposeUiTest {
         val density1 = Density(1f)
@@ -74,6 +75,7 @@ class BasicTextDensityTest {
         assertThat(textSizeDensity2.height).isGreaterThan(textSizeDensity1.height)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun simpleMultiParagraph_densityChange() = runSkikoComposeUiTest {
         val density1 = Density(1f)
@@ -116,6 +118,7 @@ class BasicTextDensityTest {
         assertThat(textSizeDensity2.height).isGreaterThan(textSizeDensity1.height)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun selectableText_densityChange() = runSkikoComposeUiTest {
         val density1 = Density(1f)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/BasicTextSemanticsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/BasicTextSemanticsTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class BasicTextSemanticsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun semanticsTextChanges_String() = runSkikoComposeUiTest {
         var text by mutableStateOf("before")
@@ -41,6 +42,7 @@ class BasicTextSemanticsTest {
         onNodeWithText("after").assertExists()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun semanticsTextChanges_AnnotatedString() = runSkikoComposeUiTest {
         var text by mutableStateOf("before")

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/ClickableTextTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/ClickableTextTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class)
 class ClickableTextTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun onclick_callback() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -53,6 +54,7 @@ class ClickableTextTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onclick_callback_whenCallbackIsUpdated() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldInputServiceIntegrationTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldInputServiceIntegrationTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
@@ -49,7 +48,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 @Ignore // TODO: these test can be applied for targets supporting touch and virtual keyboard
 class CoreTextFieldInputServiceIntegrationTest {
 
@@ -58,6 +57,7 @@ class CoreTextFieldInputServiceIntegrationTest {
     @Suppress("DEPRECATION")
     private val textInputService = androidx.compose.ui.text.input.TextInputService(platformTextInputService)
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_ImeOptions_isPassedTo_platformTextInputService() = runSkikoComposeUiTest {
         val testTag = "KeyboardOption"
@@ -94,6 +94,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_stopsThenStartsInput_whenFocusMovesBetweenTextFields() = runSkikoComposeUiTest {
         val value = TextFieldValue("abc")
@@ -130,6 +131,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardShownOnInitialClick() = runSkikoComposeUiTest {
         // Arrange.
@@ -148,6 +150,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardShownOnInitialFocus() = runSkikoComposeUiTest {
         // Arrange.
@@ -167,6 +170,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardHiddenWhenFocusIsLost() = runSkikoComposeUiTest {
         // Arrange.
@@ -189,6 +193,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardShownAfterDismissingKeyboardAndClickingAgain() = runSkikoComposeUiTest {
         // Arrange.
@@ -210,6 +215,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardStaysVisibleWhenMovingFromOneTextFieldToAnother() = runSkikoComposeUiTest {
         // Arrange.
@@ -238,6 +244,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isTrue() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardHiddenWhenFieldRemovedFromComposition() = runSkikoComposeUiTest {
         // Arrange.
@@ -263,6 +270,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardHiddenWhenFieldChangedToDisabled() = runSkikoComposeUiTest {
         // Arrange.
@@ -287,6 +295,7 @@ class CoreTextFieldInputServiceIntegrationTest {
         runOnIdle { assertThat(platformTextInputService.keyboardShown).isFalse() }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun keyboardHiddenWhenFieldChangedToReadOnly() = runSkikoComposeUiTest {
         // Arrange.

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldSoftWrapTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldSoftWrapTest.kt
@@ -38,7 +38,8 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class CoreTextFieldSoftWrapTest {
-    
+
+    @Suppress("DEPRECATION")
     @Test
     fun textField_softWrapFalse_returnsSizeForMaxIntrinsicWidth() = runSkikoComposeUiTest {
         val density = Density(density = 1f, fontScale = 1f)
@@ -79,6 +80,7 @@ class CoreTextFieldSoftWrapTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_softWrapTrue_respectsTheGivenMaxWidth() = runSkikoComposeUiTest {
         val density = Density(density = 1f, fontScale = 1f)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/TextLayoutDirectionTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/TextLayoutDirectionTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class TextLayoutDirectionTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCoreTextField_getsCorrectLayoutDirection() = runSkikoComposeUiTest {
         var layoutDirection: LayoutDirection? = null

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/TextOverflowTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/TextOverflowTest.kt
@@ -50,6 +50,7 @@ class TextOverflowTest {
 
     private val BoxTag = "wrapping box"
 
+    @Suppress("DEPRECATION")
     @Test
     fun paint_singleParagraph_withVisibleOverflow() = runSkikoComposeUiTest {
         val text = "Hello\nHello\nHello\nHello"
@@ -86,6 +87,7 @@ class TextOverflowTest {
         croppedBoxBitmap.asComposeImageBitmap().assertContainsColor(Color.Red)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun paint_multiParagraph_withVisibleOverflow() = runSkikoComposeUiTest {
         val text = buildAnnotatedString {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldCursorTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldCursorTest.kt
@@ -101,6 +101,7 @@ class TextFieldCursorTest {
         cursorRect = Rect.Zero
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldFocused_cursorRendered() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -129,6 +130,7 @@ class TextFieldCursorTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldFocused_cursorWithBrush() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -174,6 +176,7 @@ class TextFieldCursorTest {
         bitmap.assertPixelColor(Color.Green, x = cursorLeft, y = cursorBottom)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cursorBlinkingAnimation() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -219,6 +222,7 @@ class TextFieldCursorTest {
             )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cursorUnsetColor_noCursor() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -264,6 +268,7 @@ class TextFieldCursorTest {
             )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cursorNotBlinking_whileTyping() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -311,6 +316,7 @@ class TextFieldCursorTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @IgnoreWasmTarget
     fun selectionChanges_cursorNotBlinking() = runSkikoComposeUiTest {
@@ -355,6 +361,7 @@ class TextFieldCursorTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun brushChanged_doesntResetTimer() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
@@ -389,12 +396,14 @@ class TextFieldCursorTest {
             )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cursorBlinkingDoesNotHangTestWithAutoAdvance() = runSkikoComposeUiTest {
         mainClock.autoAdvance = true
         cursorBlinkingDoesNotHangTest()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cursorBlinkingDoesNotHangTestWithoutAutoAdvance() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldDefaultWidthTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldDefaultWidthTest.kt
@@ -45,6 +45,7 @@ class BaseTextFieldDefaultWidthTest {
 
     val density = Density(density = 1f, fontScale = 1f)
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore
     fun textField_hasDefaultWidth() = runSkikoComposeUiTest {
@@ -63,6 +64,7 @@ class BaseTextFieldDefaultWidthTest {
         assertThat(size).isEqualTo(defaultTextFieldSize(fontSize))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun minConstraint_greaterThan_defaultWidth_choosesMinConstraint() = runSkikoComposeUiTest {
         var size: Int? = null
@@ -85,6 +87,7 @@ class BaseTextFieldDefaultWidthTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun maxConstraint_smallerThan_defaultWidth_choosesMaxConstraint() = runSkikoComposeUiTest {
         var size: Int? = null
@@ -108,6 +111,7 @@ class BaseTextFieldDefaultWidthTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     @Ignore
     fun textWidth_smallerThan_defaultWidth_choosesDefaultWidth() = runSkikoComposeUiTest {
         var size: Int? = null
@@ -125,6 +129,7 @@ class BaseTextFieldDefaultWidthTest {
         assertThat(size).isEqualTo(defaultTextFieldSize(fontSize))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore
     fun textWidth_greaterThan_defaultWidth_choosesTextWidth() = runSkikoComposeUiTest {
@@ -144,6 +149,7 @@ class BaseTextFieldDefaultWidthTest {
         assertThat(size).isEqualTo(defaultTextFieldSize(fontSize, charCount))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun respectsWidthSetByModifier() = runSkikoComposeUiTest {
         val textFieldWidth = 100.dp

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldFocusTest.kt
@@ -73,6 +73,7 @@ class TextFieldFocusTest {
 
     data class FocusTestData(val focusRequester: FocusRequester, var focused: Boolean = false)
 
+    @Suppress("DEPRECATION")
     @Test
     @IgnoreWasmTarget
     fun requestFocus() = runSkikoComposeUiTest {
@@ -111,8 +112,9 @@ class TextFieldFocusTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
-    fun noCrushWhenSwitchingBetweenEnabledFocusedAndDisabledTextField() = runSkikoComposeUiTest {
+    fun noCrashWhenSwitchingBetweenEnabledFocusedAndDisabledTextField() = runSkikoComposeUiTest {
         val enabled = mutableStateOf(true)
         var focused = false
         val tag = "textField"
@@ -146,6 +148,7 @@ class TextFieldFocusTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @IgnoreWasmTarget
     fun wholeDecorationBox_isBroughtIntoView_whenFocused() = runSkikoComposeUiTest {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldScrollTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldScrollTest.kt
@@ -122,6 +122,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_scrollable_withLongInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -138,6 +139,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_vertical_scrollable_withLongInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition()
@@ -154,6 +156,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_vertical_scrollable_withLongInput_whenMaxLinesProvided() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition()
@@ -171,6 +174,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_notScrollable_withShortInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -184,6 +188,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         runOnIdle { assertThat(scrollerPosition.maximum).isEqualTo(0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_vertical_notScrollable_withShortInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition()
@@ -197,6 +202,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         runOnIdle { assertThat(scrollerPosition.maximum).isEqualTo(0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_singleLine_scrolledAndClipped() = runComposeUiTest {
         val parentSize = 200
@@ -225,6 +231,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_multiline_scrolledAndClipped() = runComposeUiTest {
         val parentSize = 200
@@ -253,6 +260,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_swipe_whenLongInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -274,6 +282,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         runOnIdle { assertThat(scrollerPosition.offset).isLessThan(firstSwipePosition) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_vertical_swipe_whenLongInput() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition()
@@ -295,6 +304,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         runOnIdle { assertThat(scrollerPosition.offset).isLessThan(firstSwipePosition) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScrollable_testInspectorValue() = runComposeUiTest {
         val position = TextFieldScrollerPosition(Orientation.Vertical, 10f)
@@ -313,6 +323,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_withNarrowerChild_measureWithOriginalConstraints() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -364,6 +375,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_withWiderChild_measureWithInfinityWidthConstraints() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -423,6 +435,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: selectionHandles can be applied for targets supporting touch
     fun textField_cursorHandle_hidden_whenScrolledOutOfView() = runComposeUiTest {
@@ -462,6 +475,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         onNode(isSelectionHandle(Handle.Cursor)).assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     @Ignore // TODO: selectionHandles can be applied for targets supporting touch
     fun textField_selectionHandles_hidden_whenScrolledOutOfView() = runComposeUiTest {
@@ -510,6 +524,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         onNode(isSelectionHandle(Handle.SelectionEnd)).assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_horizontal_overscroll() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition(Orientation.Horizontal)
@@ -530,6 +545,7 @@ class TextFieldScrollTest : FocusedWindowTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textFieldScroll_vertical_overscroll() = runComposeUiTest {
         val scrollerPosition = TextFieldScrollerPosition()

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldSelectionTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldSelectionTest.kt
@@ -48,6 +48,7 @@ import kotlin.test.Test
 @Ignore // TODO: enable these tests for targets supporting touch
 class TextFieldSelectionTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun readOnlyTextField_showsSelectionHandles() = runSkikoComposeUiTest {
         val testTag = "text field"
@@ -72,6 +73,7 @@ class TextFieldSelectionTest {
         onNode(isSelectionHandle(Handle.SelectionEnd)).assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_showsSelectionHandles_whenVisualTransformationIsApplied() = runSkikoComposeUiTest {
         val testTag = "text field"
@@ -96,6 +98,7 @@ class TextFieldSelectionTest {
         onNode(isSelectionHandle(Handle.SelectionEnd)).assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_showsCursorHandle() = runSkikoComposeUiTest {
         val testTag = "text field"
@@ -118,6 +121,7 @@ class TextFieldSelectionTest {
         onNode(isSelectionHandle(Handle.Cursor)).assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_dragsCursorHandle() = runSkikoComposeUiTest {
         val testTag = "text field"
@@ -159,6 +163,7 @@ class TextFieldSelectionTest {
         assertThat(cursorPositions).isEqualTo((0..14).toList())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun textField_dragsCursorHandle_withVisualTransformation() = runSkikoComposeUiTest {
         val testTag = "text field"

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldUndoTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldUndoTest.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.isEqualTo
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -38,13 +37,15 @@ import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TextInputService
-import kotlin.test.*
+import kotlin.test.Ignore
+import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class TextFieldUndoTest {
 
-    @OptIn(ExperimentalComposeUiApi::class)
-    @Test @Ignore // TODO: figure out how to make target-specific tweaks (Key.Ctrl vs Key.Command)
+    @Suppress("DEPRECATION")
+    @Test
+    @Ignore // TODO: figure out how to make target-specific tweaks (Key.Ctrl vs Key.Command)
     fun undo_redo() = runSkikoComposeUiTest {
         val textInputService = TextInputService(mock)
         val state = mutableStateOf("hi")

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
@@ -472,6 +472,7 @@ class DragGestureTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun dragGestureDoesNotRestartOnMatcherChange() = runComposeUiTest {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoLazyListTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoLazyListTest.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.ScrollWheel
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipe
@@ -44,6 +42,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class SkikoLazyListTest {
     // https://github.com/JetBrains/compose-multiplatform/issues/3559
+    @Suppress("DEPRECATION")
     @Test
     fun textFields() = runComposeUiTest {
         val state by mutableStateOf(LazyListState())
@@ -62,6 +61,7 @@ class SkikoLazyListTest {
     }
 
     // reduced https://github.com/JetBrains/compose-multiplatform/issues/3559
+    @Suppress("DEPRECATION")
     @Test
     fun dynamicModifiers() = runComposeUiTest {
         val state by mutableStateOf(LazyListState())

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -50,6 +50,7 @@ import org.jetbrains.skiko.hostOs
 
 @OptIn(ExperimentalTestApi::class)
 class SkikoScrollableTest {
+    @Suppress("DEPRECATION")
     @Test
     fun properDefaultFlingBehavior() = runComposeUiTest {
         val state by mutableStateOf(LazyListState())
@@ -75,6 +76,7 @@ class SkikoScrollableTest {
     }
 
     // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (mouse didn't work)
+    @Suppress("DEPRECATION")
     @Test
     fun recreatingListStateShouldNotBreakMouseScrolling() = runComposeUiTest {
         var state by mutableStateOf(LazyListState())
@@ -103,6 +105,7 @@ class SkikoScrollableTest {
     }
 
     // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (touch always worked)
+    @Suppress("DEPRECATION")
     @Test
     fun recreatingListStateShouldNotBreakTouchScrolling() = runComposeUiTest {
         var state by mutableStateOf(LazyListState())
@@ -131,6 +134,7 @@ class SkikoScrollableTest {
     }
 
     @OptIn(InternalComposeUiApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun closeSceneDuringScrollAnimation() = runSkikoComposeUiTest(
         size = Size(100f, 100f),

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/layout/ArrangementSpacedByUnspecifiedTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/layout/ArrangementSpacedByUnspecifiedTest.kt
@@ -21,10 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
-import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.Dp
@@ -39,6 +37,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class ArrangementSpacedByUnspecifiedTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun columnWithSpacedByDpUnspecifiedDoesNotCrash() = runComposeUiTest {
         val itemSize = 50.dp
@@ -57,6 +56,7 @@ class ArrangementSpacedByUnspecifiedTest {
         onNodeWithTag("item2").assertTopPositionInRootIsEqualTo(itemSize)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun rowWithSpacedByDpUnspecifiedDoesNotCrash() = runComposeUiTest {
         val itemSize = 50.dp

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.launch
 
 class LegacyPlatformTextInputServiceAdapterTest {
     @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun testRequestValuesUpdate() = runComposeUiTest {
         var value: TextFieldValue? = null
@@ -124,6 +125,7 @@ class LegacyPlatformTextInputServiceAdapterTest {
     }
 
     @OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun testTextEditing() = runComposeUiTest {
         var text by mutableStateOf(TextFieldValue(""))

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldFocusTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class TextFieldFocusTest {
+    @Suppress("DEPRECATION")
     @Test
     fun shouldRequestFocusOnClick() = runComposeUiTest {
         setContent {
@@ -56,6 +57,7 @@ class TextFieldFocusTest {
     }
 
     // bug https://github.com/JetBrains/compose-multiplatform/issues/3526
+    @Suppress("DEPRECATION")
     @Test
     fun shouldRequestFocusOnClickInLazyList() = runComposeUiTest {
         val size = 1000

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldInputTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldInputTest.kt
@@ -168,6 +168,7 @@ private class TextField2InputTestScope(
 }
 
 @OptIn(ExperimentalTestApi::class)
+@Suppress("DEPRECATION")
 private fun runTextFieldInputTest(
     scopeBuilders: List<(ComposeUiTest) -> TextFieldInputTestScope> = listOf(
         ::TextField1InputTestScope,

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldTest.kt
@@ -39,6 +39,7 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class TextFieldTest {
+    @Suppress("DEPRECATION")
     @Test
     fun selectionWithVisualTransformation() = runComposeUiTest {
         val rawText = "abcde"

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
@@ -21,33 +21,27 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.animateMoveTo
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.dragAndDrop
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -55,6 +49,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SelectionContainerTest {
+    @Suppress("DEPRECATION")
     @Test
     fun selectionWorksWhenDraggingFromBelowText() = runComposeUiTest {
         val selectionState = SelectionState()
@@ -84,6 +79,7 @@ class SelectionContainerTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun clickOnDisabledSelectionClearsSelection() = runComposeUiTest {
         val selectionState = SelectionState()
@@ -116,6 +112,7 @@ class SelectionContainerTest {
         assertFalse(selectionState.selection.exists())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun dragToSelect() = runComposeUiTest {
         val selectionState = SelectionState()

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
@@ -53,7 +53,6 @@ import kotlin.test.assertNotEquals
 import kotlinx.test.IgnoreJsTarget
 import kotlinx.test.IgnoreWasmTarget
 
-@Suppress("DEPRECATION")
 @OptIn(ExperimentalTestApi::class)
 class BasicTextFieldSelectionHandleTest {
     private val textPadding = 30.dp
@@ -72,6 +71,7 @@ class BasicTextFieldSelectionHandleTest {
         .padding(textPadding)
         .fillMaxSize()
 
+    @Suppress("DEPRECATION")
     @Test
     fun basicTextFieldSelectionHandles() = runSkikoComposeUiTest(size = Size(100f, 100f)) {
         val textState = TextFieldState(initialText = "TextText")
@@ -125,6 +125,7 @@ class BasicTextFieldSelectionHandleTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     // FIXME https://youtrack.jetbrains.com/issue/CMP-8803
     @IgnoreJsTarget

--- a/compose/foundation/foundation/src/webTest/kotlin/androidx/compose/foundation/text/selection/SelectionTests.kt
+++ b/compose/foundation/foundation/src/webTest/kotlin/androidx/compose/foundation/text/selection/SelectionTests.kt
@@ -50,6 +50,7 @@ class WebSelectionTests {
     private val keyboardActions = ResolvedKeyboardActions
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     private fun textFieldSemanticInteraction(
         initialValue: String = "",
         runAction: (node: SemanticsNodeInteraction, state: MutableState<TextFieldValue>) -> Unit

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.IntrinsicMeasurable
@@ -58,6 +57,7 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class DesktopAlertDialogTest {
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 
@@ -83,7 +83,6 @@ class DesktopAlertDialogTest {
         }
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `back event invokes onDismissRequest`() {
         val dialogSize = IntSize(150, 150)
@@ -114,7 +113,8 @@ class DesktopAlertDialogTest {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class, ExperimentalMaterialApi::class)
+    @Suppress("DEPRECATION")
+    @OptIn(ExperimentalTestApi::class)
     @Test
     fun `uses available width`() = runDesktopComposeUiTest(
         width = 800,

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -161,6 +161,7 @@ class DesktopMenuTest {
     }
 
     // (RTL) Anchor right is beyond the right of the window, so align popup to the window right
+    @Suppress("DEPRECATION")
     @Test
     fun menu_positioning_rtl_windowRight_belowAnchor() = runComposeUiTest {
         setContent {
@@ -179,6 +180,7 @@ class DesktopMenuTest {
             .assertLeftPositionInRootIsEqualTo(windowSize.width - 50.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `back event invokes onDismissRequest`() = runComposeUiTest {
         var dismissCount = 0
@@ -201,6 +203,7 @@ class DesktopMenuTest {
         assertEquals(1, dismissCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `navigate DropDownMenu using arrows`() = runComposeUiTest {
         var item1Clicked = 0
@@ -261,6 +264,7 @@ class DesktopMenuTest {
     }
 
     @OptIn(ExperimentalMaterialApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `right click opens DropdownMenuState`() = runComposeUiTest {
         val state = DropdownMenuState(DropdownMenuState.Status.Closed)
@@ -283,6 +287,7 @@ class DesktopMenuTest {
     }
 
     @OptIn(ExperimentalMaterialApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `right doesn't open DropdownMenuState when disabled`() = runComposeUiTest {
         val state = DropdownMenuState(DropdownMenuState.Status.Closed)
@@ -305,6 +310,7 @@ class DesktopMenuTest {
         assertThat(state.status == DropdownMenuState.Status.Closed)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `pass scroll state`() = runComposeUiTest {
         val scrollState = ScrollState(0)

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
@@ -18,7 +18,6 @@ package androidx.compose.material
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -45,6 +44,7 @@ import org.junit.Test
 @OptIn(InternalComposeUiApi::class)
 class SliderTest {
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 
@@ -53,7 +53,6 @@ class SliderTest {
         rule.mainClock.autoAdvance = true
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `slider(0 steps, ltr) changes values when arrows pressed`() {
         val state = mutableStateOf(0.5f)
@@ -137,7 +136,6 @@ class SliderTest {
         }
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `slider(0 steps, rtl) changes values when arrows pressed`() {
         val state = mutableStateOf(0.5f)
@@ -179,7 +177,6 @@ class SliderTest {
         }
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `slider(29 steps, ltr) changes values when arrows pressed`() {
         val state = mutableStateOf(15f)

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SnackbarTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SnackbarTest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 
 class SnackbarTest {
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun testParallelQueueing() = runComposeUiTest {
         var snackbarsShown = 0
@@ -50,6 +51,7 @@ class SnackbarTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun testSequentialQueueing() = runComposeUiTest {
         var snackbarsShown = 0

--- a/compose/material3/material3/src/desktopTest/kotlin/androidx/compose/material3/DesktopMenuTest.kt
+++ b/compose/material3/material3/src/desktopTest/kotlin/androidx/compose/material3/DesktopMenuTest.kt
@@ -23,10 +23,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.internal.DropdownMenuPositionProvider
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -55,10 +53,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@OptIn(InternalComposeUiApi::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(InternalComposeUiApi::class)
 @RunWith(JUnit4::class)
 class DesktopMenuTest {
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/SliderTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/SliderTest.kt
@@ -16,8 +16,6 @@
 
 package androidx.compose.material3
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,13 +27,13 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SliderTest {
+    @Suppress("DEPRECATION")
     @Test
     fun changingOnValueChangeFinishedDoesNotTriggerFinish() = runComposeUiTest {
         var finish1Called = false

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/SkikoPathMeasureTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/SkikoPathMeasureTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SkikoPathMeasureTest {
+    @Suppress("DEPRECATION")
     @Test
     @OptIn(ExperimentalTestApi::class)
     fun getSegment_reusedDestinationUpdatesRetainedSkiaPath() = runSkikoComposeUiTest {

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/shadow/DropShadowPainterTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/shadow/DropShadowPainterTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class DropShadowPainterTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterWithColor() = runSkikoComposeUiTest {
         val dropShadow = DropShadowPainter(RectangleShape, Shadow(200.dp, Color.Red))
@@ -56,6 +57,7 @@ class DropShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterWithPathAndColor() = runSkikoComposeUiTest {
         val dropShadow =
@@ -95,6 +97,7 @@ class DropShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterWithBrush() = runSkikoComposeUiTest {
         val dropShadow =
@@ -116,6 +119,7 @@ class DropShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterPathWithBrush() = runSkikoComposeUiTest {
         val dropShadow =
@@ -155,6 +159,7 @@ class DropShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterWithBrushAndColorFilter() = runSkikoComposeUiTest {
         val dropShadow =
@@ -176,6 +181,7 @@ class DropShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDropShadowPainterWithBrushAndAlpha() = runSkikoComposeUiTest {
         val dropShadow =

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/shadow/InnerShadowPainterTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/graphics/shadow/InnerShadowPainterTest.kt
@@ -28,6 +28,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class InnerShadowPainterTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testInnerShadowPainterWithColor() = runSkikoComposeUiTest {
         val innerShadow = InnerShadowPainter(RectangleShape, Shadow(20.dp, Color.Red))
@@ -48,6 +49,7 @@ class InnerShadowPainterTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testInnerShadowPainterWithPathAndColor() = runSkikoComposeUiTest {
         val innerShadow = InnerShadowPainter(RectangleShape, Shadow(20.dp, Color.Red))

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -65,6 +65,7 @@ class ComposeUiTestTest {
     // TODO why this test passed before the check for effectContext was added?
     //  effectContext didn't passed anywhere.
     @Test
+    @Suppress("DEPRECATION")
     @Ignore("effectContext isn't implemented https://github.com/JetBrains/compose-multiplatform/issues/2960")
     fun effectContextPropagatedToComposition_runComposeUiTest() {
         val testElement = TestCoroutineContextElement()
@@ -89,6 +90,7 @@ class ComposeUiTestTest {
     fun effectContextPropagatedToComposition_createComposeRule() {
         val testElement = TestCoroutineContextElement()
         lateinit var compositionScope: CoroutineScope
+        @Suppress("DEPRECATION")
         val rule = createComposeRule(testElement)
         val baseStatement = object : Statement() {
             override fun evaluate() {
@@ -106,6 +108,7 @@ class ComposeUiTestTest {
         assertThat(elementFromComposition).isSameInstanceAs(testElement)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun motionDurationScale_defaultValue() = runComposeUiTest {
         var lastRecordedMotionDurationScale: Float? = null
@@ -121,6 +124,7 @@ class ComposeUiTestTest {
 
     // TODO why this test passed before the check for effectContext was added?
     //  effectContext didn't passed anywhere.
+    @Suppress("DEPRECATION")
     @Test
     @Ignore("effectContext isn't implemented https://github.com/JetBrains/compose-multiplatform/issues/2960")
     fun motionDurationScale_propagatedToCoroutines() {
@@ -140,6 +144,7 @@ class ComposeUiTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun effectShouldBeCancelledImmediately() {
         runComposeUiTest {
@@ -166,6 +171,7 @@ class ComposeUiTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testTimeout() {
         val timeout = 100.milliseconds
@@ -183,6 +189,7 @@ class ComposeUiTestTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testFailedAssertion() {
         val error = assertFailsWith<ComparisonFailure> {

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ProvidesLocalsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ProvidesLocalsTest.kt
@@ -16,15 +16,15 @@
 
 package androidx.compose.ui.test
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class)
 class ProvidesLocalsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun providesWindowInfo() = runComposeUiTest {
         lateinit var windowInfo: WindowInfo

--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -19,7 +19,10 @@ package androidx.compose.ui.test
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -40,7 +43,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -65,6 +67,7 @@ class ComposeUiSkikoTestTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_move() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -90,6 +93,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_drag() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -123,6 +127,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_press_primary() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -140,6 +145,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_press_and_release_primary() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -170,6 +176,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_click() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -199,6 +206,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_press_multiple() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -254,6 +262,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouse_scroll() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -282,6 +291,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touch_drag() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -309,6 +319,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touch_press() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -324,6 +335,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touch_press_and_release() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -345,6 +357,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touch_click() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -365,6 +378,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touch_press_multiple() = runComposeUiTest {
         setContent { TestEventBox() }
@@ -401,6 +415,7 @@ class ComposeUiSkikoTestTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun text_input() = runComposeUiTest {
         var text by mutableStateOf(TextFieldValue(""))

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.Density
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * Variant of [runComposeUiTest] that allows you to specify the size of the surface.
@@ -62,7 +61,7 @@ fun runDesktopComposeUiTest(
     }
 }
 
-@OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class)
+@OptIn(InternalTestApi::class)
 @ExperimentalTestApi
 class DesktopComposeUiTest(
     width: Int = 1024,

--- a/compose/ui/ui-test/src/desktopTest/kotlin/androidx/compose/ui/test/DesktopTestsTest.kt
+++ b/compose/ui/ui-test/src/desktopTest/kotlin/androidx/compose/ui/test/DesktopTestsTest.kt
@@ -48,6 +48,7 @@ import org.jetbrains.skia.Image
 @OptIn(ExperimentalTestApi::class)
 class DesktopTestsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testNodeInDialogWindow() = runComposeUiTest {
         var show by mutableStateOf(true)
@@ -70,6 +71,7 @@ class DesktopTestsTest {
         onNodeWithTag("tag").assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testNodeInWindow() = runComposeUiTest {
         var show by mutableStateOf(true)
@@ -92,6 +94,7 @@ class DesktopTestsTest {
         onNodeWithTag("tag").assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIsDialogOnDialogWindow() = runComposeUiTest {
         setContent {
@@ -109,6 +112,7 @@ class DesktopTestsTest {
         onNodeWithTag("tag").assert(hasAnyAncestor(isDialog()))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDrawSquare() = runDesktopComposeUiTest(10, 10) {
         setContent {
@@ -131,6 +135,7 @@ class DesktopTestsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIdlingResource() = runDesktopComposeUiTest {
         var text by mutableStateOf("")

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
@@ -47,6 +47,7 @@ import kotlin.test.assertFails
 @OptIn(ExperimentalTestApi::class)
 class AssertionsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertExists() = runComposeUiTest {
         setContent {
@@ -59,6 +60,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertDoesNotExist() = runComposeUiTest {
         setContent {
@@ -71,6 +73,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsDisplayed() = runComposeUiTest {
         setContent {
@@ -96,6 +99,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsNotDisplayed() = runComposeUiTest {
         setContent {
@@ -121,6 +125,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsEnabled() = runComposeUiTest {
         setContent {
@@ -142,6 +147,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsNotEnabled() = runComposeUiTest {
         setContent {
@@ -163,6 +169,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsOn() = runComposeUiTest {
         setContent {
@@ -184,6 +191,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsOff() = runComposeUiTest {
         setContent {
@@ -205,6 +213,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsSelected() = runComposeUiTest {
         setContent {
@@ -226,6 +235,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsNotSelected() = runComposeUiTest {
         setContent {
@@ -247,6 +257,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsToggleable() = runComposeUiTest {
         setContent {
@@ -267,6 +278,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsSelectable() = runComposeUiTest {
         setContent {
@@ -287,6 +299,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsFocused() = runComposeUiTest {
         setContent {
@@ -313,6 +326,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertIsNotFocused() = runComposeUiTest {
         setContent {
@@ -339,6 +353,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertContentDescriptionEquals() = runComposeUiTest {
         setContent {
@@ -363,6 +378,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertContentDescriptionContains() = runComposeUiTest {
         setContent {
@@ -388,6 +404,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertTextEquals() = runComposeUiTest {
         setContent {
@@ -409,6 +426,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertTextContains() = runComposeUiTest {
         setContent {
@@ -428,6 +446,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertValueEquals() = runComposeUiTest {
         setContent {
@@ -440,6 +459,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertRangeInfoEquals() = runComposeUiTest {
         setContent {
@@ -467,6 +487,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertHasClickAction() = runComposeUiTest {
         setContent {
@@ -486,6 +507,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertHasNoClickAction() = runComposeUiTest {
         setContent {
@@ -506,6 +528,7 @@ class AssertionsTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun testAssertAny() = runComposeUiTest {
         setContent {
             Text(
@@ -525,6 +548,7 @@ class AssertionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAssertAll() = runComposeUiTest {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiTestTestCopyFromAosp.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiTestTestCopyFromAosp.kt
@@ -75,6 +75,7 @@ class ComposeUiTestTestCopyFromAosp {
      * Check that basic scenarios with input work: a composition that receives touch input and
      * changes state as a result of that, triggering recomposition.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun testInputInjection() = runComposeUiTest {
         setContent { ClickCounter() }
@@ -87,6 +88,7 @@ class ComposeUiTestTestCopyFromAosp {
     }
 
     /** Check that basic scenarios work: a composition that is recomposed due to a state change. */
+    @Suppress("DEPRECATION")
     @Test
     fun testStateChange() = runComposeUiTest {
         val clicks = mutableStateOf(0)
@@ -104,6 +106,7 @@ class ComposeUiTestTestCopyFromAosp {
      * idle, stays non-idle while the animation animates to a new target and is idle again after
      * that.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun testAnimation() = runComposeUiTest {
         var target by mutableStateOf(0f)
@@ -122,6 +125,7 @@ class ComposeUiTestTestCopyFromAosp {
      * Check that scrolling and controlling the clock works: a scrollable receives a swipe while the
      * clock is paused, when the clock is resumed it performs the fling.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun testControlledScrolling() = runComposeUiTest {
         // Define constants used in the test
@@ -199,12 +203,14 @@ class ComposeUiTestTestCopyFromAosp {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun runTestContextMustHaveMonotonicFrameClock() = runComposeUiTest {
         val frameClock = coroutineContext[MonotonicFrameClock.Key]
         assertThat(frameClock).isNotNull()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun runTestAndCompositionUseDifferentSchedulers() = runComposeUiTest {
         var number by mutableStateOf(10)
@@ -230,6 +236,7 @@ class ComposeUiTestTestCopyFromAosp {
         assertThat(mainClock.currentTime).isEqualTo(currentCompositionTime + 21)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun shouldKeepCustomCoroutineContextElements() =
         runComposeUiTest(runTestContext = MyCustomElement("testElement")) {
@@ -239,6 +246,7 @@ class ComposeUiTestTestCopyFromAosp {
         }
 
 
+    @Suppress("DEPRECATION")
     @Test
     fun defaultRunTestDispatcherIsStandardDispatcher() = runComposeUiTest {
         var i = 0
@@ -249,6 +257,7 @@ class ComposeUiTestTestCopyFromAosp {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun canOverrideRunTestDispatcher() =
         runComposeUiTest(runTestContext = UnconfinedTestDispatcher()) {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CompositionLocalsInTestsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CompositionLocalsInTestsTest.kt
@@ -51,6 +51,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class CompositionLocalsInTestsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun lifecycleInComposeTest() = runComposeUiTest {
         setContent {
@@ -59,6 +60,7 @@ class CompositionLocalsInTestsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun commonCompositionLocalsInComposeTest() = runComposeUiTest {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CreateSavedStateHandleTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CreateSavedStateHandleTest.kt
@@ -30,6 +30,7 @@ class CreateSavedStateHandleTest {
         var intState by savedStateHandle.saved("state") { 0 }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCreateSavedStateHandle() = runComposeUiTest {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/DrawOnlyInvalidationTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/DrawOnlyInvalidationTest.kt
@@ -31,6 +31,7 @@ class DrawOnlyInvalidationTest {
      * invalidation is also flushed by `waitForIdle`. Android-verified:
      * `afterSetContent=[0] afterFirstWait=[0] afterMutate=[0] afterWaitAfterMutate=[0, 1]`.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun pausedClock_drawInvalidationIsFlushedByWaitForIdle() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -54,6 +55,7 @@ class DrawOnlyInvalidationTest {
      * Paused clock, measure invalidation (state read in measure): flushed by `waitForIdle`.
      * Android-verified: draw count 1 -> 2.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun pausedClock_measureInvalidationIsFlushedByWaitForIdle() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -81,6 +83,7 @@ class DrawOnlyInvalidationTest {
      * pending (and, per [MainTestClock], pending recompositions are not awaited when autoAdvance is
      * false). Android-verified: `[0] -> [0]`.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun pausedClock_recompositionIsNotFlushedWithoutAdvancingClock() = runComposeUiTest {
         mainClock.autoAdvance = false
@@ -101,6 +104,7 @@ class DrawOnlyInvalidationTest {
     }
 
     /** Running clock (autoAdvance=true, the default): draw-only invalidation flushed. */
+    @Suppress("DEPRECATION")
     @Test
     fun runningClock_drawOnlyInvalidationIsFlushed() = runComposeUiTest {
         val state = mutableStateOf(0)

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class FiltersTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIsDialogOnDialog() = runComposeUiTest {
         setContent {
@@ -53,6 +54,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasAnyAncestor(isDialog()))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIsPopup() = runComposeUiTest {
         setContent {
@@ -67,6 +69,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasAnyAncestor(isPopup()))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasAnyChild() = runComposeUiTest {
         setContent {
@@ -78,6 +81,7 @@ class FiltersTest {
         onNodeWithTag("box").assert(hasAnyChild(hasText("text")))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasAnyAncestor() = runComposeUiTest {
         setContent {
@@ -92,6 +96,7 @@ class FiltersTest {
         onNodeWithText("text").assert(hasAnyAncestor(hasTestTag("ancestor2")))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasAnyParent() = runComposeUiTest {
         setContent {
@@ -103,6 +108,7 @@ class FiltersTest {
         onNodeWithText("text").assert(hasParent(hasTestTag("parent")))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasAnySibling() = runComposeUiTest {
         setContent {
@@ -115,6 +121,7 @@ class FiltersTest {
         onNodeWithText("text1").assert(hasAnySibling(hasText("text2")))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIsRoot() = runComposeUiTest {
         setContent {
@@ -124,6 +131,7 @@ class FiltersTest {
         onNodeWithText("text").assert(hasParent(isRoot()))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasSetTextAction() = runComposeUiTest {
         setContent {
@@ -136,6 +144,7 @@ class FiltersTest {
         onNodeWithText("text").assert(hasSetTextAction())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasScrollAction() = runComposeUiTest {
         setContent {
@@ -152,6 +161,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasScrollAction())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasNoScrollAction() = runComposeUiTest {
         setContent {
@@ -166,6 +176,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasNoScrollAction())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasScrollToIndexAction() = runComposeUiTest {
         setContent {
@@ -181,6 +192,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasScrollToIndexAction())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasScrollToKeyAction() = runComposeUiTest {
         setContent {
@@ -196,6 +208,7 @@ class FiltersTest {
         onNodeWithTag("tag").assert(hasScrollToKeyAction())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHasScrollToNodeAction() = runComposeUiTest {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/KeyInputTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/KeyInputTest.kt
@@ -63,6 +63,7 @@ class KeyInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testKeyDownAndUp() = runComposeUiTest {
         var keyEvent: KeyEvent? = null
@@ -95,6 +96,7 @@ class KeyInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testIsKeyDown() = runComposeUiTest {
         setContent {
@@ -112,6 +114,7 @@ class KeyInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPressKey() = runComposeUiTest {
         val keyEvents = mutableListOf<KeyEvent>()
@@ -138,6 +141,7 @@ class KeyInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testWithKeyDown() = runComposeUiTest {
         val keyEvents = mutableListOf<KeyEvent>()
@@ -182,6 +186,7 @@ class KeyInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testWithKeyToggled() = runComposeUiTest {
         val keyEvents = mutableListOf<KeyEvent>()

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MatchersTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MatchersTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class MatchersTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testNodeWithTag() = runComposeUiTest {
         setContent {
@@ -53,6 +54,7 @@ class MatchersTest {
         onNodeWithTag("text1", useUnmergedTree = true).assertExists()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAllNodesWithTag() = runComposeUiTest {
         setContent {
@@ -63,6 +65,7 @@ class MatchersTest {
         onAllNodesWithTag("tag").assertCountEquals(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testNodeWithText() = runComposeUiTest {
         setContent {
@@ -82,6 +85,7 @@ class MatchersTest {
         onNodeWithText("tex", substring = true).assertExists()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAllNodesWithText() = runComposeUiTest {
         setContent {
@@ -97,6 +101,7 @@ class MatchersTest {
         onAllNodesWithText("text", ignoreCase = true, substring = true).assertCountEquals(4)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testNodeWithContentDescription() = runComposeUiTest {
         setContent {
@@ -117,6 +122,7 @@ class MatchersTest {
         onNodeWithContentDescription("desc", substring = true).assertExists()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAllNodesWithContentDescription() = runComposeUiTest {
         setContent {
@@ -133,6 +139,7 @@ class MatchersTest {
             .assertCountEquals(4)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testOnNode() = runComposeUiTest {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
 class MouseInputTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformClick() = runComposeUiTest {
         var clicked = false
@@ -60,6 +61,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMouseClick() = runComposeUiTest {
         var clicked = false
@@ -82,6 +84,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMousePressDragAndRelease() = runComposeUiTest {
         var pressDetected = false
@@ -146,6 +149,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMouseEnterExit() = runComposeUiTest {
         var mouseEnterDetected = false
@@ -178,6 +182,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatePointerToDoesNotSendMoveEvent() = runComposeUiTest {
         var mouseMoveDetected = false
@@ -203,6 +208,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testScroll() = runComposeUiTest {
         var scrollDelta = Offset.Unspecified
@@ -236,6 +242,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testClick() = runComposeUiTest {
         var clickDetected = false
@@ -259,6 +266,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRightClick() = runComposeUiTest {
         var rightClickDetected = false
@@ -282,6 +290,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDoubleClick() = runComposeUiTest {
         var doubleClickDetected = false
@@ -309,6 +318,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testTripleClick() = runComposeUiTest {
         var clickCount = 0
@@ -335,6 +345,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLongClick() = runComposeUiTest {
         var longClickDetected = false
@@ -362,6 +373,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDragAndDrop() = runComposeUiTest {
         var dragOffset = Offset.Zero
@@ -394,6 +406,7 @@ class MouseInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testSmoothScroll() = runComposeUiTest {
         var scrollDelta = Offset.Zero

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/SkikoComposeUiTestTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/SkikoComposeUiTestTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 @OptIn(ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 class SkikoComposeUiTestTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun canSetContent() = runComposeUiTest {
         var set = false
@@ -47,6 +48,7 @@ class SkikoComposeUiTestTest {
         assertThat(set).isTrue()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canAwaitIdle() = runComposeUiTest {
         var visible by mutableStateOf(false)
@@ -65,6 +67,7 @@ class SkikoComposeUiTestTest {
         onNodeWithText("Hello").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canDriveAnimationsFromTest() = runComposeUiTest(runTestContext = UnconfinedTestDispatcher()) {
         val scrollState = ScrollState(initial = 0)

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -40,7 +40,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
-import kotlin.concurrent.Volatile
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.atomicfu.atomic
@@ -48,6 +47,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalTestApi::class)
 class TestBasicsTest : AbstractTestBasicsTest(
     runUiTest = { runComposeUiTest(block = it) }

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
@@ -40,6 +40,7 @@ class TextActionsTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformTextClearance() = runComposeUiTest {
         setContent {
@@ -53,6 +54,7 @@ class TextActionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformTextReplacement() = runComposeUiTest {
         setContent {
@@ -66,6 +68,7 @@ class TextActionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformTextInput() = runComposeUiTest {
         setContent {
@@ -79,6 +82,7 @@ class TextActionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformTextInputSelection() = runComposeUiTest  {
         setContent {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TrackpadInputTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TrackpadInputTest.kt
@@ -39,6 +39,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
 class TrackpadInputTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPerformClick() = runComposeUiTest {
         var clicked = false
@@ -61,6 +62,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMouseClick() = runComposeUiTest {
         var clicked = false
@@ -83,6 +85,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMousePressDragAndRelease() = runComposeUiTest {
         var pressDetected = false
@@ -147,6 +150,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMouseEnterExit() = runComposeUiTest {
         var mouseEnterDetected = false
@@ -179,6 +183,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatePointerToDoesNotSendMoveEvent() = runComposeUiTest {
         var mouseMoveDetected = false
@@ -204,6 +209,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPan() = runComposeUiTest {
         var panDelta = Offset.Unspecified
@@ -237,6 +243,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testPinch() = runComposeUiTest {
         var scale: Float? = null
@@ -270,6 +277,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testClick() = runComposeUiTest {
         var clickDetected = false
@@ -293,6 +301,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRightClick() = runComposeUiTest {
         var rightClickDetected = false
@@ -316,6 +325,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDoubleClick() = runComposeUiTest {
         var doubleClickDetected = false
@@ -343,6 +353,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testTripleClick() = runComposeUiTest {
         var clickCount = 0
@@ -369,6 +380,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLongClick() = runComposeUiTest {
         var longClickDetected = false
@@ -396,6 +408,7 @@ class TrackpadInputTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDragAndDrop() = runComposeUiTest {
         var dragOffset = Offset.Zero

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -45,6 +45,7 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class DesktopParagraphTest : SkikoComposeTestBase() {
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -115,6 +115,7 @@ class ComposeSceneTest {
     @get:Rule
     val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop")
 
+    @Suppress("DEPRECATION")
     @get:Rule
     val composeRule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/HeadlessTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/HeadlessTest.kt
@@ -31,7 +31,9 @@ interface HeadlessTest
 /**
  * Runs [runComposeUiTest] but first verifies that the test is executed in headless mode.
  */
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalTestApi::class)
+@Deprecated("runComposeUiTest is deprecated")
 internal fun runHeadlessComposeUiTest(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     assertTrue(GraphicsEnvironment.isHeadless(), "This is a headless test, but it's run not in headless mode")
     block()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/key/KeyTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/key/KeyTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.input.key
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.common.truth.Truth.assertThat
 import java.awt.event.KeyEvent
@@ -25,9 +24,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@OptIn(ExperimentalComposeUiApi::class)
 @RunWith(JUnit4::class)
 class KeyTest {
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -332,6 +332,7 @@ class MouseMoveTest {
         collector.assertPositions(move = Offset(2f, 0f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `hover on scroll`() = runSkikoComposeUiTest(
         size = Size(100f, 100f),
@@ -370,6 +371,7 @@ class MouseMoveTest {
         collector2.assertCounts(enter = 1, exit = 1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `hover on scroll in lazy list`() = runSkikoComposeUiTest(
         size = Size(100f, 100f),

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.assertSame
 @OptIn(ExperimentalTestApi::class)
 class PointerTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun customPointerChanges() = runComposeUiTest {
         val toolkit = Toolkit.getDefaultToolkit()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/PlatformLocalizationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/PlatformLocalizationTest.kt
@@ -59,6 +59,7 @@ class PlatformLocalizationTest {
      * Verify that [LocalLocalization] is available to the composable passed to
      * [ComposeUiTest.setContent].
      */
+    @Suppress("DEPRECATION")
     @Test
     fun platformLocalizationExistsByDefaultInTest() = runComposeUiTest {
         var localization: PlatformLocalization? = null
@@ -74,6 +75,7 @@ class PlatformLocalizationTest {
      * default one.
      */
     @OptIn(ExperimentalFoundationApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun canOverridePlatformLocalizationInContextMenuArea() = runComposeUiTest {
         val customLocalization = object : PlatformLocalization {
@@ -158,6 +160,7 @@ class PlatformLocalizationTest {
      * Verify that providing a [PlatformLocalization] in [LocalLocalization] in the window scope
      * correctly overrides it in a [Popup].
      */
+    @Suppress("DEPRECATION")
     @Test
     fun canOverridePlatformLocalizationFromWindowToPopupScope() = runComposeUiTest {
         val customLocalization = object : PlatformLocalization {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/util/UpdateEffectTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/util/UpdateEffectTest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 
 @Ignore("b/271123970 Fails in AOSP. Will be fixed after upstreaming Compose for Desktop")
 internal class UpdateEffectTest {
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
@@ -43,8 +42,9 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 internal class DesktopCursorPositionTest {
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -66,6 +66,7 @@ import org.junit.Rule
 import org.junit.Test
 
 class DesktopPopupTest {
+    @Suppress("DEPRECATION")
     @get:Rule
     val rule = createComposeRule()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -682,6 +682,7 @@ class DialogWindowTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `can save Unspecified dialog size`() = runComposeUiTest {
         val expectedState = DialogState(size = DpSize.Unspecified)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/WindowStateTest.kt
@@ -616,6 +616,7 @@ class WindowStateTest {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `can save Unspecified window size`() = runComposeUiTest {
         val expectedState = WindowState(size = DpSize.Unspecified)

--- a/compose/ui/ui/src/iosTest/kotlin/androidx/compose/ui/platform/UiKitPlatformClipboardTest.kt
+++ b/compose/ui/ui/src/iosTest/kotlin/androidx/compose/ui/platform/UiKitPlatformClipboardTest.kt
@@ -29,6 +29,7 @@ class UiKitPlatformClipboardTest {
     // The unit tests can't use (copy/paste) the native UIPasteboard:
     // "Cannot connect to pasteboard server" - an error at runtime
 
+    @Suppress("DEPRECATION")
     @Test
     fun canGetLocalClipboard() = runComposeUiTest {
         var clipboard: Clipboard? = null
@@ -45,6 +46,7 @@ class UiKitPlatformClipboardTest {
         assertNotNull(nativeClipboard)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun smokeTestUseClipboardMethods() = runComposeUiTest {
         var clipboard: Clipboard? = null

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerUiTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerUiTest.kt
@@ -39,6 +39,7 @@ import kotlin.test.assertEquals
  */
 @OptIn(ExperimentalTestApi::class)
 class SelectionContainerUiTest {
+    @Suppress("DEPRECATION")
     @Test
     fun selectionContainerSetsTextPointerIcon() = runComposeUiTest {
         lateinit var pointerIconService: PointerIconService

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/draganddrop/DragAndDropTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/draganddrop/DragAndDropTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class DragAndDropTest {
+    @Suppress("DEPRECATION")
     @Test
     fun mouseDragTriggersDragStart() = runComposeUiTest {
         var transferDataCreated = false
@@ -64,6 +65,7 @@ class DragAndDropTest {
         assertTrue(transferDataCreated)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mouseLongPressDoesNotTriggerDragStart() = runComposeUiTest {
         var transferDataCreated = false
@@ -91,6 +93,7 @@ class DragAndDropTest {
         assertFalse(transferDataCreated)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touchLongPressTriggersDragStart() = runComposeUiTest {
         var transferDataCreated = false
@@ -116,6 +119,7 @@ class DragAndDropTest {
         assertTrue(transferDataCreated)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun touchDragDoesNotTriggerDragStart() = runComposeUiTest {
         var transferDataCreated = false

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
@@ -94,6 +94,7 @@ import org.jetbrains.skia.Bitmap
 @OptIn(ExperimentalTestApi::class)
 class CommonGraphicsLayerTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLayerBoundsPosition() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -119,6 +120,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testScale() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -141,6 +143,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testScaleConvenienceXY() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -161,6 +164,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testScaleConvenienceUniform() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -178,6 +182,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRotation() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -200,6 +205,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRotationConvenience() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -217,6 +223,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRotationPivot() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -241,6 +248,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testTranslationXY() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -262,6 +270,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testClip() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -285,6 +294,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testSiblingComparisons() = runComposeUiTest {
         var coords1: LayoutCoordinates? = null
@@ -324,6 +334,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCameraDistanceWithRotationY() = runComposeUiTest {
         val testTag = "parent"
@@ -351,6 +362,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testEmptyClip() = runComposeUiTest {
         val EmptyRectangle =
@@ -378,6 +390,7 @@ class CommonGraphicsLayerTest {
         onNodeWithTag(tag).captureToImage().assertPixels { Color.Blue }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testTotalClip() = runComposeUiTest {
         var coords: LayoutCoordinates? = null
@@ -398,6 +411,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testColorFilter() = runComposeUiTest {
         val testTag = "colorFilterTag"
@@ -422,6 +436,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testColorFilterAsScope() = runComposeUiTest {
         val testTag = "colorFilterTag"
@@ -446,6 +461,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testBlendMode() = runComposeUiTest {
         val testTag = "blendModeTag"
@@ -468,6 +484,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testBlendModeAsScope() = runComposeUiTest {
         val testTag = "blendModeTag"
@@ -517,6 +534,7 @@ class CommonGraphicsLayerTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testBlurEffect() = runComposeUiTest {
         val tag = "blurTag"
@@ -541,6 +559,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testZeroRadiusBlurDoesNotCrash() = runComposeUiTest {
         val tag = "blurTag"
@@ -548,6 +567,7 @@ class CommonGraphicsLayerTest {
         setContent { BoxBlur(tag, size, 0f) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testOffsetEffect() = runComposeUiTest {
         val tag = "blurTag"
@@ -575,6 +595,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun invalidateWhenWeHaveSemanticModifierAfterLayer() = runComposeUiTest {
         var color by mutableStateOf(Color.Red)
@@ -585,6 +606,7 @@ class CommonGraphicsLayerTest {
         onNodeWithTag("tag").captureToImage().assertPixels { color }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDpPixelConversions() = runComposeUiTest {
         var density: Density? = null
@@ -611,6 +633,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testClickOnScaledElement() = runComposeUiTest {
         var firstClicked = false
@@ -645,6 +668,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun usingNestedDerivedStateInGraphicsLayerBlock() = runComposeUiTest {
         val mutableState = mutableStateOf(1f)
@@ -671,6 +695,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertEquals(2f, valueReadInGraphicsLayer) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCompositingStrategyModulateAlpha() = runComposeUiTest {
         val tag = "testTag"
@@ -708,6 +733,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCompositingStrategyAlways() = runComposeUiTest {
         val tag = "testTag"
@@ -738,6 +764,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testCompositingStrategyAuto() = runComposeUiTest {
         val tag = "testTag"
@@ -772,6 +799,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testGraphicsLayerScopeSize() = runComposeUiTest {
         val widthDp = 200.dp
@@ -801,6 +829,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testGraphicsLayerSizeAfterRelayout() = runComposeUiTest {
         var composableSize by mutableStateOf(20.dp)
@@ -848,6 +877,7 @@ class CommonGraphicsLayerTest {
         assertEquals(sizePx, drawScopeHeight)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removingGraphicsLayerInvalidatesParentLayer() = runComposeUiTest {
         var toggle by mutableStateOf(true)
@@ -881,6 +911,7 @@ class CommonGraphicsLayerTest {
     // Repro test for b/298520326. Unfortunately, this test does not successfully reproduce the
     // issue prior to the "fix", so is not a valid regression test. The act of calling
     // `captureToImage()` causes the bug to disappear.
+    @Suppress("DEPRECATION")
     @Test
     fun removingGraphicsLayerInvalidatesParentLayer2() = runComposeUiTest {
         var toggle by mutableStateOf(false)
@@ -925,6 +956,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun removingGraphicsLayerModifierResetsItsAction() = runComposeUiTest {
         var addGraphicsLayer by mutableStateOf(true)
@@ -951,6 +983,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertEquals(Rect(0f, 0f, 10f, 10f), coordinates.boundsInRoot()) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun invalidationAfterMovingMovableContentWithLayer() = runComposeUiTest {
         var moveContent by mutableStateOf(false)
@@ -978,6 +1011,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertThat(counterReadInDrawing).isEqualTo(counter) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatingLayerPropertiesAfterMovingMovableContent() = runComposeUiTest {
         var moveContent by mutableStateOf(false)
@@ -1005,6 +1039,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertThat(counterReadInLayerBlock).isEqualTo(counter) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatingValueIsNotCausingRemeasureOrRelayout() = runComposeUiTest {
         var translationX by mutableStateOf(0f)
@@ -1044,6 +1079,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun updatingLambdaIsNotCausingRemeasureOrRelayout() = runComposeUiTest {
         var lambda by mutableStateOf<GraphicsLayerScope.() -> Unit>({})
@@ -1083,6 +1119,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun addingLayerForChildDoesntTriggerChildRelayout() = runComposeUiTest {
         var relayoutCount = 0
@@ -1130,6 +1167,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun movingChildsLayerDoesntTriggerChildRelayout() = runComposeUiTest {
         var relayoutCount = 0
@@ -1169,6 +1207,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun placingWithExplicitLayerDraws() = runComposeUiTest {
         setContent {
@@ -1189,6 +1228,7 @@ class CommonGraphicsLayerTest {
         onNodeWithTag("tag").captureToImage().assertPixels(IntSize(10, 10)) { Color.Blue }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun placingWithExplicitLayerSetsCorrectSizeAndOffset() = runComposeUiTest {
         lateinit var layer: GraphicsLayer
@@ -1215,6 +1255,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun layerIsNotReleasedWhenWeStopPlacingIt() = runComposeUiTest {
         lateinit var layer: GraphicsLayer
@@ -1241,6 +1282,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertFalse(layer.isReleased) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun switchingFromExplicitLayerToImplicit() = runComposeUiTest {
         var useExplicitLayer by mutableStateOf(true)
@@ -1275,6 +1317,7 @@ class CommonGraphicsLayerTest {
         onNodeWithTag("tag").captureToImage().assertPixels(IntSize(10, 10)) { Color.Blue }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun centerPivotIsUsedWhenWeCalculateBoundsBeforeLayerWasFirstDrawn() = runComposeUiTest {
         var bounds: Rect = Rect.Zero
@@ -1290,6 +1333,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertRectEqual(bounds, Rect(0f, 0f, 10f, 10f)) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun centerPivotIsCorrectlyCalculatedForOddSize() = runComposeUiTest {
         var bounds: Rect = Rect.Zero
@@ -1305,6 +1349,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertRectEqual(bounds, Rect(0f, 0f, 9f, 9f)) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun customPivotIsCalculatedCorrectlyWhenWeCalculateBoundsBeforeLayerWasFirstDrawn() = runComposeUiTest {
         var bounds: Rect = Rect.Zero
@@ -1325,6 +1370,7 @@ class CommonGraphicsLayerTest {
         runOnIdle { assertRectEqual(bounds, Rect(10f, 10f, 20f, 20f)) }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun reusedLayerIsRedrawn() = runComposeUiTest {
         val drawRed = mutableStateOf(true)
@@ -1356,6 +1402,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun layerIsCorrectlyRecreatedWithClipAppliedAfterReuse() = runComposeUiTest {
         var switch by mutableStateOf(true)
@@ -1390,6 +1437,7 @@ class CommonGraphicsLayerTest {
         assertPixels()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun layerIsCorrectlyRecreatedWithClipAppliedWhenMoved() = runComposeUiTest {
         var switch by mutableStateOf(true)
@@ -1427,6 +1475,7 @@ class CommonGraphicsLayerTest {
         assertPixels()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLayerOutsetsWithImplicitClipToBounds() = runComposeUiTest {
         val outerBoxSizePx = 100
@@ -1472,6 +1521,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLayerOutsetsUpdatesCorrectly() = runComposeUiTest {
         val outerBoxSizePx = 100
@@ -1529,6 +1579,7 @@ class CommonGraphicsLayerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLayerOutsetsWithPivot() = runComposeUiTest {
         val outerBoxSizePx = 100

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/RootGraphicsLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/RootGraphicsLayerTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.Test
 class RootGraphicsLayerTest {
     private val size = Size(100.0f, 60.0f)
 
+    @Suppress("DEPRECATION")
     @Test
     fun rootLayerRedrawnAfterRootRemoval() = runSkikoComposeUiTest(size) {
         var showContent by mutableStateOf(true)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/vector/VectorPainterNestedDrawTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/vector/VectorPainterNestedDrawTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 class VectorPainterNestedDrawTest {
 
     // Verify VectorPainter draws correctly when nested inside another Painter
+    @Suppress("DEPRECATION")
     @Test
     fun vectorPainterDrawsInsideCustomPainter() = runSkikoComposeUiTest(Size(100f, 100f)) {
         setContent {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/GraphicsLayerWithInputTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/GraphicsLayerWithInputTest.kt
@@ -42,6 +42,7 @@ import kotlin.test.assertNotEquals
 @OptIn(ExperimentalTestApi::class)
 class GraphicsLayerWithInputTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testClickOnScaledBox() = runSkikoComposeUiTest {
         var clickCounter = 0

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -322,6 +322,7 @@ class PointerIconTest : SkikoComposeTestBase() {
     }
 
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun resetsToDefault() = runSkikoComposeUiTest(Size(width = 100f, height = 100f)) {
         var show by mutableStateOf(true)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/LayoutTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/LayoutTest.kt
@@ -38,6 +38,7 @@ import kotlin.test.assertEquals
 @ExperimentalTestApi
 class LayoutTest {
 
+    @Suppress("DEPRECATION")
     @Test
     // Issue: https://youtrack.jetbrains.com/issue/CMP-2696
     fun layoutInMovableContent() = runSkikoComposeUiTest {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/OnFirstVisibleTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/OnFirstVisibleTest.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalTestApi::class)
 class OnFirstVisibleTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun callOnFirstVisible() = runSkikoComposeUiTest(Size(100f, 200f)) {
         class ItemState(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/DepthSortedSetTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/DepthSortedSetTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class DepthSortedSetTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun sortedByDepth() = runSkikoComposeUiTest {
         val owner = MockOwner()
@@ -52,6 +53,7 @@ class DepthSortedSetTest {
         assertTrue(set.isEmpty())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun sortedByDepthWithItemsOfTheSameDepth() = runSkikoComposeUiTest {
         val owner = MockOwner()
@@ -82,6 +84,7 @@ class DepthSortedSetTest {
         assertTrue(set.isEmpty())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun modifyingSetWhileWeIterate() = runSkikoComposeUiTest {
         val owner = MockOwner()
@@ -129,6 +132,7 @@ class DepthSortedSetTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun modifyingDepthAfterAddingThrows() = runSkikoComposeUiTest {
         val owner = MockOwner()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerLayerTest.kt
@@ -518,6 +518,7 @@ class OwnerLayerTest : SkikoComposeTestBase() {
     // it is currently hard to isolate Snapshot changes
     // because SnapshotStateObserver/sendApplyNotifications are coupled with global state
     @OptIn(ExperimentalTestApi::class)
+    @Suppress("DEPRECATION")
     @Test
     fun invalidate_on_state_change() = runComposeUiTest {
         runOnUiThread {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerSnapshotObserverTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerSnapshotObserverTest.kt
@@ -45,6 +45,7 @@ class OwnerSnapshotObserverTest {
      * [The issue where the bug was originally discovered](https://youtrack.jetbrains.com/issue/COMPOSE-595).
      * Also see [Slack discussion](https://kotlinlang.slack.com/archives/G010KHY484C/p1700136697942499).
      */
+    @Suppress("DEPRECATION")
     @Test
     fun onObserveReadsChangedCalledBeforeOnDispose() = runComposeUiTest {
         var value by mutableIntStateOf(0)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -50,9 +49,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 // Tests for fixed bugs
-@OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalTestApi::class)
 class GraphicLayerBugTest {
     // https://github.com/JetBrains/compose-multiplatform/issues/4681
+    @Suppress("DEPRECATION")
     @Test
     fun draw_invalidates_inside_complex_layout() = runComposeUiTest {
         var valueForDraw by mutableStateOf(0f)
@@ -89,6 +89,7 @@ class GraphicLayerBugTest {
     }
 
     // https://youtrack.jetbrains.com/issue/CMP-8491
+    @Suppress("DEPRECATION")
     @Test
     fun draw_invalidates_inside_scroll() = runSkikoComposeUiTest(Size(100f, 200f)) {
         class ItemState(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/HostDefaultProviderTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/HostDefaultProviderTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalTestApi::class)
 class HostDefaultProviderTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHostDefaultProviderGetLocalViewModelStoreOwner() = runSkikoComposeUiTest {
         var owner: ViewModelStoreOwner? = null
@@ -44,6 +45,7 @@ class HostDefaultProviderTest {
     interface TestRegistry
     val TestRegistryKey = object : HostDefaultKey<TestRegistry?> {}
 
+    @Suppress("DEPRECATION")
     @Test
     fun testHostDefaultProviderNull() = runSkikoComposeUiTest {
         val LocalTestRegistry = compositionLocalWithHostDefaultOf(TestRegistryKey)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -296,6 +296,7 @@ class RenderPhasesTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun stateWriteDuringLayoutDoesNotRemeasureBeforeDraw() = runSkikoComposeUiTest {
         // A write made during layout updates this draw, but its measure invalidation is handled by
@@ -326,6 +327,7 @@ class RenderPhasesTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun measurementInvalidatedSettlesBeforeDraw() = runSkikoComposeUiTest {
         val events = mutableListOf<String>()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
@@ -33,6 +33,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class)
 class WindowInfoTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun windowInfoContainerSize() = runSkikoComposeUiTest(
         size = Size(234f, 432f),

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -59,11 +59,11 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.fail
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.StandardTestDispatcher
 
 @OptIn(ExperimentalTestApi::class)
 class DialogTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun dialogIsCenteredInWindow() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -80,6 +80,7 @@ class DialogTest {
         onNodeWithTag(dialog.tag).assertPositionInRootIsEqualTo(30.dp, 30.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun openDialog() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -118,6 +119,7 @@ class DialogTest {
         background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun closeDialog() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -163,6 +165,7 @@ class DialogTest {
         background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun secondTouchDoesNotDismissPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -208,6 +211,7 @@ class DialogTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun secondaryButtonClickDoesNotDismissDialog() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -271,6 +275,7 @@ class DialogTest {
         assertEquals(2, lastValueInComposition)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun checkUpdatedDismissCallbackInDialog() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -316,6 +321,7 @@ class DialogTest {
         assertContentEquals(listOf(1, 1, 2, 1), eventList)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testComposeSceneLayerSetContent() = runSkikoComposeUiTest {
         var useContent2 by mutableStateOf(false)
@@ -347,6 +353,7 @@ class DialogTest {
         onNodeWithTag("content2").assertIsDisplayed()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDialogScrimColorChange() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -367,12 +374,13 @@ class DialogTest {
         captureToImage().assertPixels { Color.Blue }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testMovableContentWithDialogAnimation_noCrash() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {
         val text = mutableStateOf("Hello")
-        val content = movableContentOf() { Text(text.value) }
+        val content = movableContentOf { Text(text.value) }
         val showDialog = mutableStateOf(true)
         setContent {
             if (showDialog.value) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -80,6 +80,7 @@ import org.jetbrains.skia.Surface
 
 @OptIn(ExperimentalTestApi::class)
 class PopupTest : SkikoComposeTestBase() {
+    @Suppress("DEPRECATION")
     @Test
     fun passCompositionLocalsToPopup() = runSkikoComposeUiTest {
         val compositionLocal = staticCompositionLocalOf<Int> {
@@ -100,6 +101,7 @@ class PopupTest : SkikoComposeTestBase() {
     }
 
     // https://github.com/JetBrains/compose-multiplatform/issues/4558
+    @Suppress("DEPRECATION")
     @Test
     fun changeInStaticCompositionLocalVisibleImmediatelyInPopup() = runComposeUiTest {
         // Test that when the provided value of a staticCompositionLocalOf changes, the change is
@@ -135,6 +137,7 @@ class PopupTest : SkikoComposeTestBase() {
     }
 
     // https://github.com/JetBrains/compose-multiplatform/issues/3142
+    @Suppress("DEPRECATION")
     @Test
     fun passLayoutDirectionToPopup() = runSkikoComposeUiTest {
         lateinit var localLayoutDirection: LayoutDirection
@@ -156,6 +159,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun onDisposeInsidePopup() = runSkikoComposeUiTest {
         var isPopupShowing by mutableStateOf(true)
@@ -179,6 +183,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(isDisposed).isEqualTo(true)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun useDensityInsidePopup() = runSkikoComposeUiTest {
         var density by mutableStateOf(Density(2f, 1f))
@@ -199,6 +204,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(densityInsidePopup).isEqualTo(3f)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun callDismissIfClickedOutsideOfFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -223,6 +229,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun callDismissIfClickedOutsideOfNonFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -248,6 +255,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun callDismissIfClickedOutsideOfMultipleNonFocusablePopups() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -280,6 +288,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun callDismissForNonFocusablePopupsAbove() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -326,6 +335,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun callDismissForAboveFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -372,6 +382,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(2)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun passEventIfClickedOutsideOfNonFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -396,6 +407,7 @@ class PopupTest : SkikoComposeTestBase() {
         assertThat(onDismissRequestCallCount).isEqualTo(0)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun doNotPassEventIfClickedOutsideOfFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -416,6 +428,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedNoEvents()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun passEventIfClickedOutsideOfNonBlockingFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -439,6 +452,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun doNotPassEventIfClickedOutsideOfBlockingNonFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -460,6 +474,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedNoEvents()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun canScrollOutsideOfNonFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -476,6 +491,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedLast(PointerEventType.Scroll, Offset(10f, 10f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun cannotScrollOutsideOfFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -492,6 +508,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedNoEvents()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun openFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -538,6 +555,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun closeFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -589,6 +607,7 @@ class PopupTest : SkikoComposeTestBase() {
         background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun secondTouchDoesNotDismissPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -633,6 +652,7 @@ class PopupTest : SkikoComposeTestBase() {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun secondaryButtonClickDismissPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -667,6 +687,7 @@ class PopupTest : SkikoComposeTestBase() {
         onNodeWithTag(popup.tag).assertDoesNotExist()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun clippingEnabledPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -687,6 +708,7 @@ class PopupTest : SkikoComposeTestBase() {
         onNodeWithTag("box2").assertPositionInRootIsEqualTo(0.dp, 0.dp)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun clippingDisabledPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -751,6 +773,7 @@ class PopupTest : SkikoComposeTestBase() {
             ) // Matches parent position (if inside bounds)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun doNotLoseHoverOutsideOfPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
@@ -836,6 +859,7 @@ class PopupTest : SkikoComposeTestBase() {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun popupShownAtCorrectCoordinatesImmediately() = runSkikoComposeUiTest {
         val positionProvider = object : PopupPositionProvider {

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/ComposeUiTestUtils.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/ComposeUiTestUtils.kt
@@ -20,7 +20,9 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalTestApi::class)
+@Deprecated("v1.runComposeUiTest is deprecated")
 internal fun runComposeUiTestOnUiThread(block: ComposeUiTest.() -> Unit) {
     runComposeUiTest {
         runOnUiThread { block() }


### PR DESCRIPTION
Suppress the deprecation warnings on our use of the "v1" test APIs.

Fixes https://youtrack.jetbrains.com/issue/CMP-10483

## Testing
N/A

## Release Notes
N/A