### PR TITLE
Disable OS activity log from test ouput

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/Launcher.xctestplan
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/Launcher.xctestplan
@@ -10,6 +10,12 @@
   ],
   "defaultOptions" : {
     "defaultTestExecutionTimeAllowance" : 60,
+    "environmentVariableEntries" : [
+      {
+        "key" : "OS_ACTIVITY_MODE",
+        "value" : "disable"
+      }
+    ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:CMPUIKitUtils.xcodeproj",
       "identifier" : "997DFCF92B18E5D3000B56B5",


### PR DESCRIPTION
Remove unrelated to tests messages (like errors with `CHHapticPattern`) from the console log.
Fixes the issue when iOS instrumented tests log is no longer fit in the GitHub actions output window.

## Release Notes
N/A