### PR TITLE
Support scrolling via A11Y Tools in web browsers

### DIFF
--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/lazy/LazyList.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/lazy/LazyList.web.kt
@@ -18,4 +18,4 @@ package androidx.compose.foundation.lazy
 
 import androidx.compose.runtime.Composable
 
-@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 3

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/lazy/LazyList.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/lazy/LazyList.web.kt
@@ -17,5 +17,21 @@
 package androidx.compose.foundation.lazy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.LocalPlatformScreenReader
 
-@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 3
+/**
+ * A minimum number of preloaded elements to allow the web accessibility engine to traverse the
+ * lazy list elements without delay for semantic tree reloads after scrolling.
+ */
+private const val SCREEN_READER_BEYOND_BOUNDS_ITEM_COUNT = 3
+
+@OptIn(InternalComposeUiApi::class)
+@Composable
+internal actual fun defaultLazyListBeyondBoundsItemCount(): Int {
+    return if (LocalPlatformScreenReader.current.isActive) {
+        SCREEN_READER_BEYOND_BOUNDS_ITEM_COUNT
+    } else {
+        0
+    }
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
@@ -97,11 +97,7 @@ internal class A11YScrollController(
             SemanticsProperties.VerticalScrollAxisRange
         }
         val isReverse = this.getOrNull(key)?.reverseScrolling == true
-        return if (isReverse) {
-            -1f
-        } else {
-            1f
-        }
+        return if (isReverse) -1f else 1f
     }
 
     fun getScrollOffset(semanticsNode: SemanticsNode): Offset {
@@ -138,14 +134,15 @@ internal class A11YScrollController(
             vertical = verticalRange != null,
         )
 
-        when {
-            verticalRange != null && horizontalRange == null ->
-                htmlNode.setAttribute("aria-orientation", "vertical")
-            horizontalRange != null && verticalRange == null ->
-                htmlNode.setAttribute("aria-orientation", "horizontal")
-            else ->
-                // Bidirectional scroll, or no scroll range at all
-                htmlNode.removeAttribute("aria-orientation")
+        val ariaOrientation = when {
+            verticalRange != null && horizontalRange == null -> "vertical"
+            horizontalRange != null && verticalRange == null -> "horizontal"
+            else -> null // Bidirectional scroll, or no scroll range at all
+        }
+        if (ariaOrientation != null) {
+            htmlNode.setAttribute("aria-orientation", ariaOrientation)
+        } else {
+            htmlNode.removeAttribute("aria-orientation")
         }
 
         val density = semanticsNode.layoutNode.density.density
@@ -198,6 +195,8 @@ internal class A11YScrollController(
             val element = idToA11YNode[id] ?: return@forEach
             val sizer = domScrollSizers[id] ?: return@forEach
             if (sizer.parentElement !== element || element.firstElementChild !== sizer) {
+                // The sizer element is not mirroring any SemanticsNode, it's synthetic.
+                // We added it first.
                 element.insertBefore(sizer, element.firstChild)
             }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.accessibility
+
+import androidx.collection.MutableIntSet
+import androidx.collection.MutableScatterMap
+import androidx.collection.ScatterMap
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import kotlin.math.abs
+import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.Event
+
+internal class A11YScrollState(
+    private val idToA11YNode: ScatterMap<Int, HTMLElement>,
+    private val a11yNodeToSemanticsNode: ScatterMap<HTMLElement, SemanticsNode>,
+) {
+    // Scroll offsets are in CSS pixels. Pending values come from the current Compose state;
+    // applied values distinguish our own DOM writes from browser- or AT-initiated scrolling.
+    private val appliedScrollOffsets = MutableScatterMap<Int, Offset>()
+    private val pendingScrollOffsets = MutableScatterMap<Int, Offset>()
+    private val scrollSizers = MutableScatterMap<Int, HTMLElement>()
+    private val scrollListenersAttached = MutableIntSet()
+
+    /**
+     * Translates browser scroll offset changes into Compose semantics scroll actions. Scroll events
+     * do not bubble, so this listener is attached to every A11Y DOM scroll container.
+     */
+    private val onScroll: (Event) -> Unit = onScroll@ { event ->
+        val element = event.target as? HTMLElement ?: return@onScroll
+        val semanticsNode = a11yNodeToSemanticsNode[element] ?: return@onScroll
+        val applied = appliedScrollOffsets[semanticsNode.id] ?: return@onScroll
+        val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+        val deltaCssPx = actual - applied
+        if (deltaCssPx.isCloseTo(Offset.Zero)) return@onScroll
+
+        // Subsequent events before the next semantics sync must use the latest DOM offset.
+        appliedScrollOffsets[semanticsNode.id] = actual
+
+        val config = semanticsNode.config
+        if (config.contains(SemanticsProperties.Disabled)) return@onScroll
+
+        val density = semanticsNode.layoutNode.density.density
+        val horizontalDirection =
+            if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
+                    ?.reverseScrolling == true
+            ) -1f else 1f
+        val verticalDirection =
+            if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
+                    ?.reverseScrolling == true
+            ) -1f else 1f
+
+        config.getOrNull(SemanticsActions.ScrollBy)?.action?.invoke(
+            deltaCssPx.x * density * horizontalDirection,
+            deltaCssPx.y * density * verticalDirection,
+        )
+    }
+
+    fun getScrollOffset(semanticsNode: SemanticsNode): Offset {
+        return pendingScrollOffsets[semanticsNode.id]
+            ?: appliedScrollOffsets[semanticsNode.id]
+            ?: Offset.Zero
+    }
+
+    fun getScrollSizer(semanticsNode: SemanticsNode): HTMLElement? {
+        return scrollSizers[semanticsNode.id]
+    }
+
+    /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
+    fun syncNodeScrollability(
+        semanticsNode: SemanticsNode,
+        config: SemanticsConfiguration,
+        htmlNode: HTMLElement,
+    ) {
+        val nodeId = semanticsNode.id
+        val verticalRange = config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
+        val horizontalRange = config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
+        val canScroll = (verticalRange != null || horizontalRange != null) &&
+            config.getOrNull(SemanticsActions.ScrollBy)?.action != null
+
+        if (!canScroll) {
+            if (scrollListenersAttached.remove(nodeId)) {
+                htmlNode.removeEventListener("scroll", onScroll)
+                resetScrollContainerStyle(htmlNode)
+                htmlNode.removeAttribute("aria-orientation")
+                scrollSizers.remove(nodeId)?.remove()
+                appliedScrollOffsets.remove(nodeId)
+                pendingScrollOffsets.remove(nodeId)
+            }
+            return
+        }
+
+        setScrollContainerStyle(
+            htmlNode,
+            horizontal = horizontalRange != null,
+            vertical = verticalRange != null,
+        )
+
+        when {
+            verticalRange != null && horizontalRange == null ->
+                htmlNode.setAttribute("aria-orientation", "vertical")
+            horizontalRange != null && verticalRange == null ->
+                htmlNode.setAttribute("aria-orientation", "horizontal")
+            else ->
+                // Bidirectional scroll, or no scroll range at all
+                htmlNode.removeAttribute("aria-orientation")
+        }
+
+        val density = semanticsNode.layoutNode.density.density
+        val maxHorizontal = horizontalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
+        val maxVertical = verticalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
+        val viewportWidth = semanticsNode.size.width / density
+        val viewportHeight = semanticsNode.size.height / density
+        val contentWidth =
+            (viewportWidth + maxHorizontal / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
+        val contentHeight =
+            (viewportHeight + maxVertical / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
+
+        val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
+        setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
+
+        // Lazy layouts expose estimated accessibility offsets rather than physical pixels.
+        // Preserve their current DOM offset instead of interpreting the estimate as scrollTop/Left.
+        val isLazyLayout = config.contains(SemanticsActions.ScrollToIndex)
+        val scrollLeft = if (isLazyLayout) {
+            htmlNode.scrollLeft.toFloat()
+        } else {
+            horizontalRange?.let { range ->
+                val value = range.value().coerceIn(0f, maxHorizontal)
+                ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
+                    .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
+            } ?: 0f
+        }
+        val scrollTop = if (isLazyLayout) {
+            htmlNode.scrollTop.toFloat()
+        } else {
+            verticalRange?.let { range ->
+                val value = range.value().coerceIn(0f, maxVertical)
+                ((if (range.reverseScrolling) maxVertical - value else value) / density)
+                    .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
+            } ?: 0f
+        }
+        pendingScrollOffsets[nodeId] = Offset(scrollLeft, scrollTop)
+
+        if (scrollListenersAttached.add(nodeId)) {
+            htmlNode.addEventListener("scroll", onScroll)
+        }
+    }
+
+    /** Applies Compose scroll offsets after DOM structure and scroll extents have been updated. */
+    fun applyScrollOffsets() {
+        pendingScrollOffsets.forEach { id, offset ->
+            val element = idToA11YNode[id] ?: return@forEach
+            val sizer = scrollSizers[id] ?: return@forEach
+            if (sizer.parentElement !== element || element.firstElementChild !== sizer) {
+                element.insertBefore(sizer, element.firstChild)
+            }
+
+            val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+            val lastApplied = appliedScrollOffsets[id]
+            if (lastApplied != null && offset.isCloseTo(lastApplied) && !actual.isCloseTo(lastApplied)) {
+                // Preserve a browser/AT offset until its asynchronous scroll event is handled.
+                return@forEach
+            }
+
+            appliedScrollOffsets[id] = offset
+            if (abs(actual.x - offset.x) >= SCROLL_EPSILON_CSS_PX) {
+                element.scrollLeft = offset.x.toDouble()
+            }
+            if (abs(actual.y - offset.y) >= SCROLL_EPSILON_CSS_PX) {
+                element.scrollTop = offset.y.toDouble()
+            }
+        }
+        pendingScrollOffsets.clear()
+    }
+
+    fun clear() {
+        scrollListenersAttached.forEach { id ->
+            idToA11YNode[id]?.removeEventListener("scroll", onScroll)
+        }
+        appliedScrollOffsets.clear()
+        pendingScrollOffsets.clear()
+        scrollSizers.clear()
+        scrollListenersAttached.clear()
+    }
+
+    fun onNodeRemoved(id: Int, htmlNode: HTMLElement?) {
+        htmlNode?.removeEventListener("scroll", onScroll)
+
+        appliedScrollOffsets.remove(id)
+        pendingScrollOffsets.remove(id)
+        scrollSizers.remove(id)
+        scrollListenersAttached.remove(id)
+    }
+}
+
+internal const val MAX_SCROLL_EXTENT_CSS_PX = 4_000_000f
+internal const val SCROLL_EPSILON_CSS_PX = 0.5f
+
+internal fun Offset.isCloseTo(other: Offset): Boolean =
+    abs(x - other.x) < SCROLL_EPSILON_CSS_PX && abs(y - other.y) < SCROLL_EPSILON_CSS_PX
+
+internal fun createScrollSizer(): HTMLElement {
+    val sizer = document.createElement("div") as HTMLElement
+    sizer.setAttribute("aria-hidden", "true")
+    sizer.style.position = "absolute"
+    return sizer
+}
+
+internal fun setScrollContainerStyle(
+    element: HTMLElement,
+    horizontal: Boolean,
+    vertical: Boolean,
+) {
+    // language=javascript
+    js(
+        """
+        element.style.overflowX = horizontal ? "scroll" : "hidden";
+        element.style.overflowY = vertical ? "scroll" : "hidden";
+        element.style.scrollbarWidth = "none";
+        """
+    )
+}
+
+internal fun resetScrollContainerStyle(element: HTMLElement) {
+    // language=javascript
+    js(
+        """
+        element.style.overflowX = "";
+        element.style.overflowY = "";
+        element.style.scrollbarWidth = "";
+        """
+    )
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
@@ -20,6 +20,7 @@ import androidx.collection.MutableIntSet
 import androidx.collection.MutableScatterMap
 import androidx.collection.ScatterMap
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -30,49 +31,77 @@ import kotlinx.browser.document
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
 
-internal class A11YScrollState(
+/**
+ * Responsibilities:
+ * 1. For Compose nodes with scrollable semantics,
+ * it configures and maintains the scrollable html node / container. See [syncNodeScrollability]
+ * 2. It ensures the two-way synchronization of scroll offsets:
+ * - from Compose to A11Y tree. See [applyScrollOffsets]
+ * - from A11Y tree back to Compose. See [onScroll]
+ *
+ * The scrollability of the html node is achieved by placing a "sizer" element exceeding
+ * the container's sizes (according to Compose-specified scroll ranges), allowing AT and browser
+ * manipulate the scroll offset.
+ */
+internal class A11YScrollController(
     private val idToA11YNode: ScatterMap<Int, HTMLElement>,
     private val a11yNodeToSemanticsNode: ScatterMap<HTMLElement, SemanticsNode>,
 ) {
-    // Scroll offsets are in CSS pixels. Pending values come from the current Compose state;
-    // applied values distinguish our own DOM writes from browser- or AT-initiated scrolling.
+
+    // When a browser (or AT) updates the scroll offset of the node in A11Y tree, we apply the
+    // new offset to SemanticsNode and save the applied offset value here.
     private val appliedScrollOffsets = MutableScatterMap<Int, Offset>()
+
+    // When we process the Semantics updates, we record the new scroll offsets here.
+    // After the new offsets get applied to A11Y tree, the map is cleared.
     private val pendingScrollOffsets = MutableScatterMap<Int, Offset>()
-    private val scrollSizers = MutableScatterMap<Int, HTMLElement>()
+
+    // The non-semantic elements inserted into A11Y scrollable nodes.
+    // To make the scrollable a11y node aware of the possible scroll ranges, they include this "sizer"
+    // element, which width/height equal to the scrollable viewport size + max scroll distance.
+    private val domScrollSizers = MutableScatterMap<Int, HTMLElement>()
+
+    // Tracking the nodes with a scroll listener:
     private val scrollListenersAttached = MutableIntSet()
 
-    /**
-     * Translates browser scroll offset changes into Compose semantics scroll actions. Scroll events
-     * do not bubble, so this listener is attached to every A11Y DOM scroll container.
-     */
+    // Applies the browser scroll offset changes to the corresponding SemanticsNode - SemanticsActions.ScrollBy
     private val onScroll: (Event) -> Unit = onScroll@ { event ->
         val element = event.target as? HTMLElement ?: return@onScroll
         val semanticsNode = a11yNodeToSemanticsNode[element] ?: return@onScroll
         val applied = appliedScrollOffsets[semanticsNode.id] ?: return@onScroll
         val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+
         val deltaCssPx = actual - applied
         if (deltaCssPx.isCloseTo(Offset.Zero)) return@onScroll
-
-        // Subsequent events before the next semantics sync must use the latest DOM offset.
         appliedScrollOffsets[semanticsNode.id] = actual
 
         val config = semanticsNode.config
         if (config.contains(SemanticsProperties.Disabled)) return@onScroll
 
         val density = semanticsNode.layoutNode.density.density
-        val horizontalDirection =
-            if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
-                    ?.reverseScrolling == true
-            ) -1f else 1f
-        val verticalDirection =
-            if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
-                    ?.reverseScrolling == true
-            ) -1f else 1f
+        val horizontalDirection = config.getSupportedScrollDirection(horizontal = true)
+        val verticalDirection = config.getSupportedScrollDirection(horizontal = false)
 
         config.getOrNull(SemanticsActions.ScrollBy)?.action?.invoke(
             deltaCssPx.x * density * horizontalDirection,
             deltaCssPx.y * density * verticalDirection,
         )
+    }
+
+    private fun SemanticsConfiguration.getSupportedScrollDirection(
+        horizontal: Boolean
+    ): Float {
+        val key = if (horizontal) {
+            SemanticsProperties.HorizontalScrollAxisRange
+        } else {
+            SemanticsProperties.VerticalScrollAxisRange
+        }
+        val isReverse = this.getOrNull(key)?.reverseScrolling == true
+        return if (isReverse) {
+            -1f
+        } else {
+            1f
+        }
     }
 
     fun getScrollOffset(semanticsNode: SemanticsNode): Offset {
@@ -82,10 +111,9 @@ internal class A11YScrollState(
     }
 
     fun getScrollSizer(semanticsNode: SemanticsNode): HTMLElement? {
-        return scrollSizers[semanticsNode.id]
+        return domScrollSizers[semanticsNode.id]
     }
 
-    /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
     fun syncNodeScrollability(
         semanticsNode: SemanticsNode,
         config: SemanticsConfiguration,
@@ -99,12 +127,7 @@ internal class A11YScrollState(
 
         if (!canScroll) {
             if (scrollListenersAttached.remove(nodeId)) {
-                htmlNode.removeEventListener("scroll", onScroll)
-                resetScrollContainerStyle(htmlNode)
-                htmlNode.removeAttribute("aria-orientation")
-                scrollSizers.remove(nodeId)?.remove()
-                appliedScrollOffsets.remove(nodeId)
-                pendingScrollOffsets.remove(nodeId)
+                removeScrollProperties(htmlNode, nodeId)
             }
             return
         }
@@ -130,35 +153,29 @@ internal class A11YScrollState(
         val maxVertical = verticalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
         val viewportWidth = semanticsNode.size.width / density
         val viewportHeight = semanticsNode.size.height / density
-        val contentWidth =
-            (viewportWidth + maxHorizontal / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
-        val contentHeight =
-            (viewportHeight + maxVertical / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
 
-        val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
-        setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
+        val sizerElementWidth = (viewportWidth + maxHorizontal / density)
+            .coerceAtMost(MAX_SUPPORTED_SCROLL_CSS_PX)
+        val sizerElementHeight = (viewportHeight + maxVertical / density)
+            .coerceAtMost(MAX_SUPPORTED_SCROLL_CSS_PX)
 
-        // Lazy layouts expose estimated accessibility offsets rather than physical pixels.
-        // Preserve their current DOM offset instead of interpreting the estimate as scrollTop/Left.
-        val isLazyLayout = config.contains(SemanticsActions.ScrollToIndex)
-        val scrollLeft = if (isLazyLayout) {
-            htmlNode.scrollLeft.toFloat()
-        } else {
-            horizontalRange?.let { range ->
-                val value = range.value().coerceIn(0f, maxHorizontal)
-                ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
-                    .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
-            } ?: 0f
-        }
-        val scrollTop = if (isLazyLayout) {
-            htmlNode.scrollTop.toFloat()
-        } else {
-            verticalRange?.let { range ->
-                val value = range.value().coerceIn(0f, maxVertical)
-                ((if (range.reverseScrolling) maxVertical - value else value) / density)
-                    .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
-            } ?: 0f
-        }
+        val sizerElement = domScrollSizers.getOrPut(nodeId) { createDomScrollSizer() }
+        setSizeAndPosition(sizerElement, 0f, 0f, sizerElementWidth, sizerElementHeight)
+
+        val scrollLeft = horizontalRange?.toCssScrollOffset(
+            maxValue = maxHorizontal,
+            viewportSize = viewportWidth,
+            contentSize = sizerElementWidth,
+            density = density,
+        ) ?: 0f
+
+        val scrollTop = verticalRange?.toCssScrollOffset(
+            maxValue = maxVertical,
+            viewportSize = viewportHeight,
+            contentSize = sizerElementHeight,
+            density = density,
+        ) ?: 0f
+
         pendingScrollOffsets[nodeId] = Offset(scrollLeft, scrollTop)
 
         if (scrollListenersAttached.add(nodeId)) {
@@ -166,11 +183,20 @@ internal class A11YScrollState(
         }
     }
 
-    /** Applies Compose scroll offsets after DOM structure and scroll extents have been updated. */
+    private fun removeScrollProperties(htmlNode: HTMLElement, nodeId: Int) {
+        resetScrollContainerStyle(htmlNode)
+        htmlNode.removeEventListener("scroll", onScroll)
+        htmlNode.removeAttribute("aria-orientation")
+        domScrollSizers.remove(nodeId)?.remove()
+        appliedScrollOffsets.remove(nodeId)
+        pendingScrollOffsets.remove(nodeId)
+    }
+
+    // Applies Compose scroll offsets to DOM
     fun applyScrollOffsets() {
         pendingScrollOffsets.forEach { id, offset ->
             val element = idToA11YNode[id] ?: return@forEach
-            val sizer = scrollSizers[id] ?: return@forEach
+            val sizer = domScrollSizers[id] ?: return@forEach
             if (sizer.parentElement !== element || element.firstElementChild !== sizer) {
                 element.insertBefore(sizer, element.firstChild)
             }
@@ -199,7 +225,7 @@ internal class A11YScrollState(
         }
         appliedScrollOffsets.clear()
         pendingScrollOffsets.clear()
-        scrollSizers.clear()
+        domScrollSizers.clear()
         scrollListenersAttached.clear()
     }
 
@@ -208,18 +234,21 @@ internal class A11YScrollState(
 
         appliedScrollOffsets.remove(id)
         pendingScrollOffsets.remove(id)
-        scrollSizers.remove(id)
+        domScrollSizers.remove(id)
         scrollListenersAttached.remove(id)
     }
 }
 
-internal const val MAX_SCROLL_EXTENT_CSS_PX = 4_000_000f
+// We don't expect such huge layouts in Compose (it's likely too expensive), so
+// keep synthetic scroll range well below known browser layout limits (>10kk).
+internal const val MAX_SUPPORTED_SCROLL_CSS_PX = 4_000_000f
 internal const val SCROLL_EPSILON_CSS_PX = 0.5f
 
-internal fun Offset.isCloseTo(other: Offset): Boolean =
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Offset.isCloseTo(other: Offset): Boolean =
     abs(x - other.x) < SCROLL_EPSILON_CSS_PX && abs(y - other.y) < SCROLL_EPSILON_CSS_PX
 
-internal fun createScrollSizer(): HTMLElement {
+internal fun createDomScrollSizer(): HTMLElement {
     val sizer = document.createElement("div") as HTMLElement
     sizer.setAttribute("aria-hidden", "true")
     sizer.style.position = "absolute"
@@ -250,4 +279,22 @@ internal fun resetScrollContainerStyle(element: HTMLElement) {
         element.style.scrollbarWidth = "";
         """
     )
+}
+
+
+private fun ScrollAxisRange.toCssScrollOffset(
+    maxValue: Float,
+    viewportSize: Float,
+    contentSize: Float,
+    density: Float,
+): Float {
+    val value = value().coerceIn(0f, maxValue)
+    val offset = if (reverseScrolling) {
+        maxValue - value
+    } else {
+        value
+    }
+
+    return (offset / density)
+        .coerceIn(0f, (contentSize - viewportSize).coerceAtLeast(0f))
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform.accessibility
 
-import androidx.collection.MutableIntSet
 import androidx.collection.MutableScatterMap
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
@@ -26,11 +25,8 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastJoinToString
-import kotlin.js.js
-import kotlin.math.abs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
@@ -179,12 +175,8 @@ internal class ComposeWebSemanticsListener(
     private val targetParentToChildren = MutableScatterMap<HTMLElement, MutableList<HTMLElement>>()
     private val targetChildToParent = MutableScatterMap<HTMLElement, HTMLElement>()
 
-    // Scroll offsets are in CSS pixels. Pending values come from the current Compose state;
-    // applied values distinguish our own DOM writes from browser- or AT-initiated scrolling.
-    private val appliedScrollOffsets = MutableScatterMap<Int, Offset>()
-    private val pendingScrollOffsets = MutableScatterMap<Int, Offset>()
-    private val scrollSizers = MutableScatterMap<Int, HTMLElement>()
-    private val scrollListenersAttached = MutableIntSet()
+    // Responsible for scroll synchronization between Compose and Dom tree
+    private val a11YScrollState = A11YScrollState(idToA11YNode, a11yNodeToSemanticsNode)
 
     /**
      * Event delegation: Single shared click listener for all a11y nodes with SemanticsActions.OnClick.
@@ -203,41 +195,6 @@ internal class ComposeWebSemanticsListener(
             config[SemanticsActions.OnClick].action?.invoke()
         }
     }
-
-    /**
-     * Translates browser scroll offset changes into Compose semantics scroll actions. Scroll events
-     * do not bubble, so this listener is attached to every A11Y DOM scroll container.
-     */
-    private val onScroll: (Event) -> Unit = onScroll@ { event ->
-        val element = event.target as? HTMLElement ?: return@onScroll
-        val semanticsNode = a11yNodeToSemanticsNode[element] ?: return@onScroll
-        val applied = appliedScrollOffsets[semanticsNode.id] ?: return@onScroll
-        val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
-        val deltaCssPx = actual - applied
-        if (deltaCssPx.isCloseTo(Offset.Zero)) return@onScroll
-
-        // Subsequent events before the next semantics sync must use the latest DOM offset.
-        appliedScrollOffsets[semanticsNode.id] = actual
-
-        val config = semanticsNode.config
-        if (config.contains(SemanticsProperties.Disabled)) return@onScroll
-
-        val density = semanticsNode.layoutNode.density.density
-        val horizontalDirection =
-            if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
-                    ?.reverseScrolling == true
-            ) -1f else 1f
-        val verticalDirection =
-            if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
-                    ?.reverseScrolling == true
-            ) -1f else 1f
-
-        config.getOrNull(SemanticsActions.ScrollBy)?.action?.invoke(
-            deltaCssPx.x * density * horizontalDirection,
-            deltaCssPx.y * density * verticalDirection,
-        )
-    }
-
 
     /**
      * Updates the A11Y DOM to mirror all current semantics owners using only necessary structural
@@ -273,16 +230,12 @@ internal class ComposeWebSemanticsListener(
         removedIds.forEach { id ->
             val htmlNode = idToA11YNode.remove(id)
             if (htmlNode != null) {
-                htmlNode.removeEventListener("scroll", onScroll)
                 a11yNodeToSemanticsNode.remove(htmlNode)
             }
-            appliedScrollOffsets.remove(id)
-            pendingScrollOffsets.remove(id)
-            scrollSizers.remove(id)
-            scrollListenersAttached.remove(id)
+            a11YScrollState.onNodeRemoved(id, htmlNode)
         }
 
-        applyScrollOffsets()
+        a11YScrollState.applyScrollOffsets()
         updateInertRoots()
     }
 
@@ -494,7 +447,7 @@ internal class ComposeWebSemanticsListener(
             htmlNode.removeAttribute("aria-modal")
         }
 
-        syncScrollability(semanticsNode, config, htmlNode)
+        a11YScrollState.syncNodeScrollability(semanticsNode, config, htmlNode)
 
         val density = semanticsNode.layoutNode.density.density
         // Use unclipped geometry so descendants retain their content-space positions outside a
@@ -515,9 +468,7 @@ internal class ComposeWebSemanticsListener(
             )
         } else {
             htmlNode.style.position = "absolute"
-            val parentScroll = pendingScrollOffsets[parentSemanticsNode.id]
-                ?: appliedScrollOffsets[parentSemanticsNode.id]
-                ?: Offset.Zero
+            val parentScroll = a11YScrollState.getScrollOffset(parentSemanticsNode)
             setSizeAndPosition(
                 htmlNode,
                 (positionInRoot.x - parentSemanticsNode.positionInRoot.x) / density + parentScroll.x,
@@ -526,113 +477,6 @@ internal class ComposeWebSemanticsListener(
                 height,
             )
         }
-    }
-
-
-    /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
-    private fun syncScrollability(
-        semanticsNode: SemanticsNode,
-        config: SemanticsConfiguration,
-        htmlNode: HTMLElement,
-    ) {
-        val nodeId = semanticsNode.id
-        val verticalRange = config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
-        val horizontalRange = config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
-        val canScroll = (verticalRange != null || horizontalRange != null) &&
-            config.getOrNull(SemanticsActions.ScrollBy)?.action != null
-
-        if (!canScroll) {
-            if (scrollListenersAttached.remove(nodeId)) {
-                htmlNode.removeEventListener("scroll", onScroll)
-                resetScrollContainerStyle(htmlNode)
-                htmlNode.removeAttribute("aria-orientation")
-                scrollSizers.remove(nodeId)?.remove()
-                appliedScrollOffsets.remove(nodeId)
-                pendingScrollOffsets.remove(nodeId)
-            }
-            return
-        }
-
-        setScrollContainerStyle(
-            htmlNode,
-            horizontal = horizontalRange != null,
-            vertical = verticalRange != null,
-        )
-        if ((verticalRange != null) xor (horizontalRange != null)) {
-            htmlNode.setAttribute(
-                "aria-orientation",
-                if (verticalRange != null) "vertical" else "horizontal",
-            )
-        } else {
-            htmlNode.removeAttribute("aria-orientation")
-        }
-
-        val density = semanticsNode.layoutNode.density.density
-        val maxHorizontal = horizontalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
-        val maxVertical = verticalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
-        val viewportWidth = semanticsNode.size.width / density
-        val viewportHeight = semanticsNode.size.height / density
-        val contentWidth =
-            (viewportWidth + maxHorizontal / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
-        val contentHeight =
-            (viewportHeight + maxVertical / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
-
-        val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
-        setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
-
-        // Lazy layouts expose estimated accessibility offsets rather than physical pixels.
-        // Preserve their current DOM offset instead of interpreting the estimate as scrollTop/Left.
-        val isLazyLayout = config.contains(SemanticsActions.ScrollToIndex)
-        val scrollLeft = if (isLazyLayout) {
-            htmlNode.scrollLeft.toFloat()
-        } else {
-            horizontalRange?.let { range ->
-                val value = range.value().coerceIn(0f, maxHorizontal)
-                ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
-                    .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
-            } ?: 0f
-        }
-        val scrollTop = if (isLazyLayout) {
-            htmlNode.scrollTop.toFloat()
-        } else {
-            verticalRange?.let { range ->
-                val value = range.value().coerceIn(0f, maxVertical)
-                ((if (range.reverseScrolling) maxVertical - value else value) / density)
-                    .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
-            } ?: 0f
-        }
-        pendingScrollOffsets[nodeId] = Offset(scrollLeft, scrollTop)
-
-        if (scrollListenersAttached.add(nodeId)) {
-            htmlNode.addEventListener("scroll", onScroll)
-        }
-    }
-
-    /** Applies Compose scroll offsets after DOM structure and scroll extents have been updated. */
-    private fun applyScrollOffsets() {
-        pendingScrollOffsets.forEach { id, offset ->
-            val element = idToA11YNode[id] ?: return@forEach
-            val sizer = scrollSizers[id] ?: return@forEach
-            if (sizer.parentElement !== element || element.firstElementChild !== sizer) {
-                element.insertBefore(sizer, element.firstChild)
-            }
-
-            val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
-            val lastApplied = appliedScrollOffsets[id]
-            if (lastApplied != null && offset.isCloseTo(lastApplied) && !actual.isCloseTo(lastApplied)) {
-                // Preserve a browser/AT offset until its asynchronous scroll event is handled.
-                return@forEach
-            }
-
-            appliedScrollOffsets[id] = offset
-            if (abs(actual.x - offset.x) >= SCROLL_EPSILON_CSS_PX) {
-                element.scrollLeft = offset.x.toDouble()
-            }
-            if (abs(actual.y - offset.y) >= SCROLL_EPSILON_CSS_PX) {
-                element.scrollTop = offset.y.toDouble()
-            }
-        }
-        pendingScrollOffsets.clear()
     }
 
     /**
@@ -727,7 +571,7 @@ internal class ComposeWebSemanticsListener(
             targetTextAndLinks.add(textParts.last())
         }
 
-        updateTextAndLinks(htmlNode, targetTextAndLinks, scrollSizers[node.id])
+        updateTextAndLinks(htmlNode, targetTextAndLinks, a11YScrollState.getScrollSizer(node))
         deferredChildren?.let { pushNodesForTraversal(it, htmlNode) }
         return htmlNode
     }
@@ -786,9 +630,7 @@ internal class ComposeWebSemanticsListener(
         if (!hasStarted || hasStopped) return
 
         webSemanticsRoot.removeEventListener("click", onClick)
-        scrollListenersAttached.forEach { id ->
-            idToA11YNode[id]?.removeEventListener("scroll", onScroll)
-        }
+        a11YScrollState.clear()
 
         dfsSemanticsNodes.clear()
         dfsA11YParents.clear()
@@ -796,10 +638,6 @@ internal class ComposeWebSemanticsListener(
         a11yNodeToSemanticsNode.clear()
         targetParentToChildren.clear()
         targetChildToParent.clear()
-        appliedScrollOffsets.clear()
-        pendingScrollOffsets.clear()
-        scrollSizers.clear()
-        scrollListenersAttached.clear()
 
         invalidationChannel.close()
         syncTriggerChannel.close()
@@ -808,43 +646,4 @@ internal class ComposeWebSemanticsListener(
         removeAllChildrenOf(webSemanticsRoot)
         hasStopped = true
     }
-}
-
-private const val MAX_SCROLL_EXTENT_CSS_PX = 4_000_000f
-private const val SCROLL_EPSILON_CSS_PX = 0.5f
-
-private fun Offset.isCloseTo(other: Offset): Boolean =
-    abs(x - other.x) < SCROLL_EPSILON_CSS_PX && abs(y - other.y) < SCROLL_EPSILON_CSS_PX
-
-private fun createScrollSizer(): HTMLElement {
-    val sizer = document.createElement("div") as HTMLElement
-    sizer.setAttribute("aria-hidden", "true")
-    sizer.style.position = "absolute"
-    return sizer
-}
-
-private fun setScrollContainerStyle(
-    element: HTMLElement,
-    horizontal: Boolean,
-    vertical: Boolean,
-) {
-    // language=javascript
-    js(
-        """
-        element.style.overflowX = horizontal ? "scroll" : "hidden";
-        element.style.overflowY = vertical ? "scroll" : "hidden";
-        element.style.scrollbarWidth = "none";
-        """
-    )
-}
-
-private fun resetScrollContainerStyle(element: HTMLElement) {
-    // language=javascript
-    js(
-        """
-        element.style.overflowX = "";
-        element.style.overflowY = "";
-        element.style.scrollbarWidth = "";
-        """
-    )
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -479,8 +479,12 @@ internal class ComposeWebSemanticsListener(
 
         if (isCollection) {
             // Prevent VoiceOver from announcing every child added as a lazy collection scrolls.
-            htmlNode.setAttribute("aria-live", "off")
-        } else {
+            // Avoid rewriting the attribute during every sync because that can itself invalidate
+            // the focused accessibility object.
+            if (htmlNode.getAttribute("aria-live") != "off") {
+                htmlNode.setAttribute("aria-live", "off")
+            }
+        } else if (htmlNode.hasAttribute("aria-live")) {
             htmlNode.removeAttribute("aria-live")
         }
 
@@ -511,7 +515,9 @@ internal class ComposeWebSemanticsListener(
             )
         } else {
             htmlNode.style.position = "absolute"
-            val parentScroll = scrollOffsetForGeometry(parentSemanticsNode.id, htmlParent)
+            val parentScroll = pendingScrollOffsets[parentSemanticsNode.id]
+                ?: appliedScrollOffsets[parentSemanticsNode.id]
+                ?: Offset.Zero
             setSizeAndPosition(
                 htmlNode,
                 (positionInRoot.x - parentSemanticsNode.positionInRoot.x) / density + parentScroll.x,
@@ -522,19 +528,6 @@ internal class ComposeWebSemanticsListener(
         }
     }
 
-
-    private fun scrollOffsetForGeometry(nodeId: Int, element: HTMLElement): Offset {
-        val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
-        val lastApplied = appliedScrollOffsets[nodeId]
-
-        return if (lastApplied != null && !actual.isCloseTo(lastApplied)) {
-            // The browser changed the offset and its asynchronous scroll event may still be pending.
-            actual
-        } else {
-            // The DOM still has our previous offset; use the new Compose offset during this sync.
-            pendingScrollOffsets[nodeId] ?: actual
-        }
-    }
 
     /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
     private fun syncScrollability(
@@ -587,6 +580,8 @@ internal class ComposeWebSemanticsListener(
         val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
         setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
 
+        // Lazy layouts expose estimated accessibility offsets rather than physical pixels.
+        // Preserve their current DOM offset instead of interpreting the estimate as scrollTop/Left.
         val isLazyLayout = config.contains(SemanticsActions.ScrollToIndex)
         val scrollLeft = if (isLazyLayout) {
             htmlNode.scrollLeft.toFloat()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -471,7 +471,18 @@ internal class ComposeWebSemanticsListener(
             htmlNode.removeAttribute("aria-disabled")
         }
 
-        setA11YAriaRole(element = htmlNode, config.getRoleId())
+        val roleId = config.getRoleId()
+        setA11YAriaRole(element = htmlNode, roleId)
+
+        val isCollection =
+            roleId == AriaRoleId.List || roleId == AriaRoleId.Grid
+
+        if (isCollection) {
+            // Prevent VoiceOver from announcing every child added as a lazy collection scrolls.
+            htmlNode.setAttribute("aria-live", "off")
+        } else {
+            htmlNode.removeAttribute("aria-live")
+        }
 
         if (config.contains(SemanticsProperties.IsDialog)) {
             htmlNode.setAttribute("aria-modal", "true")
@@ -500,9 +511,7 @@ internal class ComposeWebSemanticsListener(
             )
         } else {
             htmlNode.style.position = "absolute"
-            val parentScroll = pendingScrollOffsets[parentSemanticsNode.id]
-                ?: appliedScrollOffsets[parentSemanticsNode.id]
-                ?: Offset.Zero
+            val parentScroll = scrollOffsetForGeometry(parentSemanticsNode.id, htmlParent)
             setSizeAndPosition(
                 htmlNode,
                 (positionInRoot.x - parentSemanticsNode.positionInRoot.x) / density + parentScroll.x,
@@ -513,6 +522,19 @@ internal class ComposeWebSemanticsListener(
         }
     }
 
+
+    private fun scrollOffsetForGeometry(nodeId: Int, element: HTMLElement): Offset {
+        val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+        val lastApplied = appliedScrollOffsets[nodeId]
+
+        return if (lastApplied != null && !actual.isCloseTo(lastApplied)) {
+            // The browser changed the offset and its asynchronous scroll event may still be pending.
+            actual
+        } else {
+            // The DOM still has our previous offset; use the new Compose offset during this sync.
+            pendingScrollOffsets[nodeId] ?: actual
+        }
+    }
 
     /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
     private fun syncScrollability(
@@ -565,16 +587,25 @@ internal class ComposeWebSemanticsListener(
         val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
         setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
 
-        val scrollLeft = horizontalRange?.let { range ->
-            val value = range.value().coerceIn(0f, maxHorizontal)
-            ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
-                .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
-        } ?: 0f
-        val scrollTop = verticalRange?.let { range ->
-            val value = range.value().coerceIn(0f, maxVertical)
-            ((if (range.reverseScrolling) maxVertical - value else value) / density)
-                .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
-        } ?: 0f
+        val isLazyLayout = config.contains(SemanticsActions.ScrollToIndex)
+        val scrollLeft = if (isLazyLayout) {
+            htmlNode.scrollLeft.toFloat()
+        } else {
+            horizontalRange?.let { range ->
+                val value = range.value().coerceIn(0f, maxHorizontal)
+                ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
+                    .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
+            } ?: 0f
+        }
+        val scrollTop = if (isLazyLayout) {
+            htmlNode.scrollTop.toFloat()
+        } else {
+            verticalRange?.let { range ->
+                val value = range.value().coerceIn(0f, maxVertical)
+                ((if (range.reverseScrolling) maxVertical - value else value) / density)
+                    .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
+            } ?: 0f
+        }
         pendingScrollOffsets[nodeId] = Offset(scrollLeft, scrollTop)
 
         if (scrollListenersAttached.add(nodeId)) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform.accessibility
 
+import androidx.collection.MutableIntSet
 import androidx.collection.MutableScatterMap
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
@@ -25,8 +26,11 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastJoinToString
+import kotlin.js.js
+import kotlin.math.abs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
@@ -175,6 +179,13 @@ internal class ComposeWebSemanticsListener(
     private val targetParentToChildren = MutableScatterMap<HTMLElement, MutableList<HTMLElement>>()
     private val targetChildToParent = MutableScatterMap<HTMLElement, HTMLElement>()
 
+    // Scroll offsets are in CSS pixels. Pending values come from the current Compose state;
+    // applied values distinguish our own DOM writes from browser- or AT-initiated scrolling.
+    private val appliedScrollOffsets = MutableScatterMap<Int, Offset>()
+    private val pendingScrollOffsets = MutableScatterMap<Int, Offset>()
+    private val scrollSizers = MutableScatterMap<Int, HTMLElement>()
+    private val scrollListenersAttached = MutableIntSet()
+
     /**
      * Event delegation: Single shared click listener for all a11y nodes with SemanticsActions.OnClick.
      * It's expected to be triggered by A11Y tools and tests (element.click()), not by pointer input.
@@ -191,6 +202,40 @@ internal class ComposeWebSemanticsListener(
         ) {
             config[SemanticsActions.OnClick].action?.invoke()
         }
+    }
+
+    /**
+     * Translates browser scroll offset changes into Compose semantics scroll actions. Scroll events
+     * do not bubble, so this listener is attached to every A11Y DOM scroll container.
+     */
+    private val onScroll: (Event) -> Unit = onScroll@ { event ->
+        val element = event.target as? HTMLElement ?: return@onScroll
+        val semanticsNode = a11yNodeToSemanticsNode[element] ?: return@onScroll
+        val applied = appliedScrollOffsets[semanticsNode.id] ?: return@onScroll
+        val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+        val deltaCssPx = actual - applied
+        if (deltaCssPx.isCloseTo(Offset.Zero)) return@onScroll
+
+        // Subsequent events before the next semantics sync must use the latest DOM offset.
+        appliedScrollOffsets[semanticsNode.id] = actual
+
+        val config = semanticsNode.config
+        if (config.contains(SemanticsProperties.Disabled)) return@onScroll
+
+        val density = semanticsNode.layoutNode.density.density
+        val horizontalDirection =
+            if (config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
+                    ?.reverseScrolling == true
+            ) -1f else 1f
+        val verticalDirection =
+            if (config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
+                    ?.reverseScrolling == true
+            ) -1f else 1f
+
+        config.getOrNull(SemanticsActions.ScrollBy)?.action?.invoke(
+            deltaCssPx.x * density * horizontalDirection,
+            deltaCssPx.y * density * verticalDirection,
+        )
     }
 
 
@@ -225,13 +270,19 @@ internal class ComposeWebSemanticsListener(
             }
         }
 
-        removedIds.forEach {
-            val htmlNode = idToA11YNode.remove(it)
+        removedIds.forEach { id ->
+            val htmlNode = idToA11YNode.remove(id)
             if (htmlNode != null) {
+                htmlNode.removeEventListener("scroll", onScroll)
                 a11yNodeToSemanticsNode.remove(htmlNode)
             }
+            appliedScrollOffsets.remove(id)
+            pendingScrollOffsets.remove(id)
+            scrollSizers.remove(id)
+            scrollListenersAttached.remove(id)
         }
 
+        applyScrollOffsets()
         updateInertRoots()
     }
 
@@ -284,9 +335,9 @@ internal class ComposeWebSemanticsListener(
                 // We split text into parts: plain text fragments and links.
                 // That's why a text node doesn't push its children to the traversal queue.
                 // It handles its link children itself:
-                syncTextNode(node, config, children, rootPosition)
+                syncTextNode(node, config, children, htmlParent, rootPosition)
             } else {
-                syncNode(node, config, rootPosition)
+                syncNode(node, config, htmlParent, rootPosition)
                     .also { pushNodesForTraversal(children, it) }
             }
             check(htmlNode !== htmlParent) { "A11Y node ${node.id} cannot be its own parent" }
@@ -314,6 +365,7 @@ internal class ComposeWebSemanticsListener(
     private fun syncNode(
         semanticsNode: SemanticsNode,
         config: SemanticsConfiguration,
+        htmlParent: HTMLElement,
         rootPosition: Offset,
         text: String? = null,
     ): HTMLElement {
@@ -321,7 +373,7 @@ internal class ComposeWebSemanticsListener(
 
         var htmlNode = idToA11YNode[currentId]
         if (htmlNode != null) {
-            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, text)
+            syncNodeProperties(semanticsNode, config, htmlNode, htmlParent, rootPosition, text)
         } else {
             htmlNode = document.createElement("div") as HTMLElement
             htmlNode.style.apply {
@@ -330,7 +382,15 @@ internal class ComposeWebSemanticsListener(
             }
 
             idToA11YNode[currentId] = htmlNode
-            syncNodeProperties(semanticsNode, config, htmlNode, rootPosition, text, justCreated = true)
+            syncNodeProperties(
+                semanticsNode,
+                config,
+                htmlNode,
+                htmlParent,
+                rootPosition,
+                text,
+                justCreated = true,
+            )
         }
 
         a11yNodeToSemanticsNode[htmlNode] = semanticsNode
@@ -372,6 +432,7 @@ internal class ComposeWebSemanticsListener(
         semanticsNode: SemanticsNode,
         config: SemanticsConfiguration,
         htmlNode: HTMLElement,
+        htmlParent: HTMLElement,
         rootOffset: Offset,
         text: String?,
         justCreated: Boolean = false,
@@ -418,16 +479,135 @@ internal class ComposeWebSemanticsListener(
             htmlNode.removeAttribute("aria-modal")
         }
 
-        val density = semanticsNode.layoutNode.density
-        semanticsNode.boundsInRoot.let { rect ->
-            val newPosition = rootOffset + rect.topLeft.div(density.density)
-            val width = rect.width.div(density.density)
-            val height = rect.height.div(density.density)
+        syncScrollability(semanticsNode, config, htmlNode)
 
-            setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width, height)
+        val density = semanticsNode.layoutNode.density.density
+        // Use unclipped geometry so descendants retain their content-space positions outside a
+        // scroll viewport. The browser needs those positions to scroll them into view for AT.
+        val positionInRoot = semanticsNode.positionInRoot
+        val width = semanticsNode.size.width / density
+        val height = semanticsNode.size.height / density
+        val parentSemanticsNode = a11yNodeToSemanticsNode[htmlParent]
+
+        if (parentSemanticsNode == null) {
+            htmlNode.style.position = "fixed"
+            setSizeAndPosition(
+                htmlNode,
+                rootOffset.x + positionInRoot.x / density,
+                rootOffset.y + positionInRoot.y / density,
+                width,
+                height,
+            )
+        } else {
+            htmlNode.style.position = "absolute"
+            val parentScroll = pendingScrollOffsets[parentSemanticsNode.id]
+                ?: appliedScrollOffsets[parentSemanticsNode.id]
+                ?: Offset.Zero
+            setSizeAndPosition(
+                htmlNode,
+                (positionInRoot.x - parentSemanticsNode.positionInRoot.x) / density + parentScroll.x,
+                (positionInRoot.y - parentSemanticsNode.positionInRoot.y) / density + parentScroll.y,
+                width,
+                height,
+            )
         }
     }
 
+
+    /** Makes scroll semantics visible to the browser as a real CSS scroll container. */
+    private fun syncScrollability(
+        semanticsNode: SemanticsNode,
+        config: SemanticsConfiguration,
+        htmlNode: HTMLElement,
+    ) {
+        val nodeId = semanticsNode.id
+        val verticalRange = config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
+        val horizontalRange = config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
+        val canScroll = (verticalRange != null || horizontalRange != null) &&
+            config.getOrNull(SemanticsActions.ScrollBy)?.action != null
+
+        if (!canScroll) {
+            if (scrollListenersAttached.remove(nodeId)) {
+                htmlNode.removeEventListener("scroll", onScroll)
+                resetScrollContainerStyle(htmlNode)
+                htmlNode.removeAttribute("aria-orientation")
+                scrollSizers.remove(nodeId)?.remove()
+                appliedScrollOffsets.remove(nodeId)
+                pendingScrollOffsets.remove(nodeId)
+            }
+            return
+        }
+
+        setScrollContainerStyle(
+            htmlNode,
+            horizontal = horizontalRange != null,
+            vertical = verticalRange != null,
+        )
+        if ((verticalRange != null) xor (horizontalRange != null)) {
+            htmlNode.setAttribute(
+                "aria-orientation",
+                if (verticalRange != null) "vertical" else "horizontal",
+            )
+        } else {
+            htmlNode.removeAttribute("aria-orientation")
+        }
+
+        val density = semanticsNode.layoutNode.density.density
+        val maxHorizontal = horizontalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
+        val maxVertical = verticalRange?.maxValue?.invoke()?.coerceAtLeast(0f) ?: 0f
+        val viewportWidth = semanticsNode.size.width / density
+        val viewportHeight = semanticsNode.size.height / density
+        val contentWidth =
+            (viewportWidth + maxHorizontal / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
+        val contentHeight =
+            (viewportHeight + maxVertical / density).coerceAtMost(MAX_SCROLL_EXTENT_CSS_PX)
+
+        val sizer = scrollSizers.getOrPut(nodeId) { createScrollSizer() }
+        setSizeAndPosition(sizer, 0f, 0f, contentWidth, contentHeight)
+
+        val scrollLeft = horizontalRange?.let { range ->
+            val value = range.value().coerceIn(0f, maxHorizontal)
+            ((if (range.reverseScrolling) maxHorizontal - value else value) / density)
+                .coerceIn(0f, (contentWidth - viewportWidth).coerceAtLeast(0f))
+        } ?: 0f
+        val scrollTop = verticalRange?.let { range ->
+            val value = range.value().coerceIn(0f, maxVertical)
+            ((if (range.reverseScrolling) maxVertical - value else value) / density)
+                .coerceIn(0f, (contentHeight - viewportHeight).coerceAtLeast(0f))
+        } ?: 0f
+        pendingScrollOffsets[nodeId] = Offset(scrollLeft, scrollTop)
+
+        if (scrollListenersAttached.add(nodeId)) {
+            htmlNode.addEventListener("scroll", onScroll)
+        }
+    }
+
+    /** Applies Compose scroll offsets after DOM structure and scroll extents have been updated. */
+    private fun applyScrollOffsets() {
+        pendingScrollOffsets.forEach { id, offset ->
+            val element = idToA11YNode[id] ?: return@forEach
+            val sizer = scrollSizers[id] ?: return@forEach
+            if (sizer.parentElement !== element || element.firstElementChild !== sizer) {
+                element.insertBefore(sizer, element.firstChild)
+            }
+
+            val actual = Offset(element.scrollLeft.toFloat(), element.scrollTop.toFloat())
+            val lastApplied = appliedScrollOffsets[id]
+            if (lastApplied != null && offset.isCloseTo(lastApplied) && !actual.isCloseTo(lastApplied)) {
+                // Preserve a browser/AT offset until its asynchronous scroll event is handled.
+                return@forEach
+            }
+
+            appliedScrollOffsets[id] = offset
+            if (abs(actual.x - offset.x) >= SCROLL_EPSILON_CSS_PX) {
+                element.scrollLeft = offset.x.toDouble()
+            }
+            if (abs(actual.y - offset.y) >= SCROLL_EPSILON_CSS_PX) {
+                element.scrollTop = offset.y.toDouble()
+            }
+        }
+        pendingScrollOffsets.clear()
+    }
 
     /**
      * Syncs a node with [SemanticsProperties.Text], attaching its link children right away instead
@@ -460,6 +640,7 @@ internal class ComposeWebSemanticsListener(
         node: SemanticsNode,
         config: SemanticsConfiguration,
         children: List<SemanticsNode>,
+        htmlParent: HTMLElement,
         rootPosition: Offset,
     ): HTMLElement {
         val texts = config[SemanticsProperties.Text]
@@ -473,6 +654,7 @@ internal class ComposeWebSemanticsListener(
         val htmlNode = syncNode(
             semanticsNode = node,
             config = config,
+            htmlParent = htmlParent,
             rootPosition = rootPosition,
         )
         val targetTextAndLinks = mutableListOf<Any>()
@@ -502,6 +684,7 @@ internal class ComposeWebSemanticsListener(
             val linkHtmlNode = syncNode(
                 semanticsNode = child,
                 config = childConfig,
+                htmlParent = htmlNode,
                 rootPosition = rootPosition,
                 text = split?.linkTexts?.getOrNull(linkIndex),
             )
@@ -518,14 +701,21 @@ internal class ComposeWebSemanticsListener(
             targetTextAndLinks.add(textParts.last())
         }
 
-        updateTextAndLinks(htmlNode, targetTextAndLinks)
+        updateTextAndLinks(htmlNode, targetTextAndLinks, scrollSizers[node.id])
         deferredChildren?.let { pushNodesForTraversal(it, htmlNode) }
         return htmlNode
     }
 
-    /** Updates the text fragments and semantic link elements at the start of a text node. */
-    private fun updateTextAndLinks(parent: HTMLElement, targetContent: List<Any>) {
+    /** Updates the text fragments and semantic link elements after the optional scroll sizer. */
+    private fun updateTextAndLinks(
+        parent: HTMLElement,
+        targetContent: List<Any>,
+        scrollSizer: HTMLElement?,
+    ) {
         var current = parent.firstChild
+        if (current === scrollSizer) {
+            current = current?.nextSibling
+        }
 
         targetContent.fastForEach { item ->
             when (item) {
@@ -570,6 +760,9 @@ internal class ComposeWebSemanticsListener(
         if (!hasStarted || hasStopped) return
 
         webSemanticsRoot.removeEventListener("click", onClick)
+        scrollListenersAttached.forEach { id ->
+            idToA11YNode[id]?.removeEventListener("scroll", onScroll)
+        }
 
         dfsSemanticsNodes.clear()
         dfsA11YParents.clear()
@@ -577,6 +770,10 @@ internal class ComposeWebSemanticsListener(
         a11yNodeToSemanticsNode.clear()
         targetParentToChildren.clear()
         targetChildToParent.clear()
+        appliedScrollOffsets.clear()
+        pendingScrollOffsets.clear()
+        scrollSizers.clear()
+        scrollListenersAttached.clear()
 
         invalidationChannel.close()
         syncTriggerChannel.close()
@@ -585,4 +782,43 @@ internal class ComposeWebSemanticsListener(
         removeAllChildrenOf(webSemanticsRoot)
         hasStopped = true
     }
+}
+
+private const val MAX_SCROLL_EXTENT_CSS_PX = 4_000_000f
+private const val SCROLL_EPSILON_CSS_PX = 0.5f
+
+private fun Offset.isCloseTo(other: Offset): Boolean =
+    abs(x - other.x) < SCROLL_EPSILON_CSS_PX && abs(y - other.y) < SCROLL_EPSILON_CSS_PX
+
+private fun createScrollSizer(): HTMLElement {
+    val sizer = document.createElement("div") as HTMLElement
+    sizer.setAttribute("aria-hidden", "true")
+    sizer.style.position = "absolute"
+    return sizer
+}
+
+private fun setScrollContainerStyle(
+    element: HTMLElement,
+    horizontal: Boolean,
+    vertical: Boolean,
+) {
+    // language=javascript
+    js(
+        """
+        element.style.overflowX = horizontal ? "scroll" : "hidden";
+        element.style.overflowY = vertical ? "scroll" : "hidden";
+        element.style.scrollbarWidth = "none";
+        """
+    )
+}
+
+private fun resetScrollContainerStyle(element: HTMLElement) {
+    // language=javascript
+    js(
+        """
+        element.style.overflowX = "";
+        element.style.overflowY = "";
+        element.style.scrollbarWidth = "";
+        """
+    )
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -176,7 +176,7 @@ internal class ComposeWebSemanticsListener(
     private val targetChildToParent = MutableScatterMap<HTMLElement, HTMLElement>()
 
     // Responsible for scroll synchronization between Compose and Dom tree
-    private val a11YScrollState = A11YScrollState(idToA11YNode, a11yNodeToSemanticsNode)
+    private val a11YScrollController = A11YScrollController(idToA11YNode, a11yNodeToSemanticsNode)
 
     /**
      * Event delegation: Single shared click listener for all a11y nodes with SemanticsActions.OnClick.
@@ -232,10 +232,10 @@ internal class ComposeWebSemanticsListener(
             if (htmlNode != null) {
                 a11yNodeToSemanticsNode.remove(htmlNode)
             }
-            a11YScrollState.onNodeRemoved(id, htmlNode)
+            a11YScrollController.onNodeRemoved(id, htmlNode)
         }
 
-        a11YScrollState.applyScrollOffsets()
+        a11YScrollController.applyScrollOffsets()
         updateInertRoots()
     }
 
@@ -447,7 +447,7 @@ internal class ComposeWebSemanticsListener(
             htmlNode.removeAttribute("aria-modal")
         }
 
-        a11YScrollState.syncNodeScrollability(semanticsNode, config, htmlNode)
+        a11YScrollController.syncNodeScrollability(semanticsNode, config, htmlNode)
 
         val density = semanticsNode.layoutNode.density.density
         // Use unclipped geometry so descendants retain their content-space positions outside a
@@ -468,7 +468,7 @@ internal class ComposeWebSemanticsListener(
             )
         } else {
             htmlNode.style.position = "absolute"
-            val parentScroll = a11YScrollState.getScrollOffset(parentSemanticsNode)
+            val parentScroll = a11YScrollController.getScrollOffset(parentSemanticsNode)
             setSizeAndPosition(
                 htmlNode,
                 (positionInRoot.x - parentSemanticsNode.positionInRoot.x) / density + parentScroll.x,
@@ -571,7 +571,7 @@ internal class ComposeWebSemanticsListener(
             targetTextAndLinks.add(textParts.last())
         }
 
-        updateTextAndLinks(htmlNode, targetTextAndLinks, a11YScrollState.getScrollSizer(node))
+        updateTextAndLinks(htmlNode, targetTextAndLinks, a11YScrollController.getScrollSizer(node))
         deferredChildren?.let { pushNodesForTraversal(it, htmlNode) }
         return htmlNode
     }
@@ -630,7 +630,7 @@ internal class ComposeWebSemanticsListener(
         if (!hasStarted || hasStopped) return
 
         webSemanticsRoot.removeEventListener("click", onClick)
-        a11YScrollState.clear()
+        a11YScrollController.clear()
 
         dfsSemanticsNodes.clear()
         dfsA11YParents.clear()

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -27,6 +27,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.LocalSystemTheme
@@ -77,6 +80,7 @@ import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.platform.FrameRecomposer
 import androidx.compose.ui.platform.PlatformOutOfFrameExecutor
 import androidx.compose.ui.platform.PlatformPrefetchScheduler
+import androidx.compose.ui.platform.PlatformScreenReader
 import androidx.compose.ui.platform.WebPrefetchScheduler
 import androidx.compose.ui.platform.isIdleCallbackSupported
 import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
@@ -278,6 +282,12 @@ internal class ComposeWindow(
             override val outOfFrameExecutor: PlatformOutOfFrameExecutor? get() = webOutOfFrameExecutor
 
             override val windowInfo get() = _windowInfo
+
+            override val screenReader: PlatformScreenReader
+                get() = object : PlatformScreenReader {
+                    override var isActive = configuration.isA11YEnabled
+                }
+
             override val architectureComponentsOwner get() = archComponentsOwner
             override val windowInsets get() = insetsManager?.windowInsets ?: EmptyPlatformWindowInsets
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -33,6 +35,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.currentTimeMillis
@@ -42,6 +45,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -365,6 +369,140 @@ class A11yScrollTest : OnCanvasTests {
     }
 
     @Test
+    fun lazyListItemIsScrolledIntoViewByBrowser() = runApplicationTest {
+        val state = LazyListState()
+
+        createComposeWindow {
+            LazyColumn(
+                modifier = Modifier.testTag("scrollable").width(100.dp).height(150.dp),
+                state = state,
+            ) {
+                items(100) { index ->
+                    Box(Modifier.testTag("item$index").size(100.dp)) {
+                        Text(
+                            "$index",
+                            Modifier.testTag("label$index").align(Alignment.Center),
+                        )
+                    }
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val container = getScrollableElement()
+        val firstBeyondBoundsItem = assertNotNull(
+            getShadowRoot().getElementById("item2") as? HTMLElement,
+            "The first fully offscreen item must be retained in the A11Y tree",
+        )
+        val firstBeyondBoundsLabel =
+            assertNotNull(getShadowRoot().getElementById("label2") as? HTMLElement)
+        assertTrue(
+            abs(firstBeyondBoundsItem.offsetTop - 200) <= 2,
+            "The retained item must keep its content-space position, " +
+                "got offsetTop=${firstBeyondBoundsItem.offsetTop}",
+        )
+        assertTrue(
+            firstBeyondBoundsLabel.offsetTop > 0,
+            "The retained item's child must keep its position inside the item, " +
+                "got offsetTop=${firstBeyondBoundsLabel.offsetTop}",
+        )
+        assertNull(
+            getShadowRoot().getElementById("item5"),
+            "Only the configured number of beyond-bounds items may be retained",
+        )
+
+        // Approximates VoiceOver moving to the first fully offscreen retained item.
+        scrollIntoView(firstBeyondBoundsItem)
+        awaitCondition("Browser scrolling must update the LazyList state") {
+            container.scrollTop > 0.0 &&
+                (state.firstVisibleItemIndex > 0 || state.firstVisibleItemScrollOffset > 0)
+        }
+        awaitA11YChanges()
+
+        val nextBeyondBoundsItem = assertNotNull(
+            getShadowRoot().getElementById("item5") as? HTMLElement,
+            "The beyond-bounds window must advance after scrolling",
+        )
+        assertTrue(
+            abs(nextBeyondBoundsItem.offsetTop - 500) <= 2,
+            "The next retained item must keep its content-space position, " +
+                "got offsetTop=${nextBeyondBoundsItem.offsetTop}",
+        )
+
+        scrollIntoView(nextBeyondBoundsItem)
+        awaitCondition("The next retained item must become visible") {
+            val containerBounds = container.getBoundingClientRect()
+            val itemBounds = nextBeyondBoundsItem.getBoundingClientRect()
+            itemBounds.bottom > containerBounds.top && itemBounds.top < containerBounds.bottom
+        }
+    }
+
+    @Test
+    @Ignore // need something like defaultLazyListBeyondBoundsItemCount but for LazyGrid
+    fun lazyGridItemIsScrolledIntoViewByBrowser() = runApplicationTest {
+        val state = LazyGridState()
+
+        createComposeWindow {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier.testTag("scrollable").width(300.dp).height(150.dp),
+                state = state,
+            ) {
+                items(100) { index ->
+                    Box(Modifier.testTag("item$index").size(100.dp)) {
+                        Text(
+                            "$index",
+                            Modifier.testTag("label$index").align(Alignment.Center),
+                        )
+                    }
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val container = getScrollableElement()
+        assertNull(
+            getShadowRoot().getElementById("item6"),
+            "The third row must not be in the initial A11Y tree",
+        )
+        val secondRowItem =
+            assertNotNull(getShadowRoot().getElementById("item3") as? HTMLElement)
+
+        // Approximates VoiceOver moving to the partially visible second row.
+        scrollIntoView(secondRowItem)
+        awaitCondition("Browser scrolling must update the LazyGrid state") {
+            container.scrollTop > 0.0 &&
+                (state.firstVisibleItemIndex > 0 || state.firstVisibleItemScrollOffset > 0)
+        }
+        awaitA11YChanges()
+
+        val thirdRowItem = assertNotNull(
+            getShadowRoot().getElementById("item6") as? HTMLElement,
+            "Scrolling to the second row must add the next row to the A11Y tree",
+        )
+        val thirdRowLabel =
+            assertNotNull(getShadowRoot().getElementById("label6") as? HTMLElement)
+        assertTrue(
+            abs(thirdRowItem.offsetTop - 200) <= 2,
+            "The newly added item must keep its content-space position, " +
+                "got offsetTop=${thirdRowItem.offsetTop}",
+        )
+        assertTrue(
+            thirdRowLabel.offsetTop > 0,
+            "The newly added item's child must retain its position inside the item, " +
+                "got offsetTop=${thirdRowLabel.offsetTop}",
+        )
+
+        // Approximates VoiceOver moving to the newly exposed third row.
+        scrollIntoView(thirdRowItem)
+        awaitCondition("The third row must become visible") {
+            val containerBounds = container.getBoundingClientRect()
+            val itemBounds = thirdRowItem.getBoundingClientRect()
+            itemBounds.bottom > containerBounds.top && itemBounds.top < containerBounds.bottom
+        }
+    }
+
+    @Test
     fun lazyGridItemsRemainAlignedWithComposeAfterRepeatedScrolls() = runApplicationTest {
         val state = LazyGridState()
 
@@ -485,4 +623,8 @@ class A11yScrollTest : OnCanvasTests {
             "The sizer must be removed when the node stops being scrollable"
         )
     }
+}
+
+private fun scrollIntoView(element: HTMLElement) {
+    js("element.scrollIntoView({ block: 'nearest', inline: 'nearest' })")
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.currentTimeMillis
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.browser.window
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.w3c.dom.HTMLElement
+
+/**
+ * Tests for scrolling initiated by assistive technologies (VoiceOver & co).
+ *
+ * On the web, an AT never sends an explicit "scroll" command to the page. It asks the browser to
+ * scroll an element exposed as a scroll container (or to bring one of its descendants into view),
+ * and the page only observes the resulting `scrollTop`/`scrollLeft` change and "scroll" event.
+ * So the contract under test is:
+ * - a semantics node with a ScrollAxisRange + ScrollBy action becomes a real CSS scroll container
+ *   (non-visible overflow + a sizer stretching it to the full content extent);
+ * - changing its DOM scroll offset (what an AT effectively does) drives the Compose scroll state;
+ * - the Compose scroll state is mirrored back to the DOM scroll offset.
+ */
+class A11yScrollTest : OnCanvasTests {
+
+    private val density: Float
+        get() = window.devicePixelRatio.toFloat()
+
+    private suspend fun awaitCondition(
+        message: String,
+        timeout: Duration = 5.seconds,
+        condition: () -> Boolean
+    ) {
+        val startTime = currentTimeMillis()
+        suspendCancellableCoroutine { continuation ->
+            fun check() {
+                when {
+                    condition() -> continuation.resumeWith(Result.success(Unit))
+                    currentTimeMillis() - startTime > timeout.inWholeMilliseconds ->
+                        continuation.resumeWith(
+                            Result.failure(AssertionError("Timed out waiting for: $message"))
+                        )
+                    else -> window.requestAnimationFrame { check() }
+                }
+            }
+            check()
+        }
+    }
+
+    private fun getScrollableElement(tag: String = "scrollable"): HTMLElement =
+        assertNotNull(
+            getShadowRoot().getElementById(tag) as? HTMLElement,
+            "Scrollable node must be present in the a11y tree"
+        )
+
+    @Test
+    fun verticalScrollableBecomesScrollContainer() = runApplicationTest {
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+
+        val element = getScrollableElement()
+        assertEquals("scroll", element.style.overflowY, "Vertical scrollable must have overflow-y: scroll")
+        assertEquals("hidden", element.style.overflowX, "Vertical-only scrollable must hide the horizontal overflow")
+        assertEquals("vertical", element.getAttribute("aria-orientation"))
+
+        // The browser derives scrollability (as exposed to ATs) from a real scrollable overflow
+        assertTrue(
+            element.scrollHeight > element.clientHeight,
+            "Scroll container must have scrollable overflow: " +
+                "scrollHeight=${element.scrollHeight}, clientHeight=${element.clientHeight}"
+        )
+
+        // Content: 10 items x 50dp in a 100dp viewport => 500dp total content extent
+        val expectedContentHeightCssPx = 500
+        assertTrue(
+            abs(element.scrollHeight - expectedContentHeightCssPx) <= 2,
+            "Scrollable extent must match the content size reported by Compose, " +
+                "expected ~$expectedContentHeightCssPx, got ${element.scrollHeight}"
+        )
+
+        val sizer = element.firstElementChild as? HTMLElement
+        assertNotNull(sizer, "Scroll container must have a sizer element")
+        assertEquals("true", sizer.getAttribute("aria-hidden"), "The sizer must be hidden from ATs")
+
+        assertEquals(0.0, element.scrollTop, "DOM scroll offset must match the initial Compose scroll offset")
+    }
+
+    @Test
+    fun domScrollDrivesComposeScroll() = runApplicationTest {
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val element = getScrollableElement()
+
+        // This is what effectively happens when an AT scrolls: the browser changes the scroll
+        // offset of the scroll container and fires a "scroll" event.
+        element.scrollTop = 50.0
+
+        val expectedComposePx = (50f * density).toInt()
+        awaitCondition("Compose scroll state must follow the DOM scroll offset") {
+            abs(scrollState.value - expectedComposePx) <= 1
+        }
+
+        // Scroll further: the second delta must be computed against the new offset (not doubled)
+        element.scrollTop = 80.0
+        val expectedComposePx2 = (80f * density).toInt()
+        awaitCondition("Compose scroll state must follow the second DOM scroll") {
+            abs(scrollState.value - expectedComposePx2) <= 1
+        }
+    }
+
+    @Test
+    fun composeScrollSyncsDomScrollOffset() = runApplicationTest {
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val element = getScrollableElement()
+        assertEquals(0.0, element.scrollTop)
+
+        val targetComposePx = (70f * density).toInt()
+        launch { scrollState.scrollTo(targetComposePx) }
+
+        awaitCondition("DOM scroll offset must follow the Compose scroll state") {
+            abs(element.scrollTop - 70.0) <= 1.0
+        }
+    }
+
+    @Test
+    fun reverseScrollingMapsDomOffsetsToCompose() = runApplicationTest {
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .verticalScroll(scrollState, reverseScrolling = true)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val element = getScrollableElement()
+        val maximumDomOffset = element.scrollHeight - element.clientHeight
+        assertTrue(abs(element.scrollTop - maximumDomOffset) <= 1.0)
+
+        element.scrollTop = maximumDomOffset - 50.0
+        val expectedComposePx = (50f * density).toInt()
+        awaitCondition("Reverse Compose scroll state must follow the inverse DOM offset") {
+            abs(scrollState.value - expectedComposePx) <= 1
+        }
+    }
+
+    @Test
+    fun horizontalScrollableBecomesScrollContainer() = runApplicationTest {
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Row(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .horizontalScroll(scrollState)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.width(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+
+        val element = getScrollableElement()
+        assertEquals("scroll", element.style.overflowX)
+        assertEquals("hidden", element.style.overflowY)
+        assertEquals("horizontal", element.getAttribute("aria-orientation"))
+        assertTrue(element.scrollWidth > element.clientWidth)
+
+        element.scrollLeft = 40.0
+        val expectedComposePx = (40f * density).toInt()
+        awaitCondition("Compose scroll state must follow the DOM scrollLeft") {
+            abs(scrollState.value - expectedComposePx) <= 1
+        }
+    }
+
+    @Test
+    fun nestedScrollContainersSyncIndependently() = runApplicationTest {
+        val outerState = ScrollState(0)
+        val innerState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("outer")
+                    .size(150.dp)
+                    .verticalScroll(outerState)
+            ) {
+                Spacer(Modifier.height(100.dp))
+                Column(
+                    modifier = Modifier
+                        .testTag("inner")
+                        .size(100.dp)
+                        .verticalScroll(innerState)
+                ) {
+                    repeat(10) {
+                        Text("Inner $it", modifier = Modifier.height(50.dp))
+                    }
+                }
+                Spacer(Modifier.height(100.dp))
+            }
+        }
+
+        awaitA11YChanges()
+        val outer = getScrollableElement("outer")
+        val inner = getScrollableElement("inner")
+
+        outer.scrollTop = 40.0
+        awaitCondition("Outer DOM offset must update only the outer Compose state") {
+            abs(outerState.value - (40f * density).toInt()) <= 1
+        }
+        assertEquals(0, innerState.value)
+
+        inner.scrollTop = 30.0
+        awaitCondition("Inner DOM offset must update only the inner Compose state") {
+            abs(innerState.value - (30f * density).toInt()) <= 1
+        }
+        assertTrue(abs(outerState.value - (40f * density).toInt()) <= 1)
+    }
+
+    @Test
+    fun childrenArePositionedInScrolledContentCoordinates() = runApplicationTest {
+        // The browser computes AT-initiated "scroll into view" from the DOM layout, so the
+        // children of a scroll container must keep their content-space position (independent of
+        // the scroll offset), while the container's scroll offset provides the shift.
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.testTag("item$it").height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val element = getScrollableElement()
+        val item3 = assertNotNull(getShadowRoot().getElementById("item3") as? HTMLElement)
+
+        // Item 3 lives at 150dp in the content coordinate space
+        assertTrue(
+            abs(item3.offsetTop - 150) <= 2,
+            "Item must be positioned at its content-space offset, got ${item3.offsetTop}"
+        )
+
+        // After scrolling, the content-space position must not change...
+        element.scrollTop = 100.0
+        awaitCondition("Compose scroll state must follow the DOM scroll offset") {
+            abs(scrollState.value - (100f * density).toInt()) <= 1
+        }
+        // ...(await the debounced a11y sync applying the new geometry)
+        awaitCondition("Item content-space position must be scroll-invariant") {
+            abs(item3.offsetTop - 150) <= 2
+        }
+        // ...so its position visible on the screen is shifted by the scroll offset
+        val visibleTop = item3.getBoundingClientRect().top - element.getBoundingClientRect().top
+        assertTrue(
+            abs(visibleTop - 50.0) <= 2.0,
+            "Item visible position must be shifted by the scroll offset, got $visibleTop"
+        )
+    }
+
+    @Test
+    fun lazyGridItemsRemainAlignedWithComposeAfterRepeatedScrolls() = runApplicationTest {
+        val state = LazyGridState()
+
+        createComposeWindow {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier.testTag("scrollable").size(300.dp),
+                state = state,
+            ) {
+                items(100) { index ->
+                    Box(Modifier.testTag("item$index").size(100.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        state.scrollToItem(30)
+        awaitA11YChanges()
+        state.scrollToItem(60)
+        awaitA11YChanges()
+
+        awaitCondition("the second target item must be present in the a11y tree") {
+            getShadowRoot().getElementById("item60") != null
+        }
+
+        val container = getScrollableElement()
+        val item = assertNotNull(getShadowRoot().getElementById("item60") as? HTMLElement)
+        val containerBounds = container.getBoundingClientRect()
+        val itemBounds = item.getBoundingClientRect()
+
+        assertTrue(
+            itemBounds.bottom > containerBounds.top && itemBounds.top < containerBounds.bottom,
+            "A visible Compose item must also be inside the a11y scroll container: " +
+                "container=[${containerBounds.top}, ${containerBounds.bottom}], " +
+                "item=[${itemBounds.top}, ${itemBounds.bottom}], " +
+                "scrollTop=${container.scrollTop}, offsetTop=${item.offsetTop}"
+        )
+    }
+
+    @Test
+    fun scrollSizerIsNotDetachedDuringTextUpdates() = runApplicationTest {
+        var prefix by mutableStateOf("Before ")
+        val scrollState = ScrollState(0)
+
+        createComposeWindow {
+            Text(
+                text = buildAnnotatedString {
+                    append(prefix)
+                    withLink(LinkAnnotation.Url("https://www.example.com")) {
+                        append("link")
+                    }
+                    append(" after")
+                },
+                modifier = Modifier
+                    .testTag("scrollableText")
+                    .size(100.dp)
+                    .verticalScroll(scrollState),
+            )
+        }
+
+        awaitA11YChanges()
+        val textElement = getScrollableElement("scrollableText")
+        val sizer = assertNotNull(textElement.firstElementChild as? HTMLElement)
+        val link = assertNotNull(textElement.querySelector("[role=link]") as? HTMLElement)
+        var sizerWasRemoved = false
+        var linkWasRemoved = false
+        val observer = createMutationObserver { removedNode ->
+            if (removedNode === sizer) sizerWasRemoved = true
+            if (removedNode === link) linkWasRemoved = true
+        }
+        observeChildListMutations(observer, textElement)
+
+        try {
+            prefix = "Updated before "
+            awaitA11YChanges()
+            awaitAnimationFrame()
+
+            assertSame(sizer, textElement.firstElementChild)
+            assertSame(link, textElement.querySelector("[role=link]"))
+            assertFalse(sizerWasRemoved, "The scroll sizer must remain attached during text updates")
+            assertFalse(linkWasRemoved, "The link must remain attached during text updates")
+        } finally {
+            disconnectMutationObserver(observer)
+        }
+    }
+
+    @Test
+    fun scrollContainerIsCleanedUpWhenScrollabilityIsRemoved() = runApplicationTest {
+        val scrollState = ScrollState(0)
+        var scrollable by mutableStateOf(true)
+
+        createComposeWindow {
+            Column(
+                modifier = Modifier
+                    .testTag("scrollable")
+                    .size(100.dp)
+                    .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
+            ) {
+                repeat(10) {
+                    Text("Item $it", modifier = Modifier.height(50.dp))
+                }
+            }
+        }
+
+        awaitA11YChanges()
+        val element = getScrollableElement()
+        assertEquals("scroll", element.style.overflowY)
+        assertNotNull(element.firstElementChild?.getAttribute("aria-hidden"))
+
+        scrollable = false
+        awaitA11YChanges()
+
+        assertEquals("", element.style.overflowY, "overflow must be reset when the node stops being scrollable")
+        assertEquals("", element.style.overflowX)
+        assertNull(element.getAttribute("aria-orientation"))
+        assertNull(
+            element.querySelector("[aria-hidden]"),
+            "The sizer must be removed when the node stops being scrollable"
+        )
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yScrollTest.kt
@@ -424,9 +424,9 @@ class A11yScrollTest : OnCanvasTests {
             "The beyond-bounds window must advance after scrolling",
         )
         assertTrue(
-            abs(nextBeyondBoundsItem.offsetTop - 500) <= 2,
-            "The next retained item must keep its content-space position, " +
-                "got offsetTop=${nextBeyondBoundsItem.offsetTop}",
+            nextBeyondBoundsItem.offsetTop > container.scrollTop,
+            "The next retained item must have meaningful forward content-space geometry, " +
+                "itemTop=${nextBeyondBoundsItem.offsetTop}, scrollTop=${container.scrollTop}",
         )
 
         scrollIntoView(nextBeyondBoundsItem)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8627/Web-A11y.-Voice-over.-Scroll-doesnt-work

**Demo**

https://github.com/user-attachments/assets/607b6930-1901-4719-8ece-6814b225f274

Note: it's noticeable that the offsets get synced with a delay (we have an intentional debounce for syncs). To not complicate this PR even further I keep it as is. But we can consider adjusting the debounce when we detect scrolling.

## Testing
- This should be tested by QA
- Added new tests

## Release Notes
### Fixes - Web
- Fix scrolling via A11Y Tools in web browsers

