### PR TITLE
Fix position of Numeric popup-like keyboard on iPad

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -153,12 +153,7 @@ internal interface TextEditingDelegate {
      * Returned value must be in range between 0 and length of the text (inclusive).
      */
     fun verticalPositionFromPosition(position: Int, verticalOffset: Int): Int?
-}
 
-/**
- * Extension of [TextEditingDelegate] for the Native iOS Text Input path.
- */
-internal interface NativeTextEditingDelegate : TextEditingDelegate {
     /**
      * Returns the caret rectangle for a given text position.
      * https://developer.apple.com/documentation/uikit/uitextinput/caretrect(for:)
@@ -167,7 +162,12 @@ internal interface NativeTextEditingDelegate : TextEditingDelegate {
      * if the position is invalid.
      */
     fun caretDpRectForPosition(position: Int): DpRect?
+}
 
+/**
+ * Extension of [TextEditingDelegate] for the Native iOS Text Input path.
+ */
+internal interface NativeTextEditingDelegate : TextEditingDelegate {
     /**
      * Returns the selection rectangles that enclose a range of text.
      * https://developer.apple.com/documentation/uikit/uitextinput/selectionrects(for:)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputHelpers.ios.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.toCGRect
 import kotlinx.cinterop.CValue
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRect
+import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSCharacterSet
 import platform.UIKit.NSWritingDirection
 import platform.UIKit.NSWritingDirectionLeftToRight
@@ -287,6 +288,13 @@ internal fun TextEditingDelegate.selectTextNearCursor() {
     if (range == selection) return
 
     setSelectedTextRange(range)
+}
+
+internal fun TextEditingDelegate.caretRectForPosition(position: UITextPosition): CValue<CGRect> {
+    val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
+    val position = (position as? TextInputPosition)?.position ?: return fallbackRect
+    val caretDpRect = caretDpRectForPosition(position)
+    return caretDpRect?.toCGRect() ?: fallbackRect
 }
 
 /**

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
+import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.toCGRect
 import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toDpRect
@@ -108,6 +109,27 @@ internal open class ComposeTextInputConnection(
         }
         if (selectionChanged) {
             textInputView.selectionDidChange()
+        }
+    }
+
+    override fun caretDpRectForPosition(position: Int): DpRect? {
+        val viewOriginInRoot = textFieldRectInRoot?.topLeft ?: return null
+        val textOffsetInRoot = unclippedTextOffsetInRoot ?: return null
+        val text = currentTextFieldValue?.text ?: return null
+        val currentTextLayoutResult = textLayoutResult ?: return null
+
+        if (position < 0 || position > text.length) {
+            return null
+        }
+        if (position > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) {
+            return null
+        }
+        val offset = textOffsetInRoot - viewOriginInRoot
+        val rect = currentTextLayoutResult.getCursorRect(position).translate(offset)
+        return rect.toDpRect(rootView.density).let {
+            val halfWidth = CURSOR_THICKNESS / 2
+            val center = (it.left + it.right) / 2
+            it.copy(left = center - halfWidth, right = center + halfWidth)
         }
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/ComposeTextInputConnection.ios.kt
@@ -126,7 +126,7 @@ internal open class ComposeTextInputConnection(
         }
         val offset = textOffsetInRoot - viewOriginInRoot
         val rect = currentTextLayoutResult.getCursorRect(position).translate(offset)
-        return rect.toDpRect(rootView.density).let {
+        return rect.toDpRect(view.density).let {
             val halfWidth = CURSOR_THICKNESS / 2
             val center = (it.left + it.right) / 2
             it.copy(left = center - halfWidth, right = center + halfWidth)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/NativeTextInputConnection.ios.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPEditMenuCustomAction
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
@@ -178,7 +177,7 @@ internal class NativeTextInputConnection(
         }
         val rect = currentTextLayoutResult.getCursorRect(position)
         return rect.toDpRect(view.density).let {
-            val halfWidth = cursorThickness / 2
+            val halfWidth = CURSOR_THICKNESS / 2
             val center = (it.left + it.right) / 2
             it.copy(left = center - halfWidth, right = center + halfWidth)
         }
@@ -390,11 +389,4 @@ internal class NativeTextInputConnection(
         selectionTintColor = color
         setupTintColor()
     }
-
-    /**
-     * Matches DefaultCursorThickness
-     *
-     * Must be at least 1.dp to make caret interactable
-     */
-    private val cursorThickness = 2.dp
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/TextInputConnection.ios.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.BackgroundInputView
 import androidx.compose.ui.window.ComposeTextInputView
@@ -490,6 +491,13 @@ internal abstract class TextInputConnection(
         // it may jump when switching between text fields.
         // Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
         internal val CLEAR_FOCUS_DELAY: Duration = 10.milliseconds
+
+        /**
+         * Matches DefaultCursorThickness
+         *
+         * Must be at least 1.dp to make caret interactable
+         */
+        internal val CURSOR_THICKNESS = 2.dp
     }
 }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.uikit.utils.CMPEditMenuView
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toCGRect
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
 import kotlinx.cinterop.CValue
@@ -396,8 +397,12 @@ internal class ComposeTextInputView(
     override fun firstRectForRange(range: UITextRange): CValue<CGRect> =
         CGRectNull.readValue()
 
-    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> =
-        CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
+    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> {
+        val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
+        val position = (position as? TextInputPosition)?.position ?: return fallbackRect
+        val caretDpRect = input.caretDpRectForPosition(position)
+        return caretDpRect?.toCGRect() ?: fallbackRect
+    }
 
     override fun selectionRectsForRange(range: UITextRange): List<*> =
         listOf<UITextSelectionRect>()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeTextInputView.ios.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.TextInputPosition
 import androidx.compose.ui.platform.TextInputRange
 import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.TextEditingDelegate
+import androidx.compose.ui.platform.caretRectForPosition
 import androidx.compose.ui.platform.selectTextNearCursor
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
@@ -397,12 +398,8 @@ internal class ComposeTextInputView(
     override fun firstRectForRange(range: UITextRange): CValue<CGRect> =
         CGRectNull.readValue()
 
-    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> {
-        val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
-        val position = (position as? TextInputPosition)?.position ?: return fallbackRect
-        val caretDpRect = input.caretDpRectForPosition(position)
-        return caretDpRect?.toCGRect() ?: fallbackRect
-    }
+    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> =
+        input.caretRectForPosition(position)
 
     override fun selectionRectsForRange(range: UITextRange): List<*> =
         listOf<UITextSelectionRect>()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/NativeTextInputView.ios.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.TextInputRange
 import androidx.compose.ui.platform.TextInputStringTokenizer
 import androidx.compose.ui.platform.TextLayoutDirection
 import androidx.compose.ui.platform.NativeTextEditingDelegate
+import androidx.compose.ui.platform.caretRectForPosition
 import androidx.compose.ui.platform.selectTextNearCursor
 import androidx.compose.ui.platform.toTextRange
 import androidx.compose.ui.platform.toUITextRange
@@ -464,12 +465,8 @@ internal class NativeTextInputView(
             ?: fallback
     }
 
-    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> {
-        val fallbackRect = CGRectMake(x = 1.0, y = 1.0, width = 0.0, height = 1.0)
-        val position = (position as? TextInputPosition)?.position ?: return fallbackRect
-        val caretDpRect = input.caretDpRectForPosition(position)
-        return caretDpRect?.toCGRect() ?: fallbackRect
-    }
+    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> =
+        input.caretRectForPosition(position)
 
     override fun selectionRectsForRange(range: UITextRange): List<*> {
         val fallbackList = listOf<UITextSelectionRect>()


### PR DESCRIPTION
Implement `caretDpRectForPosition` for ComposeTextInputContainer to let the numpad read anchor position. 

Fixes https://youtrack.jetbrains.com/issue/CMP-9443/iOS-26-TextField-with-KeyboardType.Number-shows-keyboard-in-wrong-position

## Release Notes
### Fixes - iOS
- Fix position of Numeric popup-like keyboard on iPad
