### PR TITLE
Remove experimental flag from ComposeUIView

### DIFF
--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -4698,6 +4698,11 @@ sealed interface androidx.compose.ui.viewinterop/UIKitInteropInteractionMode { /
 }
 
 // Targets: [ios]
+final class androidx.compose.ui.uikit/ComposeUIViewConfiguration : androidx.compose.ui.uikit/ComposeContainerConfiguration { // androidx.compose.ui.uikit/ComposeUIViewConfiguration|null[0]
+    constructor <init>() // androidx.compose.ui.uikit/ComposeUIViewConfiguration.<init>|<init>(){}[0]
+}
+
+// Targets: [ios]
 final class androidx.compose.ui.uikit/ComposeUIViewControllerConfiguration : androidx.compose.ui.uikit/ComposeContainerConfiguration { // androidx.compose.ui.uikit/ComposeUIViewControllerConfiguration|null[0]
     constructor <init>() // androidx.compose.ui.uikit/ComposeUIViewControllerConfiguration.<init>|<init>(){}[0]
 
@@ -4913,6 +4918,12 @@ final fun androidx.compose.ui.viewinterop/androidx_compose_ui_viewinterop_UIKitI
 
 // Targets: [ios]
 final fun androidx.compose.ui.viewinterop/androidx_compose_ui_viewinterop_UIKitInteropRemeasureRequester$stableprop_getter(): kotlin/Int // androidx.compose.ui.viewinterop/androidx_compose_ui_viewinterop_UIKitInteropRemeasureRequester$stableprop_getter|androidx_compose_ui_viewinterop_UIKitInteropRemeasureRequester$stableprop_getter(){}[0]
+
+// Targets: [ios]
+final fun androidx.compose.ui.window/ComposeUIView(kotlin/Function1<androidx.compose.ui.uikit/ComposeUIViewConfiguration, kotlin/Unit> = ..., kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): platform.UIKit/UIView // androidx.compose.ui.window/ComposeUIView|ComposeUIView(kotlin.Function1<androidx.compose.ui.uikit.ComposeUIViewConfiguration,kotlin.Unit>;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
+
+// Targets: [ios]
+final fun androidx.compose.ui.window/ComposeUIView(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): platform.UIKit/UIView // androidx.compose.ui.window/ComposeUIView|ComposeUIView(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
 
 // Targets: [ios]
 final fun androidx.compose.ui.window/ComposeUIViewController(kotlin/Function1<androidx.compose.ui.uikit/ComposeUIViewControllerConfiguration, kotlin/Unit> = ..., kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): platform.UIKit/UIViewController // androidx.compose.ui.window/ComposeUIViewController|ComposeUIViewController(kotlin.Function1<androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration,kotlin.Unit>;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewConfiguration.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewConfiguration.ios.kt
@@ -16,10 +16,7 @@
 
 package androidx.compose.ui.uikit
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-
 /**
  * Configuration of [androidx.compose.ui.window.ComposeUIViewController] behavior.
  */
-@ExperimentalComposeUiApi
 class ComposeUIViewConfiguration: ComposeContainerConfiguration()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeUIView.uikit.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeUIView.uikit.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.scene.ComposeHostingView
 import androidx.compose.ui.uikit.ComposeUIViewConfiguration
 import platform.UIKit.UIView
@@ -32,7 +31,6 @@ import platform.UIKit.UIView
  * [ComposeUIView].
  * @return A [UIView] instance capable of hosting the specified Compose content.
  */
-@ExperimentalComposeUiApi
 fun ComposeUIView(content: @Composable () -> Unit): UIView =
     ComposeUIView(configure = {}, content = content)
 
@@ -44,7 +42,6 @@ fun ComposeUIView(content: @Composable () -> Unit): UIView =
  * [ComposeUIView].
  * @return A configured [UIView] instance capable of displaying the provided Compose content.
  */
-@ExperimentalComposeUiApi
 fun ComposeUIView(
     configure: ComposeUIViewConfiguration.() -> Unit = {},
     content: @Composable () -> Unit


### PR DESCRIPTION
Makes the `ComposeUIView()` iOS `UIView` factory functions and their `ComposeUIViewConfiguration` stable by removing `@ExperimentalComposeUiApi`, mirroring the already-stable `ComposeUIViewController`.
Updates the klib ABI dump because experimental declarations are excluded from the public API dump.

Fixes https://youtrack.jetbrains.com/issue/CMP-10328/Remove-experimental-flag-from-ComposeUIView

## Release Notes
### Features - iOS
- Promote the `ComposeUIView()` factory functions and their `ComposeUIViewConfiguration` to stable API