### PR TITLE
Fix missing aria attributes for Slider, RangeSlider and ProgressIndicator components

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.util.fastFilter
@@ -202,13 +203,14 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
 
 internal fun setA11YProgressBarRangeInfo(
     element: HTMLElement,
-    info: ProgressBarRangeInfo,
-    stateDescription: String?
+    semanticsConfiguration: SemanticsConfiguration,
 ) {
+    val info = semanticsConfiguration[SemanticsProperties.ProgressBarRangeInfo]
     if (info == ProgressBarRangeInfo.Indeterminate) {
         removeA11YProgressBarRangeInfo(element)
         return
     }
+    val stateDescription = semanticsConfiguration.getOrNull(SemanticsProperties.StateDescription)
 
     element.setAttribute("aria-valuemin", info.range.start.toString())
     element.setAttribute("aria-valuemax", info.range.endInclusive.toString())

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -120,11 +120,7 @@ internal fun SemanticsConfiguration.getRoleId(): Int {
 
     if (this.contains(SemanticsProperties.ProgressBarRangeInfo)) {
         val info = this[SemanticsProperties.ProgressBarRangeInfo]
-        roleId = if (
-            info.steps > 0 ||
-                SemanticsProperties.Disabled in this ||
-                SemanticsActions.SetProgress in this
-        ) {
+        roleId = if (info.steps > 0 || SemanticsActions.SetProgress in this) {
             AriaRoleId.Slider
         } else {
             AriaRoleId.ProgressBar

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -16,10 +16,12 @@
 
 package androidx.compose.ui.platform.accessibility
 
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEach
@@ -63,6 +65,8 @@ internal object AriaRoleId {
     const val Grid = 10
     const val Dialog = 11
     const val Link = 12
+    const val ProgressBar = 13
+    const val Slider = 14
 }
 
 internal fun SemanticsConfiguration.getRoleId(): Int {
@@ -111,6 +115,19 @@ internal fun SemanticsConfiguration.getRoleId(): Int {
             AriaRoleId.Grid
         } else {
             AriaRoleId.List
+        }
+    }
+
+    if (this.contains(SemanticsProperties.ProgressBarRangeInfo)) {
+        val info = this[SemanticsProperties.ProgressBarRangeInfo]
+        roleId = if (
+            info.steps > 0 ||
+                SemanticsProperties.Disabled in this ||
+                SemanticsActions.SetProgress in this
+        ) {
+            AriaRoleId.Slider
+        } else {
+            AriaRoleId.ProgressBar
         }
     }
 
@@ -169,6 +186,12 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
             case 12: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/link_role
                 roleValue = "link";
                 break;
+            case 13: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role
+                roleValue = "progressbar";
+                break;
+            case 14: // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role
+                roleValue = "slider";
+                break;
             default:
                 break;
         }
@@ -179,6 +202,41 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
         }
     """
     )
+}
+
+internal fun setA11YProgressBarRangeInfo(
+    element: HTMLElement,
+    info: ProgressBarRangeInfo,
+    stateDescription: String?
+) {
+    if (info == ProgressBarRangeInfo.Indeterminate) {
+        removeA11YProgressBarRangeInfo(element)
+        return
+    }
+
+    element.setAttribute("aria-valuemin", info.range.start.toString())
+    element.setAttribute("aria-valuemax", info.range.endInclusive.toString())
+    element.setAttribute("aria-valuenow", info.current.toString())
+    if (stateDescription != null) {
+        element.setAttribute("aria-valuetext", stateDescription)
+    } else {
+        element.removeAttribute("aria-valuetext")
+    }
+}
+
+internal fun removeA11YProgressBarRangeInfo(element: HTMLElement) {
+    element.removeAttribute("aria-valuemin")
+    element.removeAttribute("aria-valuemax")
+    element.removeAttribute("aria-valuenow")
+    element.removeAttribute("aria-valuetext")
+}
+
+internal fun ToggleableState.toAriaChecked(): String {
+    return when (this) {
+        ToggleableState.On -> "true"
+        ToggleableState.Off -> "false"
+        ToggleableState.Indeterminate -> "mixed"
+    }
 }
 
 internal fun removeAllChildrenOf(element: HTMLElement) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -201,34 +201,6 @@ internal fun setA11YAriaRole(element: HTMLElement, ariaRoleId: Int) {
     )
 }
 
-internal fun setA11YProgressBarRangeInfo(
-    element: HTMLElement,
-    semanticsConfiguration: SemanticsConfiguration,
-) {
-    val info = semanticsConfiguration[SemanticsProperties.ProgressBarRangeInfo]
-    if (info == ProgressBarRangeInfo.Indeterminate) {
-        removeA11YProgressBarRangeInfo(element)
-        return
-    }
-    val stateDescription = semanticsConfiguration.getOrNull(SemanticsProperties.StateDescription)
-
-    element.setAttribute("aria-valuemin", info.range.start.toString())
-    element.setAttribute("aria-valuemax", info.range.endInclusive.toString())
-    element.setAttribute("aria-valuenow", info.current.toString())
-    if (stateDescription != null) {
-        element.setAttribute("aria-valuetext", stateDescription)
-    } else {
-        element.removeAttribute("aria-valuetext")
-    }
-}
-
-internal fun removeA11YProgressBarRangeInfo(element: HTMLElement) {
-    element.removeAttribute("aria-valuemin")
-    element.removeAttribute("aria-valuemax")
-    element.removeAttribute("aria-valuenow")
-    element.removeAttribute("aria-valuetext")
-}
-
 internal fun ToggleableState.toAriaChecked(): String {
     return when (this) {
         ToggleableState.On -> "true"

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
@@ -18,8 +18,11 @@ package androidx.compose.ui.platform.accessibility
 
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.KeyboardEvent
 
 internal object A11YSliderUtils {
@@ -60,4 +63,32 @@ internal object A11YSliderUtils {
         }
     }
 
+
+    internal fun setA11YProgressBarRangeInfo(
+        element: HTMLElement,
+        semanticsConfiguration: SemanticsConfiguration,
+    ) {
+        val info = semanticsConfiguration[SemanticsProperties.ProgressBarRangeInfo]
+        if (info == ProgressBarRangeInfo.Indeterminate) {
+            removeA11YProgressBarRangeInfo(element)
+            return
+        }
+        val stateDescription = semanticsConfiguration.getOrNull(SemanticsProperties.StateDescription)
+
+        element.setAttribute("aria-valuemin", info.range.start.toString())
+        element.setAttribute("aria-valuemax", info.range.endInclusive.toString())
+        element.setAttribute("aria-valuenow", info.current.toString())
+        if (stateDescription != null) {
+            element.setAttribute("aria-valuetext", stateDescription)
+        } else {
+            element.removeAttribute("aria-valuetext")
+        }
+    }
+
+    internal fun removeA11YProgressBarRangeInfo(element: HTMLElement) {
+        element.removeAttribute("aria-valuemin")
+        element.removeAttribute("aria-valuemax")
+        element.removeAttribute("aria-valuenow")
+        element.removeAttribute("aria-valuetext")
+    }
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.accessibility
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.events.KeyboardEvent
+
+object A11YSliderUtils {
+
+    fun isSliderNode(semanticsNode: SemanticsNode): Boolean {
+        val config = semanticsNode.config
+
+        if (!config.contains(SemanticsActions.SetProgress) ||
+            !config.contains(SemanticsProperties.ProgressBarRangeInfo)
+        ) return false
+
+        val rangeInfo = config[SemanticsProperties.ProgressBarRangeInfo]
+        if (rangeInfo == ProgressBarRangeInfo.Indeterminate) {
+            return false
+        }
+
+        return true
+    }
+
+    fun handleSliderKeyEvents(keyboardEvent: KeyboardEvent, semanticsNode: SemanticsNode) {
+        val config = semanticsNode.config
+        val rangeInfo = config[SemanticsProperties.ProgressBarRangeInfo]
+        val actualSteps = if (rangeInfo.steps > 0) rangeInfo.steps + 1 else 100
+        val delta = (rangeInfo.range.endInclusive - rangeInfo.range.start) / actualSteps
+        val pageDelta = delta * (actualSteps / 10).coerceIn(1, 10)
+        val newValue = when (keyboardEvent.key) {
+            "ArrowUp", "ArrowRight" -> rangeInfo.current + delta
+            "ArrowDown", "ArrowLeft" -> rangeInfo.current - delta
+            "Home" -> rangeInfo.range.start
+            "End" -> rangeInfo.range.endInclusive
+            "PageUp" -> rangeInfo.current + pageDelta
+            "PageDown" -> rangeInfo.current - pageDelta
+            else -> return
+        }.coerceIn(rangeInfo.range)
+
+        if (config[SemanticsActions.SetProgress].action?.invoke(newValue) == true) {
+            keyboardEvent.preventDefault()
+        }
+    }
+
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YSliderUtils.kt
@@ -16,15 +16,13 @@
 
 package androidx.compose.ui.platform.accessibility
 
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
-import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.KeyboardEvent
 
-object A11YSliderUtils {
+internal object A11YSliderUtils {
 
     fun isSliderNode(semanticsNode: SemanticsNode): Boolean {
         val config = semanticsNode.config

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastJoinToString
 import kotlin.time.Duration.Companion.milliseconds
@@ -426,6 +427,21 @@ internal class ComposeWebSemanticsListener(
 
         val roleId = config.getRoleId()
         setA11YAriaRole(element = htmlNode, roleId)
+
+        if (config.contains(SemanticsProperties.ProgressBarRangeInfo)) {
+            val rangeInfo = config[SemanticsProperties.ProgressBarRangeInfo]
+            val stateDescription = config.getOrNull(SemanticsProperties.StateDescription)
+            setA11YProgressBarRangeInfo(htmlNode, rangeInfo, stateDescription)
+        } else {
+            removeA11YProgressBarRangeInfo(htmlNode)
+        }
+
+        if (config.contains(SemanticsProperties.ToggleableState)) {
+            val ariaChecked = config[SemanticsProperties.ToggleableState].toAriaChecked()
+            htmlNode.setAttribute("aria-checked", ariaChecked)
+        } else {
+            htmlNode.removeAttribute("aria-checked")
+        }
 
         val isCollection =
             roleId == AriaRoleId.List || roleId == AriaRoleId.Grid

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -453,9 +453,7 @@ internal class ComposeWebSemanticsListener(
         }
 
         if (config.contains(SemanticsProperties.ProgressBarRangeInfo)) {
-            val rangeInfo = config[SemanticsProperties.ProgressBarRangeInfo]
-            val stateDescription = config.getOrNull(SemanticsProperties.StateDescription)
-            setA11YProgressBarRangeInfo(htmlNode, rangeInfo, stateDescription)
+            setA11YProgressBarRangeInfo(htmlNode, config)
         } else {
             removeA11YProgressBarRangeInfo(htmlNode)
         }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -453,9 +453,9 @@ internal class ComposeWebSemanticsListener(
         }
 
         if (config.contains(SemanticsProperties.ProgressBarRangeInfo)) {
-            setA11YProgressBarRangeInfo(htmlNode, config)
+            A11YSliderUtils.setA11YProgressBarRangeInfo(htmlNode, config)
         } else {
-            removeA11YProgressBarRangeInfo(htmlNode)
+            A11YSliderUtils.removeA11YProgressBarRangeInfo(htmlNode)
         }
 
         if (config.contains(SemanticsProperties.ToggleableState)) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -20,6 +20,7 @@ import androidx.collection.MutableScatterMap
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -42,6 +43,7 @@ import kotlinx.coroutines.launch
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
+import org.w3c.dom.events.KeyboardEvent
 
 internal class ComposeWebSemanticsListener(
     val webSemanticsRoot: HTMLElement,
@@ -136,8 +138,9 @@ internal class ComposeWebSemanticsListener(
             }
         }
 
-        // Event delegation: all nodes delegate to one global click listener
+        // Event delegation: all nodes delegate to global accessibility action listeners.
         webSemanticsRoot.addEventListener("click", onClick)
+        webSemanticsRoot.addEventListener("keydown", onKeyDown)
     }
 
     private val semanticsOwners = mutableListOf<SemanticsOwner>()
@@ -194,6 +197,18 @@ internal class ComposeWebSemanticsListener(
             config.contains(SemanticsActions.OnClick)
         ) {
             config[SemanticsActions.OnClick].action?.invoke()
+        }
+    }
+
+    private val onKeyDown: (Event) -> Unit = onKeyDown@ { event ->
+        val keyboardEvent = event as? KeyboardEvent ?: return@onKeyDown
+        val target = event.target as? HTMLElement ?: return@onKeyDown
+        val semanticsNode = a11yNodeToSemanticsNode[target] ?: return@onKeyDown
+        val config = semanticsNode.config
+        if (config.contains(SemanticsProperties.Disabled)) return@onKeyDown
+
+        if (A11YSliderUtils.isSliderNode(semanticsNode)) {
+            A11YSliderUtils.handleSliderKeyEvents(keyboardEvent, semanticsNode)
         }
     }
 
@@ -428,6 +443,15 @@ internal class ComposeWebSemanticsListener(
         val roleId = config.getRoleId()
         setA11YAriaRole(element = htmlNode, roleId)
 
+        if (roleId == AriaRoleId.Slider &&
+            !config.contains(SemanticsProperties.Disabled) &&
+            config.contains(SemanticsActions.SetProgress)
+        ) {
+            htmlNode.setAttribute("tabindex", "0")
+        } else {
+            htmlNode.removeAttribute("tabindex")
+        }
+
         if (config.contains(SemanticsProperties.ProgressBarRangeInfo)) {
             val rangeInfo = config[SemanticsProperties.ProgressBarRangeInfo]
             val stateDescription = config.getOrNull(SemanticsProperties.StateDescription)
@@ -646,6 +670,7 @@ internal class ComposeWebSemanticsListener(
         if (!hasStarted || hasStopped) return
 
         webSemanticsRoot.removeEventListener("click", onClick)
+        webSemanticsRoot.removeEventListener("keydown", onKeyDown)
         a11YScrollController.clear()
 
         dfsSemanticsNodes.clear()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -748,13 +748,15 @@ class CfWA11YTest : OnCanvasTests {
         assertNotNull(slider)
         assertEquals("slider", slider.getAttribute("role"))
         assertEquals("0", slider.getAttribute("tabindex"))
+        assertEquals(0.5f, slider.getAttribute("aria-valuenow")!!.toFloat())
+
         slider.focus()
         slider.dispatchEvent(keyEvent("ArrowRight"))
         awaitA11YChanges()
+
         assertEquals(0.51f, slider.getAttribute("aria-valuenow")!!.toFloat())
         assertEquals(0f, slider.getAttribute("aria-valuemin")!!.toFloat())
         assertEquals(1f, slider.getAttribute("aria-valuemax")!!.toFloat())
-        assertEquals(0.5f, slider.getAttribute("aria-valuenow")!!.toFloat())
     }
 
     @OptIn(ExperimentalMaterialApi::class)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
@@ -746,6 +747,11 @@ class CfWA11YTest : OnCanvasTests {
         val slider = getShadowRoot().getElementById("slider") as? HTMLElement
         assertNotNull(slider)
         assertEquals("slider", slider.getAttribute("role"))
+        assertEquals("0", slider.getAttribute("tabindex"))
+        slider.focus()
+        slider.dispatchEvent(keyEvent("ArrowRight"))
+        awaitA11YChanges()
+        assertEquals(0.51f, slider.getAttribute("aria-valuenow")!!.toFloat())
         assertEquals(0f, slider.getAttribute("aria-valuemin")!!.toFloat())
         assertEquals(1f, slider.getAttribute("aria-valuemax")!!.toFloat())
         assertEquals(0.5f, slider.getAttribute("aria-valuenow")!!.toFloat())

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -27,6 +27,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.RangeSlider
+import androidx.compose.material.Slider
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.getValue
@@ -722,6 +727,106 @@ class CfWA11YTest : OnCanvasTests {
 
         assertEquals("textbox", textField.getAttribute("role"))
         assertEquals("Hello, World!", textField.innerText)
+    }
+
+    @Test
+    fun sliderHasSliderRoleAndRangeValues() = runApplicationTest {
+        var value by mutableStateOf(0.5f)
+
+        createComposeWindow {
+            Slider(
+                value = value,
+                onValueChange = { value = it },
+                modifier = Modifier.testTag("slider"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val slider = getShadowRoot().getElementById("slider") as? HTMLElement
+        assertNotNull(slider)
+        assertEquals("slider", slider.getAttribute("role"))
+        assertEquals(0f, slider.getAttribute("aria-valuemin")!!.toFloat())
+        assertEquals(1f, slider.getAttribute("aria-valuemax")!!.toFloat())
+        assertEquals(0.5f, slider.getAttribute("aria-valuenow")!!.toFloat())
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Test
+    fun rangeSliderHasSliderRoleForBothThumbs() = runApplicationTest {
+        createComposeWindow {
+            RangeSlider(
+                value = 0.25f..0.75f,
+                onValueChange = {},
+                modifier = Modifier.testTag("rangeSlider"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val rangeSlider = getShadowRoot().getElementById("rangeSlider") as? HTMLElement
+        assertNotNull(rangeSlider)
+        val sliders = rangeSlider.querySelectorAll("[role=slider]")
+        assertEquals(2, sliders.length)
+        assertEquals(0.25f, (sliders[0] as HTMLElement).getAttribute("aria-valuenow")!!.toFloat())
+        assertEquals(0.75f, (sliders[1] as HTMLElement).getAttribute("aria-valuenow")!!.toFloat())
+    }
+
+    @Test
+    fun progressIndicatorsHaveProgressbarRoleAndRangeValues() = runApplicationTest {
+        createComposeWindow {
+            LinearProgressIndicator(
+                progress = 0.4f,
+                modifier = Modifier.testTag("progress"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val progress = getShadowRoot().getElementById("progress") as? HTMLElement
+        assertNotNull(progress)
+        assertEquals("progressbar", progress.getAttribute("role"))
+        assertEquals(0f, progress.getAttribute("aria-valuemin")!!.toFloat())
+        assertEquals(1f, progress.getAttribute("aria-valuemax")!!.toFloat())
+        assertEquals(0.4f, progress.getAttribute("aria-valuenow")!!.toFloat())
+    }
+
+    @Test
+    fun indeterminateProgressIndicatorOmitsRangeValues() = runApplicationTest {
+        createComposeWindow {
+            LinearProgressIndicator(modifier = Modifier.testTag("progress"))
+        }
+
+        awaitA11YChanges()
+
+        val progress = getShadowRoot().getElementById("progress") as? HTMLElement
+        assertNotNull(progress)
+        assertEquals("progressbar", progress.getAttribute("role"))
+        assertNull(progress.getAttribute("aria-valuenow"))
+    }
+
+    @Test
+    fun switchHasSwitchRoleAndCheckedState() = runApplicationTest {
+        var checked by mutableStateOf(false)
+
+        createComposeWindow {
+            Switch(
+                checked = checked,
+                onCheckedChange = { checked = it },
+                modifier = Modifier.testTag("switch"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val switch = getShadowRoot().getElementById("switch") as? HTMLElement
+        assertNotNull(switch)
+        assertEquals("switch", switch.getAttribute("role"))
+        assertEquals("false", switch.getAttribute("aria-checked"))
+
+        switch.click()
+        awaitA11YChanges()
+        assertEquals("true", switch.getAttribute("aria-checked"))
     }
 
     @Test


### PR DESCRIPTION
**Changes:**
- Set missing aria roles: progressbar and slider
- Set min,max,current aria values for sliders and progressbars
- Listen to arrow keydown events to trigger slide values changes (mobile web sends a synthetic arrow keydown events!)
- Update the aria-checked state for toggleable elements

Fixes https://youtrack.jetbrains.com/issue/CMP-8612/Web-A11y.-Slider-RangeSlider-ProgressIndicator.-Value-not-passed-to-aria-valuenow-aria-valuetext
Fixes https://youtrack.jetbrains.com/issue/CMP-8619/Web-A11y.-Slider-RangeSlider-ProgressIndicator-Switch-dont-have-role-attribute

**Demo**


https://github.com/user-attachments/assets/0baa18c7-48a1-457c-b11b-d3a3cc295e7e

Note: Voice Over doesn't announce the progress value in the progress indicator (consistent with the behaviour of progress html element)

## Testing
- Added new tests
- This should be tested by QA

## Release Notes
### Fixes - Web
- Fix missing aria attributes for `Slider`, `RangeSlider` and `ProgressIndicator` components

