### PR TITLE
Supported bullets drawing in AnnotatedString

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/BulletListDemo.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/BulletListDemo.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components.text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.Bullet
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun BulletListDemo() {
+    val textStyle = TextStyle(fontSize = 20.sp)
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Case("1. Control: SpanStyle (must work everywhere)") {
+            Text(
+                buildAnnotatedString {
+                    append("plain, ")
+                    withStyle(SpanStyle(color = Color.Red, fontWeight = FontWeight.Bold)) {
+                        append("red bold")
+                    }
+                    append(", plain")
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("2. Default bullet list") {
+            Text(
+                buildAnnotatedString {
+                    append("Not a bullet item\n")
+                    withBulletList {
+                        withBulletListItem { append("Item 1") }
+                        withBulletListItem { append("Item 2") }
+                    }
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("3. Nested bullet list") {
+            Text(
+                buildAnnotatedString {
+                    withBulletList {
+                        withBulletListItem { append("Item 1") }
+                        withBulletList { withBulletListItem { append("Nested item 2") } }
+                        withBulletListItem { append("Item 3") }
+                    }
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("4. Custom bullets: rect / stroke / colored") {
+            val rect = Bullet.Default.copy(shape = RectangleShape)
+            val stroked = rect.copy(drawStyle = Stroke(width = 2f))
+            val colored = rect.copy(brush = SolidColor(Color.Magenta))
+            Text(
+                buildAnnotatedString {
+                    withBulletList(bullet = rect) {
+                        withBulletListItem { append("Rectangle") }
+                        withBulletListItem(bullet = stroked) { append("Stroke") }
+                        withBulletListItem(bullet = colored) { append("Magenta") }
+                    }
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("5. Multi-line item (marker must be painted once, on the first line)") {
+            Text(
+                buildAnnotatedString {
+                    withBulletList {
+                        withBulletListItem {
+                            append(
+                                "This list item is deliberately long so that it wraps onto " +
+                                    "several lines and shows whether the marker is painted once " +
+                                    "per paragraph or once per line."
+                            )
+                        }
+                    }
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("6. addBullet directly, bypassing withBulletList") {
+            Text(
+                buildAnnotatedString {
+                    withStyle(
+                        ParagraphStyle(
+                            textIndent = TextIndent(
+                                Bullet.DefaultIndentation,
+                                Bullet.DefaultIndentation,
+                            )
+                        )
+                    ) {
+                        val start = length
+                        append("Manual bullet via addBullet")
+                        addBullet(Bullet.Default, start, length)
+                    }
+                },
+                style = textStyle,
+            )
+        }
+
+        Case("7. Reference: same indentation, no Bullet annotation") {
+            Text(
+                buildAnnotatedString {
+                    withStyle(ParagraphStyle(textIndent = TextIndent(1.em, 1.em))) {
+                        append("Indented paragraph without any bullet")
+                    }
+                },
+                style = textStyle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Case(title: String, content: @Composable () -> Unit) {
+    Text(title, style = TextStyle(fontSize = 12.sp, color = Color(0xFF6650A4)))
+    Spacer(Modifier.height(4.dp))
+    content()
+    Spacer(Modifier.height(20.dp))
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
@@ -27,4 +27,5 @@ val TextDemos = Screen.Selection(
     Screen.Example("TextDirection") { TextDirection() },
     Screen.Example("TextOverflow") { TextOverflow() },
     Screen.Example("LinkAnnotation") { AttributedStringDemo() },
+    Screen.Example("Annotations (Bullets)") { BulletListDemo() },
 )

--- a/compose/ui/ui-skiko/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopBulletPaintTest.kt
+++ b/compose/ui/ui-skiko/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopBulletPaintTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.text.AnnotatedString.Range
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DesktopBulletPaintTest : SkikoComposeTestBase() {
+
+    private val fontFamilyResolver = createFontFamilyResolver()
+    private val defaultDensity = Density(density = 1f)
+    private val canvasWidth = 200
+    private val canvasHeight = 60
+
+    private val fontSize = 20.sp
+    private val bulletSizePx = 10
+    private val paddingPx = 4
+    private val bullet = Bullet(
+        shape = RectangleShape,
+        width = bulletSizePx.sp,
+        height = bulletSizePx.sp,
+        padding = paddingPx.sp,
+        brush = SolidColor(Color.Red)
+    )
+
+    /** The paragraph is indented by one em, see [paragraph]. */
+    private val indentPx = with(defaultDensity) { fontSize.toPx() }
+
+    @Test
+    fun bullet_isPaintedIntoTheLeadingMargin() {
+        val bounds = checkNotNull(
+            redBounds(paint(bullets = listOf(Range(bullet, 0, TEXT.length))))
+        ) { "no bullet was painted" }
+
+        // The text starts after the indentation ...
+        assertThat(paragraph(bullets = emptyList()).getLineLeft(0)).isEqualTo(indentPx)
+
+        // ... and the bullet is drawn at its requested size, right aligned in the margin the
+        // indentation leaves, one padding away from the text.
+        assertThat(bounds.left).isEqualTo(indentPx.toInt() - paddingPx - bulletSizePx)
+        assertThat(bounds.width).isEqualTo(bulletSizePx)
+
+        // Vertically the bullet is centered on the line, so it may bleed into an extra blended row.
+        assertThat(bounds.height).isIn(bulletSizePx..(bulletSizePx + 1))
+    }
+
+    @Test
+    fun withoutBulletAnnotation_nothingIsPaintedIntoTheLeadingMargin() {
+        assertThat(redBounds(paint(bullets = emptyList()))).isNull()
+    }
+
+    private fun paragraph(bullets: List<Range<Bullet>>): Paragraph {
+        val intrinsics = ParagraphIntrinsics(
+            text = TEXT,
+            style = TextStyle(
+                fontSize = fontSize,
+                color = Color.Black,
+                textIndent = TextIndent(firstLine = 1.em, restLine = 1.em)
+            ),
+            annotations = bullets,
+            density = defaultDensity,
+            fontFamilyResolver = fontFamilyResolver
+        )
+        return Paragraph(
+            paragraphIntrinsics = intrinsics,
+            constraints = Constraints(maxWidth = canvasWidth),
+            overflow = TextOverflow.Clip
+        )
+    }
+
+    private fun paint(bullets: List<Range<Bullet>>): ImageBitmap {
+        val image = ImageBitmap(canvasWidth, canvasHeight)
+        paragraph(bullets).paint(Canvas(image))
+        return image
+    }
+
+    private fun redBounds(image: ImageBitmap): PixelBounds? {
+        val pixels = image.toPixelMap()
+        var left = Int.MAX_VALUE
+        var top = Int.MAX_VALUE
+        var right = Int.MIN_VALUE
+        var bottom = Int.MIN_VALUE
+        for (y in 0 until image.height) {
+            for (x in 0 until image.width) {
+                val color = pixels[x, y]
+                // Blending against the transparent canvas keeps the hue but not the exact color.
+                if (color.red > 0.5f && color.green < 0.5f && color.blue < 0.5f) {
+                    if (x < left) left = x
+                    if (x > right) right = x
+                    if (y < top) top = y
+                    if (y > bottom) bottom = y
+                }
+            }
+        }
+        return if (right < left) null else PixelBounds(left, top, right, bottom)
+    }
+
+    private data class PixelBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+        val width get() = right - left + 1
+        val height get() = bottom - top + 1
+    }
+
+    private companion object {
+        const val TEXT = "Item"
+    }
+}

--- a/compose/ui/ui-skiko/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntrinsicsIndentTest.kt
+++ b/compose/ui/ui-skiko/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntrinsicsIndentTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.text.platform.Font
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Intrinsic widths of an indented paragraph, measured with a fixed advance test font so that the
+ * expected numbers can be derived from the text length instead of from another measurement.
+ */
+@RunWith(JUnit4::class)
+class DesktopParagraphIntrinsicsIndentTest : SkikoComposeTestBase() {
+
+    private val fontFamilyResolver = createFontFamilyResolver()
+    private val fontFamilyMeasureFont =
+        FontFamily(
+            Font(
+                "font_desktop/sample_font.ttf",
+                weight = FontWeight.Normal,
+                style = FontStyle.Normal
+            )
+        )
+    private val defaultDensity = Density(density = 1f)
+    private val fontSize = 10.sp
+    private val fontSizeInPx = with(defaultDensity) { fontSize.toPx() }
+
+    /** Every glyph of the measure font advances by exactly the font size. */
+    private val textWidthInPx = TEXT.length * fontSizeInPx
+
+    @Test
+    fun withoutIndent_maxIntrinsicWidth_isTheTextWidth() {
+        val intrinsics = intrinsics(textIndent = null)
+
+        assertThat(intrinsics.maxIntrinsicWidth).isWithin(TOLERANCE).of(textWidthInPx)
+    }
+
+    @Test
+    fun spIndent_isAddedToMaxIntrinsicWidth() {
+        val intrinsics = intrinsics(textIndent = TextIndent(firstLine = 30.sp))
+
+        assertThat(intrinsics.maxIntrinsicWidth).isWithin(TOLERANCE).of(textWidthInPx + 30f)
+    }
+
+    @Test
+    fun emIndent_isAddedToMaxIntrinsicWidth() {
+        // The unit a bullet list uses, see Bullet.DefaultIndentation.
+        val intrinsics = intrinsics(textIndent = TextIndent(firstLine = 1.em))
+
+        assertThat(intrinsics.maxIntrinsicWidth)
+            .isWithin(TOLERANCE)
+            .of(textWidthInPx + fontSizeInPx)
+    }
+
+    @Test
+    fun indentedText_needsTheIndentedWidth_toFitIntoASingleLine() {
+        val textIndent = TextIndent(firstLine = 30.sp)
+
+        // The width skia reports on its own, without the indentation, is one line short ...
+        assertThat(lineCount(textIndent, maxWidth = textWidthInPx.toInt())).isEqualTo(2)
+
+        // ... while the width the paragraph reports as intrinsic fits the text.
+        assertThat(lineCount(textIndent, maxWidth = (textWidthInPx + 30f).toInt())).isEqualTo(1)
+    }
+
+    private fun lineCount(textIndent: TextIndent, maxWidth: Int) = Paragraph(
+        paragraphIntrinsics = intrinsics(textIndent),
+        constraints = Constraints(maxWidth = maxWidth),
+        overflow = TextOverflow.Clip
+    ).lineCount
+
+    private fun intrinsics(textIndent: TextIndent?) = ParagraphIntrinsics(
+        text = TEXT,
+        style = TextStyle(
+            fontSize = fontSize,
+            fontFamily = fontFamilyMeasureFont,
+            textIndent = textIndent
+        ),
+        annotations = emptyList(),
+        density = defaultDensity,
+        fontFamilyResolver = fontFamilyResolver
+    )
+
+    private companion object {
+        // Skia drops the indentation when a single unbreakable run does not fit into what is left
+        // of the width, so the text needs several words.
+        const val TEXT = "abc abc"
+        const val TOLERANCE = 0.001f
+    }
+}

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoBulletPainter.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoBulletPainter.nonAndroid.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSimple
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.TextUnit
+
+/**
+ * Draws [Bullet] markers into the leading margin of a paragraph.
+ *
+ * Skia's paragraph has no notion of a leading margin span, so the marker is painted separately
+ * right after the text. The [Paint] is reused between calls because painting happens on every
+ * frame.
+ *
+ * Note that the right-to-left placement has not been verified visually.
+ */
+internal class SkikoBulletPainter {
+    private val paint = Paint()
+
+    /**
+     * @param xStart x coordinate of the left edge of the bullet's bounds
+     * @param yCenter y coordinate of the center of the bullet's bounds
+     * @param textColor color the rest of the text is drawn with, used when the bullet defines
+     *   neither a brush of its own nor [textBrush]
+     * @param textBrush brush the rest of the text is drawn with, if any
+     * @param textAlpha opacity the rest of the text is drawn with, used when the bullet's own alpha
+     *   is [Float.NaN]
+     */
+    fun paint(
+        canvas: Canvas,
+        bullet: Bullet,
+        widthPx: Float,
+        heightPx: Float,
+        xStart: Float,
+        yCenter: Float,
+        layoutDirection: LayoutDirection,
+        density: Density,
+        textColor: Color,
+        textBrush: Brush?,
+        textAlpha: Float,
+    ) {
+        val size = Size(widthPx, heightPx)
+
+        paint.shader = null
+        paint.pathEffect = null
+        paint.alpha = 1f
+
+        val drawStyle = bullet.drawStyle
+        if (drawStyle is Stroke) {
+            paint.style = PaintingStyle.Stroke
+            paint.strokeWidth = drawStyle.width
+            paint.strokeMiterLimit = drawStyle.miter
+            paint.strokeCap = drawStyle.cap
+            paint.strokeJoin = drawStyle.join
+            paint.pathEffect = drawStyle.pathEffect
+        } else {
+            paint.style = PaintingStyle.Fill
+        }
+
+        val alpha = if (bullet.alpha.isNaN()) textAlpha else bullet.alpha
+        val brush = bullet.brush ?: textBrush
+        if (brush != null) {
+            brush.applyTo(size, paint, alpha)
+        } else {
+            paint.color = textColor
+            paint.alpha = alpha
+        }
+
+        val top = yCenter - heightPx / 2f
+        when (val outline = bullet.shape.createOutline(size, layoutDirection, density)) {
+            is Outline.Rectangle -> {
+                val rect = outline.rect
+                canvas.drawRect(xStart, top, xStart + rect.width, top + rect.height, paint)
+            }
+            is Outline.Rounded -> {
+                val roundRect = outline.roundRect
+                if (roundRect.isSimple) {
+                    canvas.drawRoundRect(
+                        xStart,
+                        top,
+                        xStart + roundRect.width,
+                        top + roundRect.height,
+                        roundRect.topLeftCornerRadius.x,
+                        roundRect.topLeftCornerRadius.y,
+                        paint,
+                    )
+                } else {
+                    val path = Path().apply { addRoundRect(roundRect) }
+                    canvas.save()
+                    canvas.translate(xStart, top)
+                    canvas.drawPath(path, paint)
+                    canvas.restore()
+                }
+            }
+            is Outline.Generic -> {
+                canvas.save()
+                canvas.translate(xStart, top)
+                canvas.drawPath(outline.path, paint)
+                canvas.restore()
+            }
+        }
+    }
+}
+
+/**
+ * Resolves a [Bullet]'s size or padding to pixels, mirroring the Android implementation: an
+ * unspecified value falls back to [contextFontSize], and an unknown [TextUnit] type yields
+ * [Float.NaN] so that the caller can skip the bullet instead of failing.
+ */
+internal fun TextUnit.resolveBulletSizeToPx(density: Density, contextFontSize: Float): Float =
+    when {
+        this == TextUnit.Unspecified -> contextFontSize
+        isSp -> with(density) { toPx() }
+        isEm -> contextFontSize * value
+        else -> Float.NaN
+    }

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoParagraph.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoParagraph.nonAndroid.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.graphics.skiaCanvas
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.toComposeRect
-import androidx.compose.ui.text.PlatformParagraph
 import androidx.compose.ui.text.platform.SkikoParagraphIntrinsics
 import androidx.compose.ui.text.platform.cursorHorizontalPosition
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -42,7 +42,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.util.fastForEach
 import kotlin.math.floor
 import org.jetbrains.skia.FontMetrics
 import org.jetbrains.skia.IRange
@@ -66,6 +68,9 @@ internal class SkikoParagraph(
 
     internal val defaultFont
         get() = layouter.defaultFont
+
+    private val bulletPainter =
+        if (layouter.bullets.isEmpty()) null else SkikoBulletPainter()
 
     /**
      * Paragraph isn't always immutable, it could be changed via [paint] method without
@@ -560,6 +565,7 @@ internal class SkikoParagraph(
             )
         }
         paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paintBullets(canvas, color = color, brush = null, alpha = 1f)
     }
 
     @ExperimentalTextApi
@@ -584,6 +590,7 @@ internal class SkikoParagraph(
             )
         }
         paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paintBullets(canvas, color = color, brush = null, alpha = 1f)
     }
 
     @ExperimentalTextApi
@@ -613,6 +620,50 @@ internal class SkikoParagraph(
             )
         }
         paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
+        paintBullets(canvas, color = Color.Unspecified, brush = brush, alpha = alpha)
+    }
+
+    private fun paintBullets(canvas: Canvas, color: Color, brush: Brush?, alpha: Float) {
+        val painter = bulletPainter ?: return
+        val density = layouter.density
+        val contextFontSize = layouter.defaultFont.size
+        val textColor = color.takeOrElse { layouter.textStyle.color }
+        val layoutDirection = when (paragraphIntrinsics.textDirection) {
+            ResolvedTextDirection.Rtl -> LayoutDirection.Rtl
+            else -> LayoutDirection.Ltr
+        }
+
+        layouter.bullets.fastForEach { range ->
+            val bullet = range.item
+            val widthPx = bullet.width.resolveBulletSizeToPx(density, contextFontSize)
+            val heightPx = bullet.height.resolveBulletSizeToPx(density, contextFontSize)
+            val gapPx = bullet.padding.resolveBulletSizeToPx(density, contextFontSize)
+            if (widthPx.isNaN() || heightPx.isNaN() || gapPx.isNaN()) return@fastForEach
+
+            val line = lineMetricsForOffset(range.start) ?: return@fastForEach
+            val lineTop = (line.baseline - line.ascent).toFloat()
+            val lineBottom = (line.baseline + line.descent).toFloat()
+            val yCenter = (lineTop + lineBottom) / 2f
+            val xStart = if (layoutDirection == LayoutDirection.Rtl) {
+                line.right.toFloat() + gapPx
+            } else {
+                (line.left.toFloat() - (widthPx + gapPx)).coerceAtLeast(0f)
+            }
+
+            painter.paint(
+                canvas = canvas,
+                bullet = bullet,
+                widthPx = widthPx,
+                heightPx = heightPx,
+                xStart = xStart,
+                yCenter = yCenter,
+                layoutDirection = layoutDirection,
+                density = density,
+                textColor = textColor,
+                textBrush = brush,
+                textAlpha = alpha,
+            )
+        }
     }
 
     /**

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.nonAndroid.kt
@@ -112,6 +112,9 @@ internal class ParagraphLayouter(
 
     val defaultFont get() = builder.defaultFont
     val textStyle get() = builder.textStyle
+    val bullets get() = builder.bullets
+    val density get() = builder.density
+    val firstLineIndentPx get() = builder.firstLineIndentPx
 
     private fun invalidateParagraph(onlyForeground: Boolean = false) {
         // skia's updateForegroundPaint applies the same style to every span,

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.Bullet
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.FontHinting
 import androidx.compose.ui.text.FontRasterizationSettings
@@ -57,9 +58,9 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
-import kotlin.jvm.JvmName
 import org.jetbrains.skia.Font as SkFont
 import org.jetbrains.skia.FontEdging as SkFontEdging
 import org.jetbrains.skia.FontFeature
@@ -389,6 +390,9 @@ internal class ParagraphBuilder(
     private lateinit var initialStyle: SpanStyle
     private lateinit var ops: List<Op>
 
+    /** [Bullet]s to be painted next to the paragraphs they are attached to. */
+    val bullets: List<AnnotatedString.Range<Bullet>> = annotations.filterBullets()
+
     private fun prepareDefaultStyle() {
         initialStyle = textStyle.toSpanStyle().copyWithDefaultFontSize(
             drawStyle = drawStyle
@@ -542,7 +546,7 @@ internal class ParagraphBuilder(
     ): List<Op> {
         val cuts = mutableListOf<Cut>()
         annotations.fastForEach { annotation ->
-            // TODO https://youtrack.jetbrains.com/issue/CMP-7151
+            // Only [SpanStyle] is turned into a skia style span.
             val spanStyle = annotation.item as? SpanStyle ?: return@fastForEach
 
             cuts.add(Cut.StyleAdd(annotation.start, spanStyle))
@@ -657,7 +661,7 @@ internal class ParagraphBuilder(
         pStyle.direction = textDirection.toSkDirection()
         textStyle.textIndent?.run {
             pStyle.textIndent = SkTextIndent(
-                firstLine.toPx(density, computedStyle.fontSize),
+                firstLineIndentPx,
                 restLine.toPx(density, computedStyle.fontSize)
             )
         }
@@ -674,6 +678,17 @@ internal class ParagraphBuilder(
         val loadResult = textStyle.resolveFontFamily(fontFamilyResolver)
         SkFont(loadResult?.typeface, defaultStyle.fontSize)
     }
+
+    /**
+     * Indentation of the paragraph's first line in pixels, as passed to skia in [SkTextIndent].
+     * Skia leaves the indentation out of the paragraph's intrinsic widths, so
+     * [SkikoParagraphIntrinsics] adds this value back on top of them.
+     *
+     * A font size relative unit resolves against the default font size, which is known only once
+     * [build] has run, so before that this returns [Float.NaN].
+     */
+    internal val firstLineIndentPx: Float
+        get() = textStyle.textIndent?.firstLine?.toPx(density, defaultStyle.fontSize) ?: 0f
 
     // workaround for https://bugs.chromium.org/p/skia/issues/detail?id=11321 :(
     internal fun emptyLineMetrics(paragraph: SkParagraph): Array<LineMetrics> {
@@ -719,6 +734,19 @@ private fun TextUnit.orDefaultFontSize() = when {
     isUnspecified -> DefaultFontSize
     isEm -> DefaultFontSize * value
     else -> this
+}
+
+private fun List<AnnotatedString.Range<out AnnotatedString.Annotation>>.filterBullets():
+    List<AnnotatedString.Range<Bullet>> {
+    if (!fastAny { it.item is Bullet }) return emptyList()
+    val bullets = mutableListOf<AnnotatedString.Range<Bullet>>()
+    fastForEach { annotation ->
+        val item = annotation.item
+        if (item is Bullet) {
+            bullets.add(AnnotatedString.Range(item, annotation.start, annotation.end))
+        }
+    }
+    return bullets
 }
 
 private fun TextUnit.toPx(density: Density, fontSize: TextUnit): Float =

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphIntrinsics.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphIntrinsics.nonAndroid.kt
@@ -40,7 +40,7 @@ import kotlin.math.ceil
 internal class SkikoParagraphIntrinsics(
     val text: String,
     private val style: TextStyle,
-    private val annotations: List<AnnotatedString.Range<out AnnotatedString.Annotation>>,
+    private val annotations: List<Range<out AnnotatedString.Annotation>>,
     private val placeholders: List<Range<Placeholder>>,
     private val density: Density,
     private val fontFamilyResolver: FontFamily.Resolver
@@ -76,9 +76,14 @@ internal class SkikoParagraphIntrinsics(
         private set
 
     init {
-        val para = layouter!!.layoutParagraph(Float.POSITIVE_INFINITY)
-        minIntrinsicWidth = ceil(para.minIntrinsicWidth)
-        maxIntrinsicWidth = ceil(para.maxIntrinsicWidth)
+        val layouter = layouter!!
+        val para = layouter.layoutParagraph(Float.POSITIVE_INFINITY)
+
+        // Skia excludes the indentation from the intrinsic widths, so text laid out at that width
+        // breaks a line early. Android sums the leading margins in, see Layout.measurePara.
+        val indent = layouter.firstLineIndentPx
+        minIntrinsicWidth = ceil(para.minIntrinsicWidth + indent)
+        maxIntrinsicWidth = ceil(para.maxIntrinsicWidth + indent)
     }
 }
 

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import kotlin.math.ceil
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -481,6 +483,53 @@ class SkikoParagraphTest {
         assertEquals(1, paragraph.lineCount)
     }
 
+    @Test
+    fun maxIntrinsicWidth_includesFirstLineIndent() {
+        val text = "Bullet list item"
+        val textStyle = TextStyle(fontSize = 20.sp)
+
+        val plain = simpleIntrinsics(text, textStyle)
+        val indented = simpleIntrinsics(
+            text = text,
+            textStyle = textStyle.copy(textIndent = TextIndent(firstLine = 20.sp))
+        )
+
+        assertEquals(plain.maxIntrinsicWidth + 20f, indented.maxIntrinsicWidth)
+    }
+
+    @Test
+    fun paragraphAtItsMaxIntrinsicWidth_doesNotWrap_spIndent() {
+        assertSingleLineAtMaxIntrinsicWidth(TextIndent(firstLine = 20.sp), expectedIndentPx = 20f)
+    }
+
+    @Test
+    fun paragraphAtItsMaxIntrinsicWidth_doesNotWrap_emIndent() {
+        // The unit a bullet list uses, see Bullet.DefaultIndentation.
+        assertSingleLineAtMaxIntrinsicWidth(TextIndent(firstLine = 1.em), expectedIndentPx = 20f)
+    }
+
+    /** Expects the text laid out at its own intrinsic width to fit into a single line. */
+    private fun assertSingleLineAtMaxIntrinsicWidth(
+        textIndent: TextIndent,
+        expectedIndentPx: Float
+    ) {
+        val intrinsics = simpleIntrinsics(
+            // Skia drops the indentation when a single unbreakable run does not fit into what is
+            // left of the width, so the text needs several words.
+            text = "Bullet list item",
+            textStyle = TextStyle(fontSize = 20.sp, textIndent = textIndent)
+        )
+
+        val paragraph = Paragraph(
+            paragraphIntrinsics = intrinsics,
+            constraints = Constraints(maxWidth = ceil(intrinsics.maxIntrinsicWidth).toInt()),
+            overflow = TextOverflow.Clip
+        )
+
+        assertEquals(1, paragraph.lineCount)
+        assertEquals(expectedIndentPx, paragraph.getLineLeft(0))
+    }
+
     // Regression test for https://youtrack.jetbrains.com/issue/CMP-10034
     @Test
     fun getCursorRect_doesNotCrash_inRtlParagraphsWithNewlinesAndSpecialCharacters() {
@@ -507,6 +556,14 @@ class SkikoParagraphTest {
             }
         }
     }
+
+    private fun simpleIntrinsics(text: String, textStyle: TextStyle) = ParagraphIntrinsics(
+        text = text,
+        style = textStyle,
+        annotations = emptyList(),
+        density = defaultDensity,
+        fontFamilyResolver = fontFamilyResolver
+    )
 
     private fun simpleParagraph(text: String, textStyle: TextStyle = TextStyle()) = Paragraph(
         text = text,


### PR DESCRIPTION
Add support for Bullet annotation rendering in Skiko text layout

- Implemented `SkikoBulletPainter` for rendering bullet markers in paragraphs
- Updated `SkikoParagraphBuilder` and `ParagraphLayouter` to process and layout bullets
- Adjusted Skia intrinsic width calculations to include bullet indentation
- Added utility functions for bullet size resolution and filtering bullet annotations

Fixes: [CMP-7151](https://youtrack.jetbrains.com/issue/CMP-7151) Support Paragraph(Intrinsics) with annotations

## Testing
Should be tested by QA

## Release Notes
### Features - Multiple Platforms
- Support for rendering bullet list annotations (Bullet) in AnnotatedString
### Fixes - Multiple Platforms
- Fixed text with textIndent wrapping unexpectedly: the indentation is now included into the paragraph's intrinsic width 

