### PR TITLE
Apply web resize and scale changes eagerly

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/CrashAfterResizeDemo.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/CrashAfterResizeDemo.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+
+private const val CoroutineCount = 100_000
+private const val YieldsPerCoroutine = 10
+
+
+// https://youtrack.jetbrains.com/issue/CMP-10751
+@Composable
+fun CrashAfterResizeDemo() {
+    val compositionScope = rememberCoroutineScope()
+    var attempts by remember { mutableIntStateOf(0) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("Main dispatcher / resize trampoline race")
+        Button(
+            onClick = {
+                compositionScope.launch { scheduleCoroutines() }
+                attempts++
+            }
+        ) {
+            Text("Overload Main and then resize")
+        }
+        Text("Attempts: $attempts")
+        Text("Queued work per attempt: $CoroutineCount coroutines × $YieldsPerCoroutine yields")
+    }
+}
+
+private suspend fun CoroutineScope.scheduleCoroutines() {
+    repeat(CoroutineCount) {
+        launch(Dispatchers.Main) {
+            repeat(YieldsPerCoroutine) {
+                yield()
+            }
+        }
+    }
+    delay(1000.milliseconds)
+    scheduleCoroutines()
+}

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -17,6 +17,7 @@
 package androidx.compose.mpp.demo.bugs
 
 import androidx.compose.mpp.demo.KeyEventsDemo
+import androidx.compose.mpp.demo.CrashAfterResizeDemo
 import androidx.compose.mpp.demo.Screen
 
 val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
@@ -39,6 +40,9 @@ val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
     },
     Screen.Example("Tab Focus With Interop") {
         TabFocusWithInterop()
+    },
+    Screen.Example("Crash after resize") {
+        CrashAfterResizeDemo()
     },
 ))
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -27,9 +27,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.LocalSystemTheme
@@ -111,11 +108,7 @@ import kotlin.js.js
 import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.receiveAsFlow
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoRenderDelegate
@@ -131,7 +124,6 @@ import org.w3c.dom.Node
 import org.w3c.dom.TouchEvent
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventTarget
-import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
@@ -142,7 +134,8 @@ private val actualDensity
 
 internal interface ComposeWindowState {
     fun init() {}
-    fun sizeFlow(): Flow<IntSize>
+    fun currentSize(): IntSize
+    fun observeSizeAndScaleChanges(listener: () -> Unit): () -> Unit
 
     val globalEvents: EventTargetListener
 
@@ -157,7 +150,7 @@ private sealed interface KeyboardModeState {
 }
 
 internal class DefaultWindowState(private val viewportContainer: Element) : ComposeWindowState {
-    private val resizeAndScaleEventsChannel = Channel<IntSize>(CONFLATED)
+    private var sizeChangeListener: (() -> Unit)? = null
 
     override val globalEvents = EventTargetListener(window)
 
@@ -167,7 +160,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
 
     override fun init() {
         val resizeListener: (Event) -> Unit = {
-            resizeAndScaleEventsChannel.trySend(getParentContainerBox())
+            sizeChangeListener?.invoke()
         }
 
         globalEvents.addDisposableEvent("resize", resizeListener)
@@ -178,12 +171,20 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
         viewportTargetListener?.addDisposableEvent("resize", resizeListener)
 
         recreateMediaQueryListener()
-
-        resizeAndScaleEventsChannel.trySend(getParentContainerBox())
     }
 
-    private fun getParentContainerBox(): IntSize {
+    override fun currentSize(): IntSize {
         return IntSize(viewportContainer.clientWidth, viewportContainer.clientHeight)
+    }
+
+    override fun observeSizeAndScaleChanges(listener: () -> Unit): () -> Unit {
+        check(sizeChangeListener == null) { "A size listener is already registered" }
+        sizeChangeListener = listener
+        return {
+            if (sizeChangeListener === listener) {
+                sizeChangeListener = null
+            }
+        }
     }
 
     private fun recreateMediaQueryListener() {
@@ -192,7 +193,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
         mediaQueryListener = object : MediaQueryListener("(resolution: ${contentScale}dppx)") {
             override fun onChange(matches: Boolean) {
                 if (!matches) {
-                    resizeAndScaleEventsChannel.trySend(getParentContainerBox())
+                    sizeChangeListener?.invoke()
                 }
                 recreateMediaQueryListener()
             }
@@ -200,13 +201,11 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
     }
 
     override fun dispose() {
-        resizeAndScaleEventsChannel.close()
+        sizeChangeListener = null
         viewportTargetListener?.dispose()
         mediaQueryListener?.dispose()
         super.dispose()
     }
-
-    override fun sizeFlow() = resizeAndScaleEventsChannel.receiveAsFlow()
 }
 
 @VisibleForTesting
@@ -631,8 +630,10 @@ internal class ComposeWindow(
         initEvents(canvas)
         state.init()
 
-
-        scene.density = density // initial density
+        applyResizeAndScale(
+            size = state.currentSize(),
+            viewportScale = getVisualViewportScale()
+        )
         archComponentsOwner.enableSavedStateHandles()
 
         val interopContainer = WebInteropContainer(InteropViewGroup(interopContainerElement))
@@ -655,13 +656,18 @@ internal class ComposeWindow(
                         }
                     }
 
-                    LaunchedEffect(Unit) {
-                        state.sizeFlow().collect { size ->
-                            // Convert to proper type: IntSize was exposed to public API with meaning of DPs.
-                            val boxSize = DpSize(size.width.dp, size.height.dp)
-                            val viewportScale = getVisualViewportScale()
-                            this@ComposeWindow.resizeAndScale(boxSize, viewportScale)
+                    DisposableEffect(state) {
+                        // Observe the resize/scale events and retrieve the new values.
+                        // Apply new values eagerly to improve resize smoothness and avoid performing
+                        // canvas/scene resize mutations while the recomposer drains composition effects.
+                        // See https://youtrack.jetbrains.com/issue/CMP-10751
+                        val stopObservingSize = state.observeSizeAndScaleChanges {
+                            applyResizeAndScale(
+                                size = state.currentSize(),
+                                viewportScale = getVisualViewportScale()
+                            )
                         }
+                        onDispose(stopObservingSize)
                     }
 
                     LaunchedEffect(Unit) {
@@ -688,7 +694,10 @@ internal class ComposeWindow(
             .navigationEventDispatcher.addInput(navigationEventInput)
     }
 
-    private fun resizeAndScale(boxSize: DpSize, viewportScale: Float) = Snapshot.withMutableSnapshot {
+    private fun applyResizeAndScale(
+        size: IntSize,
+        viewportScale: Float
+    ) = Snapshot.withMutableSnapshot {
         // Coerce the original value so it doesn't exceed 2.0 to avoid unlimited canvas growth and memory consumption.
         // Otherwise, the browser might clip the canvas content (tested in Chrome) making some UI parts unreachable.
         // We accept some blur might be still noticeable on higher than 2.0 scale.
@@ -707,7 +716,8 @@ internal class ComposeWindow(
             scene.density = newDensity
         }
 
-        val sizeInPx = boxSize.toSize(density).toIntSize()
+        val dpSize = DpSize(size.width.dp, size.height.dp)
+        val sizeInPx = dpSize.toSize(density).toIntSize()
 
         // we need to scale canvas both via CSS styling and HTML attributes
         // https://www.khronos.org/webgl/wiki/HandlingHighDPI
@@ -719,7 +729,7 @@ internal class ComposeWindow(
         // the wasm2js boundary. See ComposeViewport for the setup.
 
         _windowInfo.containerSize = sizeInPx
-        _windowInfo.containerDpSize = boxSize
+        _windowInfo.containerDpSize = dpSize
 
         // TODO: Align with Container/Mediator architecture
         skiaLayer.attachTo(canvas)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10751

## Testing
- Added a new demo page
- This should be tested by QA

**Demo (reproduces the crash in compose/mpp/demo):**

https://github.com/user-attachments/assets/8ed0ac59-6be5-4091-8dfd-ce81aabddf25




Before the fix:
```text
   Browser resize
       │
       ▼
   Conflated Channel
       │
       ▼
   LaunchedEffect continuation queued (collection the resize events from the Channel/Flow)
       │
       ▼
   Skiko frame begins
       │
       ▼
   performTrampolineDispatch()
       │
       ├── resumes resize collector
       │       │
       │       └── resize canvas and scene  ◄──  ⚠️ during frame processing; the Skia `canvas` becomes null here
       │
       ▼
   measure / layout / draw ◄── ❌ crash happens here when using a null canvas; the reference to the new resized Skia canvas is not known here yet
```

After the fix:

 ```text
   Browser resize
       │
       ▼
   DisposableEffect-owned listener
       │
       ▼
   Apply canvas and scene size immediately
       │
       ▼
   Schedule rendering
       │
       ▼
   Skiko frame: measure / layout / draw
 ```

**Decisions made here:**
- We could've have postponed the application of the new size to the next frame. But it affects the smoothness of the resize. So I decided to apply new sizes immediately. 

## Release Notes
### Fixes - Web
- _(prerelease fix)_ Fix a crash when resizing a ComposeViewport