### PR TITLE
Fix repeated web locale parsing during composition

### DIFF
--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
@@ -69,16 +69,16 @@ internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     WebPlatformLocaleDelegate()
 
 private class WebPlatformLocaleDelegate : PlatformLocaleDelegate {
-    private val currentLocaleList = mutableStateOf(readCurrentLocaleList())
+    private var currentLocaleList = readCurrentLocaleList()
 
     init {
         addLanguageChangeListener {
-            currentLocaleList.value = readCurrentLocaleList()
+            currentLocaleList = readCurrentLocaleList()
         }
     }
 
     override val current: LocaleList
-        get() = currentLocaleList.value
+        get() = currentLocaleList
 
 
     private fun readCurrentLocaleList() = localeListFromLanguageTags(userPreferredLanguages())

--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.text.intl
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.util.fastMapNotNull
 import kotlin.js.ExperimentalWasmJsInterop
@@ -65,10 +66,24 @@ actual class Locale internal constructor(internal val platformLocale: IntlLocale
 private const val FALLBACK_LANGUAGE_TAG = "en-001"
 
 internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
-    object : PlatformLocaleDelegate {
-        override val current: LocaleList
-            get() = localeListFromLanguageTags(userPreferredLanguages())
+    WebPlatformLocaleDelegate()
+
+private class WebPlatformLocaleDelegate : PlatformLocaleDelegate {
+    private val currentLocaleList = mutableStateOf(readCurrentLocaleList())
+
+    init {
+        addLanguageChangeListener {
+            currentLocaleList.value = readCurrentLocaleList()
+        }
     }
+
+    override val current: LocaleList
+        get() = currentLocaleList.value
+
+
+    private fun readCurrentLocaleList() = localeListFromLanguageTags(userPreferredLanguages())
+}
+
 
 internal fun localeListFromLanguageTags(tags: List<String>): LocaleList {
     val locales = tags.fastMapNotNull { it.toIntlLocaleOrNull()?.let(::Locale) }
@@ -128,3 +143,8 @@ private fun userPreferredLanguages(): List<String> {
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun getUserPreferredLanguagesAsArray(): JsArray<JsString> =
     js("window.navigator.languages")
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun addLanguageChangeListener(listener: () -> Unit) {
+    js("window.addEventListener('languagechange', listener)")
+}

--- a/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/intl/PlatformLocaleWebTest.kt
+++ b/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/intl/PlatformLocaleWebTest.kt
@@ -16,8 +16,12 @@
 
 package androidx.compose.ui.text.intl
 
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.js
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 // Covers https://youtrack.jetbrains.com/issue/CMP-10359
@@ -52,4 +56,47 @@ class PlatformLocaleWebTest {
         val current = Locale.current
         assertTrue(current.toLanguageTag().isNotEmpty())
     }
+
+    @Test
+    fun localeCurrent_isCachedAndUpdatedOnLanguageChange() {
+        val current = Locale.current
+        val frLang = "fr-FR"
+
+        assertNotEquals(frLang, current.toLanguageTag())
+
+        withNavigatorLanguage(frLang) {
+            val first = Locale.current
+            val second = Locale.current
+
+            assertEquals(frLang, first.toLanguageTag())
+            assertSame(first, second)
+        }
+    }
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun withNavigatorLanguage(languageTag: String, block: () -> Unit) {
+    js(
+        """
+        const navigator = window.navigator;
+        const hadOwnProperty = Object.prototype.hasOwnProperty.call(navigator, "languages");
+        const originalDescriptor = Object.getOwnPropertyDescriptor(navigator, "languages");
+
+        try {
+            Object.defineProperty(navigator, "languages", {
+                configurable: true,
+                value: [languageTag]
+            });
+            window.dispatchEvent(new Event("languagechange"));
+            block();
+        } finally {
+            if (hadOwnProperty) {
+                Object.defineProperty(navigator, "languages", originalDescriptor);
+            } else {
+                delete navigator.languages;
+            }
+            window.dispatchEvent(new Event("languagechange"));
+        }
+        """
+    )
 }


### PR DESCRIPTION
Cache the current LocaleList in the web platform locale delegate and refresh it when the browser fires the `languagechange` event. Store the cached value in Compose state so locale consumers are recomposed after the browser language changes.

Fixes https://youtrack.jetbrains.com/issue/CMP-10768

## Testing
Added new test case

## Release Notes
### Fixes - Web
- Fix repeated web locale parsing during composition
