### PR TITLE
Fix NullPointerException crash in Demp app

### DIFF
--- a/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/NativePopupExample.ios.kt
+++ b/compose/mpp/demo/src/iosMain/kotlin/androidx/compose/mpp/demo/NativePopupExample.ios.kt
@@ -47,6 +47,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import platform.UIKit.*
 import platform.Foundation.*
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 /*
  * Copyright 2023 The Android Open Source Project
@@ -131,11 +133,11 @@ private fun NativeNavigationPage() {
                 DisposableEffect(Unit) {
                     val url = NSURL(string = "https://cataas.com/cat/says/$index")
                     val task = NSURLSession.sharedSession.dataTaskWithURL(url, completionHandler = { data, response, error ->
-                        if (data == null) {
-                            return@dataTaskWithURL
-                        }
+                        val decoded = data?.let { UIImage.imageWithData(it) } ?: return@dataTaskWithURL
 
-                        image = UIImage(data = data)
+                        dispatch_async(dispatch_get_main_queue()) {
+                            image = decoded
+                        }
                     })
                     task.resume()
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10704/iOS-Crash-when-quickly-pushing-ComposeUIViewControllers-containing-UIKitView-image-updates

## Release Notes
N/A