### PR TITLE
Fix Linux Docker errors

### DIFF
--- a/androidx-settings-plugins-fork/settings.gradle
+++ b/androidx-settings-plugins-fork/settings.gradle
@@ -1,7 +1,7 @@
 apply from: "../buildSrc-fork/settingsScripts/out-setup.groovy"
 
 getGradle().beforeProject { project ->
-    def checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
+    def checkoutRoot = new File("${buildscript.sourceFile.parent}/..")
     init.chooseBuildDirectory(checkoutRoot, rootProject.name, project)
 }
 

--- a/buildSrc-fork/public/src/main/kotlin/androidx/build/SdkHelper.kt
+++ b/buildSrc-fork/public/src/main/kotlin/androidx/build/SdkHelper.kt
@@ -99,10 +99,7 @@ fun Project.getSupportRootFolder(): File {
  * This method assumes that the canonical root project directory is {@code frameworks/support}.
  */
 fun Project.getCheckoutRoot(): File {
-    if (!ProjectLayoutType.isPlayground(project)) {
-        throw IllegalStateException("repo checkout root is not available in playground project layout")
-    }
-    return project.getSupportRootFolder().parentFile.parentFile
+    return project.getSupportRootFolder()
 }
 
 /** Returns the path to the konan prebuilts folder (e.g. <root>/prebuilts/androidx/konan). */

--- a/buildSrc-fork/repos.gradle
+++ b/buildSrc-fork/repos.gradle
@@ -19,12 +19,12 @@ if (supportRootFolder == null) {
     throw new RuntimeException("Canonical root project directory is not set. You must specify " +
             "ext.supportRootFolder before including this script")
 }
-// Makes strong assumptions about the project structure.
-def checkoutRoot = supportRootFolder.parentFile.parentFile
 
 ext.repos = new Properties()
-ext.repos.checkoutRoot = checkoutRoot.absolutePath
-ext.repos.prebuiltsRoot = new File(checkoutRoot, "prebuilts").absolutePath
+ext.repos.checkoutRoot = supportRootFolder.absolutePath
+
+ // TODO remove, it doesn't exist and not used in fork
+ext.repos.prebuiltsRoot = new File(supportRootFolder, "prebuilts").absolutePath
 
 /**
  * Adds maven repositories to the given repository handler.

--- a/gradlew
+++ b/gradlew
@@ -67,13 +67,13 @@
 ##############################################################################
 
 # --------- androidx specific code needed for build server. ------------------
-if [ "$PROJECT_MODE" == "AOSP" ]; then
+if [ "$PROJECT_MODE" = "AOSP" ]; then
     SCRIPT_PATH="$(cd $(dirname $0) && pwd -P)"
     if [ -n "$OUT_DIR" ] ; then
         mkdir -p "$OUT_DIR"
         OUT_DIR="$(cd $OUT_DIR && pwd -P)"
         export TMPDIR="$OUT_DIR/tmp"
-    elif [[ $SCRIPT_PATH == /google/cog/* ]] ; then
+    elif [[ $SCRIPT_PATH = /google/cog/* ]] ; then
         export OUT_DIR="$HOME/androidxout"
     else
         CHECKOUT_ROOT="$(cd $SCRIPT_PATH/../.. && pwd -P)"

--- a/settings-fork.gradle
+++ b/settings-fork.gradle
@@ -21,19 +21,9 @@ skikoSetup.defineSkikoInVersionCatalog(settings)
 
 def supportRootFolder = buildscript.sourceFile.getParentFile()
 
-/* In JetBrains Fork we don't force Android Studio usage.
-// Abort immediately if we're running in Studio, but not a managed instance of Studio.
-if (startParameter.projectProperties.containsKey('android.injected.invoked.from.ide')) {
-    def expectedAgpVersion = System.getenv().get("EXPECTED_AGP_VERSION")
-    if (expectedAgpVersion == null) {
-        throw new Exception("Android Studio must be run from studiow or gradlew studio.")
-    }
-}
-*/
-
-// Makes strong assumptions about the project structure.
+ // TODO remove, it doesn't exist and not used in fork
 def prebuiltsRoot = new File(
-        supportRootFolder.parentFile.parentFile,
+        supportRootFolder,
         "prebuilts"
 ).absolutePath
 def rootProjectRepositories


### PR DESCRIPTION
Fixes:
- working in a Docker container that mounts repo as the root folder
- creating `out` dir outside of the repo
- printing a warning on Linux when running `gradlew`: `[ isn't supported`

## Release Notes
N/A