### PR TITLE
Fix ComposeViewport canvas overflow at fractional scales

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -55,7 +55,7 @@ fun ComposeViewport(
 
 /**
  * Creates the composition in HTML canvas created in parent container identified by [viewportContainer] Element.
- * This size of canvas is adjusted with the size of the container
+ * This size of canvas is adjusted with the size of the container which must have definite dimensions.
  *
  * <container>
  *   <positioning_container>
@@ -93,6 +93,9 @@ fun ComposeViewport(
     val positioningContainer = ComposeWindow.createComposeComponent()
     positioningContainer.style.apply {
         position = "relative"
+        display = "block" // inline by default for custom elements; 'block' - is the default for <div>
+        width = "100%"
+        height = "100%"
     }
     viewportContainer.appendChild(positioningContainer)
 
@@ -100,6 +103,8 @@ fun ComposeViewport(
     val shadowContainer = document.createElement("div") as HTMLDivElement
     shadowContainer.style.apply {
         position = "relative"
+        width = "100%"
+        height = "100%"
     }
     positioningContainer.appendChild(shadowContainer)
 
@@ -154,6 +159,8 @@ fun ComposeViewport(
     val appContainer = document.createElement("div") as HTMLElement
     appContainer.style.apply {
         position = "relative"
+        width = "100%"
+        height = "100%"
     }
     shadowRoot.appendChild(appContainer)
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeViewportSizeTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeViewportSizeTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.OnCanvasTests
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.w3c.dom.HTMLElement
+
+class ComposeViewportSizeTest : OnCanvasTests {
+
+    @Test
+    fun backingStoreSizeDoesNotAffectCanvasCssSize() = runApplicationTest {
+        val container = getContainer() as HTMLElement
+        val originalContainerStyle = container.style.cssText
+
+        container.style.apply {
+            width = "801px"
+            height = "600px"
+            padding = "0"
+            border = "0"
+        }
+
+        createComposeWindow { /* The content doesn't matter for this test */ }
+
+        val canvas = getCanvas()
+        val containerBounds = container.getBoundingClientRect()
+        val before = canvas.getBoundingClientRect()
+        val originalHeight = canvas.height
+
+        assertEquals(containerBounds.width, before.width, absoluteTolerance = 0.01)
+        assertEquals(containerBounds.height, before.height, absoluteTolerance = 0.01)
+
+        // Change the canvas' backing store size.
+        canvas.height = originalHeight + 10
+
+        // Flush pending layout and read the resulting CSS dimensions.
+        val after = canvas.getBoundingClientRect()
+
+        assertEquals(before.width, after.width, absoluteTolerance = 0.01)
+        assertEquals(before.height, after.height, absoluteTolerance = 0.01)
+    }
+}


### PR DESCRIPTION
**Description:**
The generated positioning container and its nested containers did not establish a definite sizing chain. As a result, the canvas’s height: 100% could not always resolve against the viewport container, and its rendered CSS size could fall back to the intrinsic aspect ratio derived from the canvas.width and canvas.height backing-store attributes.

At fractional display scales, independently rounded backing-store dimensions could make the rendered canvas slightly taller than the viewport container, causing browser scrollbars.

Giving the positioning container and its nested containers explicit dimensions ensures that the canvas’s CSS bounds are determined by the viewport container and remain independent of its backing-store size.
___

Fixes https://youtrack.jetbrains.com/issue/CMP-10762/Scrollbar-appears-at-some-browser-zoom-levels (see the screenshot of the problem there)

## Testing
- This should be tested by QA
- Added a new test

## Release Notes
N/A