### PR TITLE
Add material3-ripple to publication

### DIFF
--- a/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
+++ b/buildSrc-fork/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
@@ -86,6 +86,7 @@ object JetBrainsPublication {
             ComposeComponent(":compose:material3:material3"),
             ComposeComponent(":compose:material3:material3-window-size-class"),
             ComposeComponent(":compose:material3:material3-adaptive-navigation-suite"),
+            ComposeComponent(":compose:material3:material3-ripple"),
         ),
         "COMPOSE_MATERIAL3_ADAPTIVE" to listOf(
             ComposeComponent(":compose:material3:adaptive:adaptive"),

--- a/compose/material3/material3-ripple/api/desktop/material3-ripple.api
+++ b/compose/material3/material3-ripple/api/desktop/material3-ripple.api
@@ -1,0 +1,98 @@
+public final class androidx/compose/material3/ripple/RippleKt {
+	public static final fun createRippleModifierNode (Landroidx/compose/foundation/interaction/InteractionSource;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/node/DelegatableNode;
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration {
+	public static final field $stable I
+	public synthetic fun <init> (ZFLandroidx/compose/ui/graphics/ColorProducer;Landroidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration;Landroidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration;Landroidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration;Landroidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor ()Landroidx/compose/ui/graphics/ColorProducer;
+	public final fun getDragConfiguration ()Landroidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration;
+	public final fun getFocusConfiguration ()Landroidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration;
+	public final fun getHoverConfiguration ()Landroidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration;
+	public final fun getPressConfiguration ()Landroidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration;
+	public final fun getRadius-D9Ej5fM ()F
+	public fun hashCode ()I
+	public final fun isBounded ()Z
+}
+
+public abstract interface class androidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration {
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration$None : androidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration {
+	public static final field $stable I
+	public static final field INSTANCE Landroidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration$None;
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration$Opacity : androidx/compose/material3/ripple/RippleNodeConfiguration$DragConfiguration {
+	public static final field $stable I
+	public fun <init> (F)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlpha ()F
+	public fun hashCode ()I
+}
+
+public abstract interface class androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration {
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration$InsetRing : androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/ui/graphics/Shape;FFLandroidx/compose/ui/graphics/ColorProducer;FFLandroidx/compose/ui/graphics/ColorProducer;Landroidx/compose/animation/core/FiniteAnimationSpec;Landroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFocusingAnimationSpec ()Landroidx/compose/animation/core/FiniteAnimationSpec;
+	public final fun getInnerStrokeColor ()Landroidx/compose/ui/graphics/ColorProducer;
+	public final fun getInnerStrokeInset-D9Ej5fM ()F
+	public final fun getInnerStrokeWidth-D9Ej5fM ()F
+	public final fun getOuterStrokeColor ()Landroidx/compose/ui/graphics/ColorProducer;
+	public final fun getOuterStrokeInset-D9Ej5fM ()F
+	public final fun getOuterStrokeWidth-D9Ej5fM ()F
+	public final fun getShape ()Landroidx/compose/ui/graphics/Shape;
+	public final fun getUnfocusingAnimationSpec ()Landroidx/compose/animation/core/FiniteAnimationSpec;
+	public fun hashCode ()I
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration$None : androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration {
+	public static final field $stable I
+	public static final field INSTANCE Landroidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration$None;
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration$Opacity : androidx/compose/material3/ripple/RippleNodeConfiguration$FocusConfiguration {
+	public static final field $stable I
+	public fun <init> (F)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlpha ()F
+	public fun hashCode ()I
+}
+
+public abstract interface class androidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration {
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration$None : androidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration {
+	public static final field $stable I
+	public static final field INSTANCE Landroidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration$None;
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration$Opacity : androidx/compose/material3/ripple/RippleNodeConfiguration$HoverConfiguration {
+	public static final field $stable I
+	public fun <init> (F)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlpha ()F
+	public fun hashCode ()I
+}
+
+public abstract interface class androidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration {
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration$None : androidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration {
+	public static final field $stable I
+	public static final field INSTANCE Landroidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration$None;
+}
+
+public final class androidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration$Opacity : androidx/compose/material3/ripple/RippleNodeConfiguration$PressConfiguration {
+	public static final field $stable I
+	public fun <init> (F)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlpha ()F
+	public fun hashCode ()I
+}
+

--- a/compose/material3/material3-ripple/api/material3-ripple.klib.api
+++ b/compose/material3/material3-ripple/api/material3-ripple.klib.api
@@ -1,0 +1,134 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.jetbrains.compose.material3:material3-ripple>
+final class androidx.compose.material3.ripple/RippleNodeConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration|null[0]
+    constructor <init>(kotlin/Boolean, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/ColorProducer, androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration, androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration, androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration, androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration) // androidx.compose.material3.ripple/RippleNodeConfiguration.<init>|<init>(kotlin.Boolean;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.ColorProducer;androidx.compose.material3.ripple.RippleNodeConfiguration.PressConfiguration;androidx.compose.material3.ripple.RippleNodeConfiguration.FocusConfiguration;androidx.compose.material3.ripple.RippleNodeConfiguration.HoverConfiguration;androidx.compose.material3.ripple.RippleNodeConfiguration.DragConfiguration){}[0]
+
+    final val color // androidx.compose.material3.ripple/RippleNodeConfiguration.color|{}color[0]
+        final fun <get-color>(): androidx.compose.ui.graphics/ColorProducer // androidx.compose.material3.ripple/RippleNodeConfiguration.color.<get-color>|<get-color>(){}[0]
+    final val dragConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.dragConfiguration|{}dragConfiguration[0]
+        final fun <get-dragConfiguration>(): androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.dragConfiguration.<get-dragConfiguration>|<get-dragConfiguration>(){}[0]
+    final val focusConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.focusConfiguration|{}focusConfiguration[0]
+        final fun <get-focusConfiguration>(): androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.focusConfiguration.<get-focusConfiguration>|<get-focusConfiguration>(){}[0]
+    final val hoverConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.hoverConfiguration|{}hoverConfiguration[0]
+        final fun <get-hoverConfiguration>(): androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.hoverConfiguration.<get-hoverConfiguration>|<get-hoverConfiguration>(){}[0]
+    final val isBounded // androidx.compose.material3.ripple/RippleNodeConfiguration.isBounded|{}isBounded[0]
+        final fun <get-isBounded>(): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.isBounded.<get-isBounded>|<get-isBounded>(){}[0]
+    final val pressConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.pressConfiguration|{}pressConfiguration[0]
+        final fun <get-pressConfiguration>(): androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.pressConfiguration.<get-pressConfiguration>|<get-pressConfiguration>(){}[0]
+    final val radius // androidx.compose.material3.ripple/RippleNodeConfiguration.radius|{}radius[0]
+        final fun <get-radius>(): androidx.compose.ui.unit/Dp // androidx.compose.material3.ripple/RippleNodeConfiguration.radius.<get-radius>|<get-radius>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.hashCode|hashCode(){}[0]
+
+    sealed interface DragConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration|null[0]
+        final class Opacity : androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity|null[0]
+            constructor <init>(kotlin/Float) // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity.<init>|<init>(kotlin.Float){}[0]
+
+            final val alpha // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity.alpha|{}alpha[0]
+                final fun <get-alpha>(): kotlin/Float // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity.alpha.<get-alpha>|<get-alpha>(){}[0]
+
+            final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.Opacity.hashCode|hashCode(){}[0]
+        }
+
+        final object None : androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.DragConfiguration.None|null[0]
+    }
+
+    sealed interface FocusConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration|null[0]
+        final class InsetRing : androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing|null[0]
+            constructor <init>(androidx.compose.ui.graphics/Shape, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/ColorProducer, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/ColorProducer, androidx.compose.animation.core/FiniteAnimationSpec<kotlin/Float>, androidx.compose.animation.core/FiniteAnimationSpec<kotlin/Float>) // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.<init>|<init>(androidx.compose.ui.graphics.Shape;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.ColorProducer;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.ColorProducer;androidx.compose.animation.core.FiniteAnimationSpec<kotlin.Float>;androidx.compose.animation.core.FiniteAnimationSpec<kotlin.Float>){}[0]
+
+            final val focusingAnimationSpec // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.focusingAnimationSpec|{}focusingAnimationSpec[0]
+                final fun <get-focusingAnimationSpec>(): androidx.compose.animation.core/FiniteAnimationSpec<kotlin/Float> // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.focusingAnimationSpec.<get-focusingAnimationSpec>|<get-focusingAnimationSpec>(){}[0]
+            final val innerStrokeColor // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeColor|{}innerStrokeColor[0]
+                final fun <get-innerStrokeColor>(): androidx.compose.ui.graphics/ColorProducer // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeColor.<get-innerStrokeColor>|<get-innerStrokeColor>(){}[0]
+            final val innerStrokeInset // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeInset|{}innerStrokeInset[0]
+                final fun <get-innerStrokeInset>(): androidx.compose.ui.unit/Dp // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeInset.<get-innerStrokeInset>|<get-innerStrokeInset>(){}[0]
+            final val innerStrokeWidth // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeWidth|{}innerStrokeWidth[0]
+                final fun <get-innerStrokeWidth>(): androidx.compose.ui.unit/Dp // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.innerStrokeWidth.<get-innerStrokeWidth>|<get-innerStrokeWidth>(){}[0]
+            final val outerStrokeColor // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeColor|{}outerStrokeColor[0]
+                final fun <get-outerStrokeColor>(): androidx.compose.ui.graphics/ColorProducer // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeColor.<get-outerStrokeColor>|<get-outerStrokeColor>(){}[0]
+            final val outerStrokeInset // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeInset|{}outerStrokeInset[0]
+                final fun <get-outerStrokeInset>(): androidx.compose.ui.unit/Dp // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeInset.<get-outerStrokeInset>|<get-outerStrokeInset>(){}[0]
+            final val outerStrokeWidth // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeWidth|{}outerStrokeWidth[0]
+                final fun <get-outerStrokeWidth>(): androidx.compose.ui.unit/Dp // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.outerStrokeWidth.<get-outerStrokeWidth>|<get-outerStrokeWidth>(){}[0]
+            final val shape // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.shape|{}shape[0]
+                final fun <get-shape>(): androidx.compose.ui.graphics/Shape // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.shape.<get-shape>|<get-shape>(){}[0]
+            final val unfocusingAnimationSpec // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.unfocusingAnimationSpec|{}unfocusingAnimationSpec[0]
+                final fun <get-unfocusingAnimationSpec>(): androidx.compose.animation.core/FiniteAnimationSpec<kotlin/Float> // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.unfocusingAnimationSpec.<get-unfocusingAnimationSpec>|<get-unfocusingAnimationSpec>(){}[0]
+
+            final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.InsetRing.hashCode|hashCode(){}[0]
+        }
+
+        final class Opacity : androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity|null[0]
+            constructor <init>(kotlin/Float) // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity.<init>|<init>(kotlin.Float){}[0]
+
+            final val alpha // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity.alpha|{}alpha[0]
+                final fun <get-alpha>(): kotlin/Float // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity.alpha.<get-alpha>|<get-alpha>(){}[0]
+
+            final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.Opacity.hashCode|hashCode(){}[0]
+        }
+
+        final object None : androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.FocusConfiguration.None|null[0]
+    }
+
+    sealed interface HoverConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration|null[0]
+        final class Opacity : androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity|null[0]
+            constructor <init>(kotlin/Float) // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity.<init>|<init>(kotlin.Float){}[0]
+
+            final val alpha // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity.alpha|{}alpha[0]
+                final fun <get-alpha>(): kotlin/Float // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity.alpha.<get-alpha>|<get-alpha>(){}[0]
+
+            final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.Opacity.hashCode|hashCode(){}[0]
+        }
+
+        final object None : androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.HoverConfiguration.None|null[0]
+    }
+
+    sealed interface PressConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration|null[0]
+        final class Opacity : androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration { // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity|null[0]
+            constructor <init>(kotlin/Float) // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity.<init>|<init>(kotlin.Float){}[0]
+
+            final val alpha // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity.alpha|{}alpha[0]
+                final fun <get-alpha>(): kotlin/Float // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity.alpha.<get-alpha>|<get-alpha>(){}[0]
+
+            final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.Opacity.hashCode|hashCode(){}[0]
+        }
+
+        final object None : androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration // androidx.compose.material3.ripple/RippleNodeConfiguration.PressConfiguration.None|null[0]
+    }
+}
+
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop[0]
+final val androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop|#static{}androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop[0]
+
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_None$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_DragConfiguration_Opacity$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_InsetRing$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_None$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_FocusConfiguration_Opacity$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_None$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_HoverConfiguration_Opacity$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_None$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop_getter(): kotlin/Int // androidx.compose.material3.ripple/androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop_getter|androidx_compose_material3_ripple_RippleNodeConfiguration_PressConfiguration_Opacity$stableprop_getter(){}[0]
+final fun androidx.compose.material3.ripple/createRippleModifierNode(androidx.compose.foundation.interaction/InteractionSource, kotlin/Function0<androidx.compose.material3.ripple/RippleNodeConfiguration>): androidx.compose.ui.node/DelegatableNode // androidx.compose.material3.ripple/createRippleModifierNode|createRippleModifierNode(androidx.compose.foundation.interaction.InteractionSource;kotlin.Function0<androidx.compose.material3.ripple.RippleNodeConfiguration>){}[0]


### PR DESCRIPTION
Fixes CI failure after merging https://github.com/JetBrains/compose-multiplatform-core/pull/3352:
```
Execution failed for task ':compose:material3:material3:jbVerifyDependencyVersions' (registered by plugin class 'org.jetbrains.androidx.build.JetBrainsAndroidXImplPlugin'). org.gradle.api.GradleException: Project with version 1.13.0-alpha01+snapshot.default may not take a dependency on less-stable artifact org.jetbrains.compose.material3:material3-ripple:9999.0.0-SNAPSHOT for configuration commonMainImplementation. Dependency versions must be at least as stable as the project version.
```

## Testing
```
./gradlew publishComposeJbToMavenLocal
```

## Release Notes
N/A