### PR TITLE
fix: Use FontSynthesis.All as the default in toSkTextStyle (nonAndroid target)

### DIFF
--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
@@ -205,7 +205,7 @@ private sealed interface ComputedStyle {
                     it,
                     fontWeight ?: FontWeight.Normal,
                     fontStyle ?: FontStyle.Normal,
-                    fontSynthesis ?: FontSynthesis.None
+                    fontSynthesis ?: FontSynthesis.All
                 ).value as FontLoadResult
                 res.fontFamilies = resolved.aliases.toTypedArray()
                 res.typeface = resolved.typeface


### PR DESCRIPTION
`toSkTextStyle` fell back to `FontSynthesis.None` when the style had no `fontSynthesis`, while the `Op.StyleAdd` pre-resolve and `resolveFontFamily` in the same file fell back to `FontSynthesis.All`. `fontSynthesis` is part of `TypefaceRequest`, which is the key of the 16-entry `FontFamilyResolver` result cache, so every style without an explicit `fontSynthesis` was resolved and cached twice under two different keys, halving the effective cache size.

Align on `FontSynthesis.All`, which is what `FontFamily.Resolver.resolve` defaults to and what the Android code paths already use.

There is no visual change on non-Android targets: `synthesizeTypeface` is a no-op on desktop, native and web, so only the cache key and the number of resolutions change.

## Testing
N/A since there are no testable changes

## Release Notes
### Fixes - Multiple Platforms
- Fix a text style without an explicit `fontSynthesis` being resolved twice in the font resolver cache on desktop, iOS and web


## Google CLA
Sign the Google Contributor's License Agreement at https://cla.developers.google.com to let us upstream your code to Google's AOSP repository
