### PR TITLE
Don't publish constraints on libraries that are not published

### DIFF
--- a/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc-fork/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -116,6 +116,7 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 import org.gradle.plugin.devel.tasks.ValidatePlugins
 import org.gradle.process.CommandLineArgumentProvider
+import org.jetbrains.androidx.build.JetBrainsPublication
 import org.jetbrains.androidx.build.jetBrainsGetDefaultAndroidBaseJavaVersion
 import org.jetbrains.androidx.build.jetBrainsGetDefaultTargetJavaVersion
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -1302,6 +1303,9 @@ abstract class AndroidXImplPlugin @Inject constructor() : Plugin<Project> {
                 val otherProjectShouldExist =
                     allProjectsExist || findProject(otherGradlePath) != null
                 if (!otherProjectShouldExist) {
+                    continue
+                }
+                if (!JetBrainsPublication.shouldPublish(otherGradlePath)) {
                     continue
                 }
                 // We only emit constraints referring to projects that will release

--- a/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
+++ b/buildSrc-fork/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
@@ -130,7 +130,7 @@ internal fun Project.configureDependencyVerification() {
                     .asSequence()
                     .map { project.configurations.getByName(it) }
                     .flatMap { configuration ->
-                        configuration.allDependencies
+                        configuration.allDependencies.asSequence()
                             .filter { it.group != null && it.version != null }
                             .map { dependency ->
                                 AndroidXDependency(
@@ -140,6 +140,19 @@ internal fun Project.configureDependencyVerification() {
                                     configuration.name,
                                 )
                             }
+                            .plus(
+                                configuration.allDependencyConstraints
+                                    .asSequence()
+                                    .filter { it.version != null }
+                                    .map { constraint ->
+                                        AndroidXDependency(
+                                            constraint.group,
+                                            constraint.name,
+                                            constraint.version!!,
+                                            configuration.name,
+                                        )
+                                    }
+                            )
                     }
                     .toList()
             }

--- a/buildSrc-fork/tests/src/test/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTaskTest.kt
+++ b/buildSrc-fork/tests/src/test/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTaskTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.androidx.build
+
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class JetBrainsVerifyDependencyVersionsTaskTest {
+    @get:Rule
+        val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `fails when dependency is less stable`() {
+        testProject(
+            version = "1.0.0-alpha01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-SNAPSHOT")
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0-beta01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-alpha01")
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0-rc01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-beta01")
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-rc01")
+            """.trimIndent(),
+        ).buildAndFail()
+    }
+
+    @Test
+    fun `succeeds when dependency is as stable`() {
+        testProject(
+            version = "1.0.0-alpha01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-alpha02")
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0-beta01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-beta02")
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0-rc01",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.0-rc02")
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0",
+            dependencies = """
+                implementation("androidx.example:dependency:1.0.1")
+            """.trimIndent(),
+        ).build()
+    }
+
+    @Test
+    fun `fails when constraint is less stable`() {
+        testProject(
+            version = "1.0.0-alpha01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-SNAPSHOT")
+                }
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0-beta01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-alpha01")
+                }
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0-rc01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-beta01")
+                }
+            """.trimIndent(),
+        ).buildAndFail()
+        testProject(
+            version = "1.0.0",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-rc01")
+                }
+            """.trimIndent(),
+        ).buildAndFail()
+    }
+
+    @Test
+    fun `succeeds when constraint is as stable`() {
+        testProject(
+            version = "1.0.0-alpha01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-alpha02")
+                }
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0-beta01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-beta02")
+                }
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0-rc01",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.0-rc02")
+                }
+            """.trimIndent(),
+        ).build()
+        testProject(
+            version = "1.0.0",
+            dependencies = """
+                constraints {
+                    implementation("androidx.example:constrained:1.0.1")
+                }
+            """.trimIndent(),
+        ).build()
+    }
+
+    private fun testProject(version: String, dependencies: String): GradleRunner {
+        val root = temporaryFolder.newFolder()
+        root.resolve("compose/ui/ui").mkdirs()
+        val pluginClasspath = System.getProperty("java.class.path")
+            .split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .joinToString(",\n") { "\"${File(it).invariantSeparatorsPath}\"" }
+        root.resolve("settings.gradle").writeText("include(\":compose:ui:ui\")")
+        root.resolve("build.gradle").writeText(
+            """
+                import static org.jetbrains.androidx.build.JetBrainsVerifyDependencyVersionsTaskKt.configureDependencyVerification
+
+                buildscript {
+                    dependencies {
+                        classpath(files([$pluginClasspath]))
+                    }
+                }
+
+                project(":compose:ui:ui") {
+                    version = "$version"
+                    apply plugin: "org.jetbrains.kotlin.multiplatform"
+
+                    kotlin {
+                        jvm()
+
+                        sourceSets {
+                            jvmMain.dependencies {
+                                $dependencies
+                            }
+                        }
+                    }
+
+                    configureDependencyVerification(project)
+                }
+            """.trimIndent(),
+        )
+
+        return GradleRunner.create()
+            .withProjectDir(root)
+            .withArguments(":compose:ui:ui:jbVerifyDependencyVersions", "--stacktrace")
+    }
+}

--- a/buildSrc-fork/tests/src/test/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTaskTest.kt
+++ b/buildSrc-fork/tests/src/test/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTaskTest.kt
@@ -24,7 +24,7 @@ import org.junit.rules.TemporaryFolder
 
 class JetBrainsVerifyDependencyVersionsTaskTest {
     @get:Rule
-        val temporaryFolder = TemporaryFolder()
+    val temporaryFolder = TemporaryFolder()
 
     @Test
     fun `fails when dependency is less stable`() {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10766/Maven-Central-SNAPSHOT-versions-not-allowed-for-dependency-org.jetbrains.androidx.navigationnavigation-testing

Regression from [#3264](https://github.com/JetBrains/compose-multiplatform-core/pull/3264), which began rewriting the unselected `navigation-testing` project constraint to `9999.0.0-SNAPSHOT`. That exposed the underlying issue: atomic-group constraints were emitted for AndroidX artifacts not published by the JetBrains fork. Only publishable JetBrains components now receive those constraints.

## Testing

Generate a diff:

```sh
git checkout origin/jb-main
./gradlew -Pcompose.platforms=desktop,linux --rerun-tasks -Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL3,COMPOSE_MATERIAL3_ADAPTIVE,NAVIGATION,NAVIGATION_3 -Pjetbrains.publication.version.COMPOSE=1.13.0-alpha01+dev4743 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.13.0-alpha01+dev4743 -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=1.3.0-rc01+dev4743 -Pjetbrains.publication.version.NAVIGATION=2.10.0-beta01+dev4743 -Pjetbrains.publication.version.NAVIGATION_3=1.2.0-beta01+dev4743 -Dorg.gradle.daemon=false publishComposeJb --console=plain
mv out/repository out/repository-before-fix-desktop-linux

git checkout <fix-commit>
./gradlew -Pcompose.platforms=desktop,linux --rerun-tasks -Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL3,COMPOSE_MATERIAL3_ADAPTIVE,NAVIGATION,NAVIGATION_3 -Pjetbrains.publication.version.COMPOSE=1.13.0-alpha01+dev4743 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.13.0-alpha01+dev4743 -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=1.3.0-rc01+dev4743 -Pjetbrains.publication.version.NAVIGATION=2.10.0-beta01+dev4743 -Pjetbrains.publication.version.NAVIGATION_3=1.2.0-beta01+dev4743 -Dorg.gradle.daemon=false publishComposeJb --console=plain

diff -ru "out/repository-before-fix-desktop-linux" "out/repository" > out/published-repository.diff || true
```

[published-repository.txt](https://github.com/user-attachments/files/31922698/published-repository.txt)

contains removing constraints against "unspecified" versions of incorrect groups:
```
       <dependency>
-        <groupId>compose-multiplatform-core.compose.ui</groupId>
-        <artifactId>ui-test-manifest-lint</artifactId>
-        <version>unspecified</version>
-      </dependency>
```
and removing:
```
-        {
-          "group": "org.jetbrains.androidx.navigation",
-          "module": "navigation-testing",
-          "version": {
-            "requires": "9999.0.0-SNAPSHOT"
-          },
-          "reason": "navigation-common is in atomic group androidx.navigation"
         }
```


```sh
./gradlew -p buildSrc :tests:test --tests org.jetbrains.androidx.build.JetBrainsVerifyDependencyVersionsTaskTest --no-daemon --no-configuration-cache --console=plain
```

## Release Notes
N/A
