### PR TITLE
Make `awaitDragOrCancellationImpl` deliver move events even if the pointer hasn't moved

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGestureDetector.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGestureDetector.skiko.kt
@@ -17,11 +17,22 @@
 package androidx.compose.foundation.gestures
 
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.positionChangedIgnoreConsumed
 
 internal actual suspend fun AwaitPointerEventScope.awaitDragOrCancellationImpl(
     pointerId: PointerId
 ): PointerInputChange? {
-    return defaultAwaitDragOrCancellationImpl(pointerId)
+    if (currentEvent.isPointerUp(pointerId)) {
+        return null // The pointer has already been lifted, so the gesture is canceled
+    }
+    // The default/Android implementation just checks whether the pointer moved.
+    // But if the target element has moved instead while the pointer is stationary, we still need to
+    // deliver the (synthetic) move event.
+    val change = awaitDragOrUp(pointerId) { event, change ->
+        change.positionChangedIgnoreConsumed() || (event.type == PointerEventType.Move)
+    }
+    return if (change?.isConsumed == false) change else null
 }

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
@@ -18,11 +18,15 @@ package androidx.compose.ui.test
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.*
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.onClick
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.*
@@ -460,5 +464,84 @@ class MouseInputTest {
             message = (if (message == null) "" else "$message; ") +
                 "expected=$expected, actual=$actual, toleratedDistance=$toleratedDistance"
         )
+    }
+
+    private fun Modifier.dragWithNoMoveWorkaround(
+        onDrag: (PointerInputChange) -> Unit
+    ) = this
+        .pointerInput(onDrag) {
+            awaitPointerEventScope {
+                val press = awaitFirstDown()
+                val pointerId = press.id
+                drag(pointerId) { change ->
+                    onDrag(change)
+                    change.consume()
+                }
+            }
+        }
+
+    // Verify that only move events are consumed during drag
+    @Test
+    fun scrollDuringDragIsNotConsumed() = androidx.compose.ui.test.v2.runComposeUiTest {
+        var scrollEventReceived = false
+        setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("box")
+                    .size(100.dp)
+                    .onPointerEvent(PointerEventType.Scroll) {
+                        scrollEventReceived = true
+                    }
+                    .dragWithNoMoveWorkaround { }
+            )
+        }
+
+        onNodeWithTag("box").performMouseInput {
+            press()
+            moveBy(Offset(0f, 20f))
+            scroll(Offset(0f, 20f))
+            release()
+        }
+
+        assertTrue(scrollEventReceived)
+    }
+
+    // Verify that moving the underlying element during a drag gesture causes a drag event to be
+    // detected.
+    @Test
+    fun dragCalledWhenElementIsMoved() = androidx.compose.ui.test.v2.runComposeUiTest {
+        var pointerPosition = Offset.Unspecified
+        val scrollState = ScrollState(0)
+        setContent {
+            Box(
+                modifier = Modifier
+                    .size(100.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .testTag("box")
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .dragWithNoMoveWorkaround { change ->
+                            pointerPosition = change.position
+                        }
+                )
+            }
+        }
+
+        onNodeWithTag("box").performMouseInput {
+            moveTo(Offset(0f, 0f))
+            press()
+        }
+
+        scrollState.scrollTo(50)
+        awaitIdle()
+
+        onNodeWithTag("box").performMouseInput {
+            release()
+        }
+
+        assertEquals(Offset(0f, 50f), pointerPosition)
     }
 }


### PR DESCRIPTION
Make `awaitDragOrCancellationImpl` deliver move events even if the pointer hasn't moved.

This allows `SelectionContainer` to auto-scroll when dragging the selection without having to jiggle the mouse.


https://github.com/user-attachments/assets/71a2dd2b-edc7-4ede-b0ea-f42b458e37bf


Fixes https://youtrack.jetbrains.com/issue/CMP-10396

## Testing
Tested manually and added unit tests.

```
private const val LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

fun main() = singleWindowApplication(
    state = WindowState(size = DpSize(600.dp, 400.dp))
) {
    SelectionContainer(Modifier.background(Color.LightGray)) {
        Column(
            Modifier.fillMaxSize().padding(32.dp).verticalScroll(rememberScrollState()),
            verticalArrangement = Arrangement.spacedBy(24.dp)
        ) {
            repeat(20) {
                Text(LoremIpsum)
            }
        }
    }
}
```

## Release Notes
### Fixes - Multiple Platforms
- Dragging to select text will now automatically scroll the contents of a `SelectionContainer` when dragging to outside the container, without the need to jiggle the mouse/pointer.

