### PR TITLE
Move disposed flag to obj-c to avoid Kotlin cleanup

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPAccessibilityElement.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CMPAccessibilityElement : UIAccessibilityElement <UIFocusItem>
 
+@property (nonatomic, assign) BOOL isDisposed;
+
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions;
 
 - (UIAccessibilityTraits)accessibilityTraits;

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitObjcUtils/CMPAccessibilityElement.m
@@ -129,6 +129,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)dealloc {
+    _isDisposed = TRUE;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -570,12 +570,10 @@ private class AccessibilityElement(
 
     val key: AccessibilityElementKey get() = node.key
 
-    private var disposed = false
-
     /**
      * Indicates whether this element is still present in the tree.
      */
-    private val isAlive get() = !disposed && node.semanticsNode.isValid
+    private val isAlive get() = !isDisposed && node.semanticsNode.isValid
 
     init {
         setAccessibilityElements(children + nodeSemanticsElements())
@@ -610,11 +608,11 @@ private class AccessibilityElement(
     }
 
     fun dispose() {
-        check(!disposed) {
+        check(!this.isDisposed) {
             "AccessibilityElement is already disposed"
         }
 
-        disposed = true
+        isDisposed = true
         setAccessibilityContainer(null)
         setAccessibilityElements(emptyList<Any>())
         if (available(OS.Ios to OSVersion(major = 17))) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10615/iOS-AccessibilityElement-is-messaged-after-its-Kotlin-peer-is-freed-CMP-10406s-isAlive-guard-cannot-prevent-the-crash-it-only

## Release Notes
### Fixes - iOS
- Fix crash when iOS reads `AccessibilityElement`'s properties after disposal.