### PR TITLE
Re-expose `LocalSystemTheme` as `@InternalComposeUiApi` and deprecate it

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ProvideSystemTheme.desktop.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jetbrains.skiko.hostOs
 
 private var subscriberCount = 0
 private var pollingJob: Job? = null
@@ -71,7 +70,8 @@ private suspend fun pollCurrentSystemTheme() {
 @Composable
 internal fun ProvideSystemTheme(content: @Composable () -> Unit) {
     CompositionLocalProvider(
-        LocalSystemTheme provides currentSystemTheme.value,
+        @Suppress("DEPRECATION")
+        LocalSystemTheme provides currentSystemTheme.value.asComposeSystemTheme(),
         content = content
     )
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.asComposeSystemTheme
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.navigationevent.IosBackNavigationEventInput
 import androidx.compose.ui.platform.DefaultArchitectureComponentsOwner
@@ -71,7 +72,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
-import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SystemTheme
 import platform.Foundation.NSKeyValueObservingOptionNew
 import platform.Foundation.addObserver
@@ -491,7 +491,8 @@ internal class ComposeContainer(
     private fun ProvideContainerCompositionLocals(content: @Composable () -> Unit) =
         CompositionLocalProvider(
             LocalUIViewController provides containingViewController,
-            LocalSystemTheme provides systemThemeState.value,
+            @Suppress("DEPRECATION")
+            LocalSystemTheme provides systemThemeState.value.asComposeSystemTheme(),
             content = content
         )
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
@@ -19,7 +19,7 @@ package androidx.compose.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
-import org.jetbrains.skiko.SystemTheme
+import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
 import org.jetbrains.skiko.currentSystemTheme
 
 @Deprecated("This class was made public by mistake and will be removed in a future release")
@@ -27,11 +27,25 @@ enum class SystemTheme {
     Dark, Light, Unknown
 }
 
-internal val LocalSystemTheme = staticCompositionLocalOf { currentSystemTheme }
+@Deprecated("This property was made public by mistake and will be removed in a future release")
+@InternalComposeUiApi
+val LocalSystemTheme = staticCompositionLocalOf {
+    currentSystemTheme.asComposeSystemTheme()
+}
 
+@Suppress("DEPRECATION")
+internal fun SkikoSystemTheme.asComposeSystemTheme() : SystemTheme {
+    return when (this) {
+        SkikoSystemTheme.DARK -> SystemTheme.Dark
+        SkikoSystemTheme.LIGHT -> SystemTheme.Light
+        SkikoSystemTheme.UNKNOWN -> SystemTheme.Unknown
+    }
+}
+
+@Suppress("DEPRECATION")
 @InternalComposeUiApi
 @Composable
 @ReadOnlyComposable
 fun isUiSystemInDarkTheme(): Boolean {
-    return LocalSystemTheme.current == SystemTheme.DARK
+    return LocalSystemTheme.current == SystemTheme.Dark
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import org.jetbrains.skiko.SystemTheme
 import platform.UIKit.UIUserInterfaceStyle
 
 class SystemThemeTest {
@@ -34,7 +36,7 @@ class SystemThemeTest {
             systemTheme = LocalSystemTheme.current
         }
 
-        assertEquals(SystemTheme.LIGHT, systemTheme)
+        assertEquals(SystemTheme.Light, systemTheme)
     }
 
     @Test
@@ -45,7 +47,7 @@ class SystemThemeTest {
             systemTheme = LocalSystemTheme.current
         }
 
-        assertEquals(SystemTheme.DARK, systemTheme)
+        assertEquals(SystemTheme.Dark, systemTheme)
     }
 
     @Test
@@ -59,14 +61,14 @@ class SystemThemeTest {
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleLight
-        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.LIGHT }
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleDark
-        waitUntil("System theme should eventually be Dark") { systemTheme == SystemTheme.DARK }
+        waitUntil("System theme should eventually be Dark") { systemTheme == SystemTheme.Dark }
 
         appDelegate.window?.overrideUserInterfaceStyle =
             UIUserInterfaceStyle.UIUserInterfaceStyleLight
-        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.LIGHT }
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
     }
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.asComposeSystemTheme
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.geometry.Offset
@@ -644,7 +645,8 @@ internal class ComposeWindow(
         }
         scene.setContent {
             CompositionLocalProvider(
-                LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value,
+                @Suppress("DEPRECATION")
+                LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value.asComposeSystemTheme(),
                 LocalInteropContainer provides interopContainer,
                 LocalActiveClipEventsTarget provides clipEventsTargetProvider,
                 LocalComposeWindow provides this,


### PR DESCRIPTION
Re-expose `LocalSystemTheme` as `@InternalComposeUiApi` and deprecate it

Fixes https://youtrack.jetbrains.com/issue/CMP-10761/Temporarily-re-expose-LocalSystemTheme

## Testing
N/A

## Release Notes
### Migration Notes - Multiple Platforms
- Temporarily re-exposed `LocalSystemTheme` (as `@InternalComposeUiApi`) and deprecated it. It will be removed in a future release.
