### PR TITLE
Fix context menu for SelectionContainer

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPEditMenuView.m
@@ -86,6 +86,8 @@
 
 @property (readwrite) UIEditMenuInteraction* editInteraction API_AVAILABLE(ios(16.0));
 
+- (void)dismissEditMenu;
+
 @end
 
 @implementation CMPEditMenuView
@@ -132,11 +134,11 @@ id _editInteraction;
             [self.editInteraction updateVisibleMenuPositionAnimated:NO];
         }
     } else {
-        self.isEditMenuShown = YES;
         if (contextMenuItemsChanged || positionChanged) {
-            [self hideEditMenu];
+            [self dismissEditMenu];
             [self scheduleShowMenuController];
         }
+        self.isEditMenuShown = YES;
     }
 }
 
@@ -283,7 +285,7 @@ id _editInteraction;
     return YES;
 }
 
-- (void)hideEditMenu {
+- (void)dismissEditMenu {
     if (@available(iOS 16, *)) {
         [self cancelPresentEditMenuInteraction];
 
@@ -297,10 +299,15 @@ id _editInteraction;
         [self cancelShowMenuController];
         [[UIMenuController sharedMenuController] hideMenu];
     }
+}
+
+- (void)hideEditMenu {
+    [self dismissEditMenu];
 
     self.copyBlock = nil;
     self.cutBlock = nil;
     self.pasteBlock = nil;
+    self.selectBlock = nil;
     self.selectAllBlock = nil;
     self.customActions = @[];
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/TextInputService.ios.kt
@@ -71,10 +71,17 @@ internal class TextInputService(
 
     private var currentInputConnection: TextInputConnection? by mutableStateOf(null)
 
+    private var selectionContainerConnection: SelectionContainerConnection? = null
+
+    private val toolbarConnection: ComposeTextInputConnection?
+        get() = currentInputConnection as? ComposeTextInputConnection ?: selectionContainerConnection
+
     private var updateEditMenuState = {}
 
     val hasInvalidations: Boolean
-        get() = currentInputConnection?.hasInvalidations ?: false
+        get() = currentInputConnection?.hasInvalidations
+            ?: selectionContainerConnection?.hasInvalidations
+            ?: false
 
     suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
         coroutineScope {
@@ -108,6 +115,7 @@ internal class TextInputService(
         val usingNativeTextInput = request.imeOptions.platformImeOptions?.usingNativeTextInput ?: false
 
         currentInputConnection?.stop()
+        stopSelectionContainerConnection()
         listener.onInputWillStart()
         currentInputConnection = if (usingNativeTextInput) {
             NativeTextInputConnection(
@@ -137,7 +145,10 @@ internal class TextInputService(
         currentInputConnection = null
         listener.onInputDidStop()
     }
-
+    private fun stopSelectionContainerConnection() {
+        selectionContainerConnection?.stop()
+        selectionContainerConnection = null
+    }
     fun showSoftwareKeyboard() {
         currentInputConnection?.showKeyboard()
     }
@@ -152,7 +163,7 @@ internal class TextInputService(
     val textToolbar: TextToolbar by lazy(LazyThreadSafetyMode.NONE) {
         object : TextToolbar {
             override val status: TextToolbarStatus
-                get() = (currentInputConnection as? ComposeTextInputConnection)?.toolbarStatus ?: TextToolbarStatus.Hidden
+                get() = toolbarConnection?.toolbarStatus ?: TextToolbarStatus.Hidden
 
             override fun showMenu(
                 rect: Rect,
@@ -161,7 +172,7 @@ internal class TextInputService(
                 onCutRequested: (() -> Unit)?,
                 onSelectAllRequested: (() -> Unit)?
             ) {
-                if (currentInputConnection == null) {
+                if (currentInputConnection == null && selectionContainerConnection == null) {
                     // Entry point for showing the context menu in SelectionContainer scenarios, where
                     // there is no active text input session. iOS requires a UIView that can become first
                     // responder in order to host the context menu, so we create a dedicated connection
@@ -169,13 +180,13 @@ internal class TextInputService(
                     // Note: start() is intentionally not called here — it establishes a text editing
                     // session (requiring a PlatformTextInputMethodRequest) which is not applicable for
                     // SelectionContainer.
-                    currentInputConnection = SelectionContainerConnection(
+                    selectionContainerConnection = SelectionContainerConnection(
                         view = view,
                         coroutineScope = coroutineScope,
                         viewConfiguration = viewConfiguration,
                         focusManager = focusManager
                     )
-                    currentInputConnection?.start(
+                    selectionContainerConnection?.start(
                         object : PlatformTextInputMethodRequest {
                             override val value: () -> TextFieldValue get() = { TextFieldValue() }
                             override val state: TextEditorState = object : TextEditorState {
@@ -198,7 +209,7 @@ internal class TextInputService(
                         }
                     )
                 }
-                (currentInputConnection as? ComposeTextInputConnection)?.showToolbarMenu(
+                toolbarConnection?.showToolbarMenu(
                     rect = rect,
                     onCopyRequested = onCopyRequested,
                     onPasteRequested = onPasteRequested,
@@ -208,14 +219,8 @@ internal class TextInputService(
             }
 
             override fun hide() {
-                (currentInputConnection as? ComposeTextInputConnection)?.hideToolbar()
-
-                if (currentInputConnection is SelectionContainerConnection) {
-                    // stop() removes the view from the hierarchy and resigns first responder,
-                    // without requiring a prior start() call.
-                    currentInputConnection?.stop()
-                    currentInputConnection = null
-                }
+                toolbarConnection?.hideToolbar()
+                stopSelectionContainerConnection()
             }
         }
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/text/input/SelectionContainerConnection.ios.kt
@@ -16,9 +16,12 @@
 
 package androidx.compose.ui.text.input
 
+import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.scene.ComposeSceneFocusManager
+import kotlinx.cinterop.readValue
 import kotlinx.coroutines.CoroutineScope
+import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIView
 
 
@@ -35,6 +38,15 @@ internal class SelectionContainerConnection(
     null,
     focusManager
 ) {
+    private val keyboardlessInputTraits = object : SkikoUITextInputTraits {
+        val emptyInputView = UIView(frame = CGRectZero.readValue())
+        override fun inputView(): UIView = emptyInputView
+    }
+
+    override var inputTraits: SkikoUITextInputTraits
+        get() = keyboardlessInputTraits
+        set(value) {}
+
     override fun showKeyboard() {
         // Does nothing. Keyboard is not needed for the selection container
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldEditMenuTest.kt
@@ -30,6 +30,8 @@ import androidx.compose.foundation.text.contextmenu.modifier.filterTextContextMe
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.text.selection.SelectionState
+import androidx.compose.foundation.text.selection.rememberSelectionState
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.LaunchedEffect
@@ -739,6 +741,66 @@ class TextFieldEditMenuTest {
         }
     }
 
+    @Test
+    fun testSelectionContainerToolbar() = runContextMenuTest(newContextMenuEnabled = false) {
+        lateinit var selectionState: SelectionState
+        setContent {
+            selectionState = rememberSelectionState()
+            Column(modifier = Modifier.safeDrawingPadding()) {
+                SelectionContainer(
+                    state = selectionState,
+                    modifier = Modifier.testTag("SelectionContainer")
+                ) {
+                    Text(SELECTION_CONTAINER_TEXT)
+                }
+            }
+        }
+
+        // A double tap in the middle of the text selects the word under it.
+        findNodeWithTag("SelectionContainer").doubleTap()
+        waitForContextMenu()
+
+        assertEquals(
+            listOf(SELECTION_CONTAINER_MIDDLE_WORD),
+            selectionState.selectedTexts.map { it.text },
+            "The word in the middle of the text should be selected"
+        )
+
+        verifyContextMenuItemsVisible(labels = listOf("Copy"))
+        verifyContextMenuItemsHidden(labels = listOf("Cut", "Paste"))
+
+        assertEquals(0.dp, keyboardHeight, "Software keyboard should stay hidden")
+    }
+
+    @Test
+    fun testSelectionContainerToolbarWithTextField() = runContextMenuTest(newContextMenuEnabled = false) {
+        lateinit var selectionState: SelectionState
+        setContent {
+            selectionState = rememberSelectionState()
+            SelectionContainer(state = selectionState) {
+                Column(modifier = Modifier.safeDrawingPadding()) {
+                    TextField(value = PARTIAL_SELECTION_TEXT, onValueChange = {})
+                    Text(SELECTION_CONTAINER_TEXT, modifier = Modifier.testTag("SelectionText"))
+                }
+            }
+        }
+
+        // A double tap in the middle of the text selects the word under it.
+        findNodeWithTag("SelectionText").doubleTap()
+        waitForContextMenu()
+
+        assertEquals(
+            listOf(SELECTION_CONTAINER_MIDDLE_WORD),
+            selectionState.selectedTexts.map { it.text },
+            "The word in the middle of the text should be selected"
+        )
+
+        verifyContextMenuItemsVisible(labels = listOf("Copy"))
+        verifyContextMenuItemsHidden(labels = listOf("Cut", "Paste"))
+
+        assertEquals(0.dp, keyboardHeight, "Software keyboard should stay hidden")
+    }
+
     private fun UIKitInstrumentedTest.openToolbar(textFieldTag: String) {
         findNodeWithTag(textFieldTag).focusThenDoubleTap()
         waitForContextMenu()
@@ -797,6 +859,8 @@ class TextFieldEditMenuTest {
     }
 
     private companion object {
+        private const val SELECTION_CONTAINER_MIDDLE_WORD = "LongLongLongLongLongLong"
+        private const val SELECTION_CONTAINER_TEXT = "Hello-$SELECTION_CONTAINER_MIDDLE_WORD-text"
         private const val PARTIAL_SELECTION_TEXT = "accomplishment extraordinary magnificent establishment"
     }
 


### PR DESCRIPTION
Use dedicated `selectionContainerConnection` to properly display toolbar menu from `SelectionContainer`.
Refactor `CMPEditMenuView` to properly hide and cleanup context menu.
Provide `emptyInputView` as `inputView()` to prevent keyboard appearance for `SelectionContainer`.

Fixes https://youtrack.jetbrains.com/issue/CMP-10747

## Release Notes
### Fixes - iOS
- Fix issue where Toolbar is not visible on iOS < 16
- Fix issue where Toolbar is not appears when `SelectionContainer` has at least one `TextField` inside