### PR TITLE
Wire `PlatformContext`'s `UiMediaScope` to `Owner`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -548,9 +548,8 @@ internal class RootNodeOwner(
         override val semanticsOwner = SemanticsOwner(root, rootSemanticsNode, layoutNodes)
         override val windowInfo get() = platformContext.windowInfo
 
-        //TODO https://youtrack.jetbrains.com/issue/CMP-10709/Support-mediaQuery-derivedMediaQuery
         @ExperimentalMediaQueryApi
-        override val uiMediaScope: UiMediaScope? get() = null
+        override val uiMediaScope: UiMediaScope get() = platformContext.mediaScope
         override val retainedValuesStore: RetainedValuesStore get() = ForgetfulRetainedValuesStore
         override val rectManager = RectManager(layoutNodes)
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
@@ -24,7 +24,10 @@ import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ComposeUiFlags
+import androidx.compose.ui.ExperimentalMediaQueryApi
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.LocalUiMediaScope
 import androidx.lifecycle.LifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 
@@ -65,6 +68,7 @@ val LocalPlatformPrefetchScheduler = staticCompositionLocalOf<PlatformPrefetchSc
     error("CompositionLocal LocalPlatformPrefetchScheduler not present")
 }
 
+@OptIn(ExperimentalMediaQueryApi::class)
 @Composable
 internal fun ProvidePlatformCompositionLocals(
     vararg values: ProvidedValue<*>,
@@ -87,6 +91,15 @@ internal fun ProvidePlatformCompositionLocals(
         HostDefaultProviderImpl(platformContext)
     }
 
+    val mediaScope = if (
+        !ComposeUiFlags.isMinimalistLocalsEnabled &&
+        ComposeUiFlags.isMediaQueryIntegrationEnabled
+    ) {
+        arrayOf(LocalUiMediaScope provides platformContext.mediaScope)
+    } else {
+        emptyArray()
+    }
+
     CompositionLocalProvider(
         *values,
         LocalPlatformScreenReader provides platformContext.screenReader,
@@ -96,6 +109,7 @@ internal fun ProvidePlatformCompositionLocals(
         LocalSavedStateRegistryOwner provides platformContext.architectureComponentsOwner.savedStateRegistryOwner,
         LocalSaveableStateRegistry provides saveableStateRegistry,
         LocalHostDefaultProvider provides hostDefaultProvider,
+        *mediaScope,
         content = content,
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
@@ -24,9 +24,7 @@ import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.ExperimentalMediaQueryApi
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.LocalUiMediaScope
 import androidx.lifecycle.LifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 
@@ -67,7 +65,6 @@ val LocalPlatformPrefetchScheduler = staticCompositionLocalOf<PlatformPrefetchSc
     error("CompositionLocal LocalPlatformPrefetchScheduler not present")
 }
 
-@OptIn(ExperimentalMediaQueryApi::class)
 @Composable
 internal fun ProvidePlatformCompositionLocals(
     vararg values: ProvidedValue<*>,
@@ -95,7 +92,6 @@ internal fun ProvidePlatformCompositionLocals(
         LocalPlatformScreenReader provides platformContext.screenReader,
         LocalPlatformWindowInsets provides platformContext.windowInsets,
         LocalPlatformPrefetchScheduler provides platformContext.prefetchScheduler,
-        LocalUiMediaScope provides platformContext.mediaScope,
         androidx.lifecycle.compose.LocalLifecycleOwner provides platformContext.architectureComponentsOwner.lifecycleOwner,
         LocalSavedStateRegistryOwner provides platformContext.architectureComponentsOwner.savedStateRegistryOwner,
         LocalSaveableStateRegistry provides saveableStateRegistry,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -231,7 +231,7 @@ interface PlatformContext {
      * using media state remains safe on platforms that do not provide a richer
      * implementation.
      */
-    @OptIn(ExperimentalMediaQueryApi::class)
+    @ExperimentalMediaQueryApi
     val mediaScope: UiMediaScope get() = EmptyMediaScope
 
     interface RootForTestListener {
@@ -411,7 +411,7 @@ private object NoOpHapticFeedback : HapticFeedback {
     override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) = Unit
 }
 
-@OptIn(ExperimentalMediaQueryApi::class)
+@ExperimentalMediaQueryApi
 private object EmptyMediaScope : UiMediaScope {
     override val windowPosture: UiMediaScope.Posture
         get() = UiMediaScope.Posture.Flat


### PR DESCRIPTION
#3339's follow-up
[CMP-10709](https://youtrack.jetbrains.com/issue/CMP-10709) Support `mediaQuery`, `derivedMediaQuery`

## Release Notes
N/A
