### PR TITLE
Fix Web TextField a11y synchronization

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/A11YTextValueNotUpdated.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/A11YTextValueNotUpdated.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.password
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+// https://youtrack.jetbrains.com/issue/CMP-10745/Web-A11y.-Entered-text-value-is-not-updated-inside-the-TextFields-div
+@Composable
+fun A11YTextValueNotUpdated() {
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        var textState by remember { mutableStateOf("") }
+        TextField(
+            value = textState,
+            onValueChange = { textState = it },
+            label = { Text("Paste here") },
+            modifier = Modifier.fillMaxWidth().testTag("pasteField")
+        )
+
+        var text by remember { mutableStateOf("") }
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            placeholder = { Text("Paste here") },
+            modifier = Modifier.testTag("textFieldTag"),
+        )
+
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            label = { Text("Paste here") },
+            trailingIcon = {
+                IconButton(
+                    onClick = { text = "" },
+                    modifier = Modifier.testTag("clearIconTag"),
+                ) {
+                    Text("Clear")
+                }
+            },
+            modifier = Modifier.testTag("textFieldTag2"),
+        )
+
+        var password by remember { mutableStateOf("12345678") }
+        var showPassword by remember { mutableStateOf(false) }
+
+        TextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            visualTransformation = if (showPassword) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            trailingIcon = {
+                IconButton(
+                    onClick = { showPassword = !showPassword },
+                    modifier = Modifier.testTag("passwordIconTag"),
+                ) {
+                    Text(if (showPassword) "Hide" else "Show")
+                }
+            },
+            modifier = Modifier.testTag("passwordFieldTag")
+                .semantics { password(isPasswordObfuscated = !showPassword) },
+        )
+
+    }
+}

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -44,5 +44,8 @@ val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
     Screen.Example("Crash after resize") {
         CrashAfterResizeDemo()
     },
+    Screen.Example("A11Y Text Value Not Updated") {
+        A11YTextValueNotUpdated()
+    }
 ))
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YImplementationUtils.kt
@@ -16,17 +16,16 @@
 
 package androidx.compose.ui.platform.accessibility
 
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
+import androidx.compose.ui.util.fastJoinToString
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 
@@ -275,4 +274,29 @@ internal fun splitTextAndLinks(texts: List<AnnotatedString>): TextAndLinksSplit 
     parts.add(pendingText.toString())
 
     return TextAndLinksSplit(textParts = parts, linkTexts = linkTexts)
+}
+
+
+internal fun SemanticsConfiguration.getAriaLabel(): String? {
+    return when {
+        this.contains(SemanticsProperties.ContentDescription) ->
+            this[SemanticsProperties.ContentDescription].fastJoinToString(", ")
+        this.contains(SemanticsProperties.EditableText) &&
+            this.contains(SemanticsProperties.Text) ->
+            this[SemanticsProperties.Text].fastJoinToString("\n") { it.text }
+        else -> null
+    }
+}
+
+internal fun SemanticsConfiguration.hasNonEditableText(): Boolean {
+    return this.contains(SemanticsProperties.Text) && !this.contains(SemanticsProperties.EditableText)
+}
+
+internal fun SemanticsConfiguration.isObfuscatedPassword(): Boolean {
+    return this.contains(SemanticsProperties.Password) &&
+        this.getOrElse(SemanticsProperties.IsPasswordObfuscated) { true }
+}
+
+internal fun obfuscatedPassword(password: String): String {
+    return "\u2022".repeat(password.length)
 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -298,16 +298,16 @@ internal class ComposeWebSemanticsListener(
             val config = node.config
             val children = node.replacedChildren
 
-            val htmlNode = if (config.contains(SemanticsProperties.Text)) {
+            val htmlNode = syncNode(node, config, htmlParent, rootPosition)
+            if (config.hasNonEditableText()) {
                 // Usually, the order of SemanticsNode children matches the mirroring a11y HTML.
                 // But for text with links we have to interleave text parts with links.
                 // We split text into parts: plain text fragments and links.
                 // That's why a text node doesn't push its children to the traversal queue.
                 // It handles its link children itself:
-                syncTextNode(node, config, children, htmlParent, rootPosition)
+                syncTextContentAndChildren(node, config, children, htmlNode, rootPosition)
             } else {
-                syncNode(node, config, htmlParent, rootPosition)
-                    .also { pushNodesForTraversal(children, it) }
+                pushNodesForTraversal(children, htmlNode)
             }
             check(htmlNode !== htmlParent) { "A11Y node ${node.id} cannot be its own parent" }
             targetParentToChildren.getOrPut(htmlParent) { mutableListOf() }.add(htmlNode)
@@ -410,9 +410,11 @@ internal class ComposeWebSemanticsListener(
             htmlNode.innerText = text
         }
 
-        if (config.contains(SemanticsProperties.ContentDescription)) {
-            val contentDescription = config[SemanticsProperties.ContentDescription]
-            htmlNode.setAttribute("aria-label", contentDescription.fastJoinToString(", "))
+        val ariaLabel = config.getAriaLabel()
+        if (ariaLabel != null) {
+            htmlNode.setAttribute("aria-label", ariaLabel)
+        } else {
+            htmlNode.removeAttribute("aria-label")
         }
 
         if (config.contains(SemanticsProperties.TestTag)) {
@@ -422,8 +424,14 @@ internal class ComposeWebSemanticsListener(
 
         if (config.contains(SemanticsProperties.EditableText)) {
             val editableText = config[SemanticsProperties.EditableText].text
-            if (htmlNode.innerText != editableText) {
-                htmlNode.innerText = editableText
+            val isObfuscatedPassword = config.isObfuscatedPassword()
+            val exposedEditableText = if (isObfuscatedPassword) {
+                obfuscatedPassword(editableText)
+            } else {
+                editableText
+            }
+            if (htmlNode.innerText != exposedEditableText) {
+                htmlNode.innerText = exposedEditableText
             }
 
             if (justCreated) {
@@ -518,8 +526,8 @@ internal class ComposeWebSemanticsListener(
     }
 
     /**
-     * Syncs a node with [SemanticsProperties.Text], attaching its link children right away instead
-     * of scheduling them for the regular traversal.
+     * Syncs the content and children of a non-editable node with [SemanticsProperties.Text],
+     * attaching its link children right away instead of scheduling them for the regular traversal.
      *
      * A link doesn't have its own text in the semantics tree: the whole text (including the links)
      * belongs to the text node, while every link range is a separate child node marked with
@@ -544,13 +552,13 @@ internal class ComposeWebSemanticsListener(
      * [children] other than the links (a text node might be a merged node with arbitrary merging
      * children) are pushed to the regular traversal and end up after the links.
      */
-    private fun syncTextNode(
+    private fun syncTextContentAndChildren(
         node: SemanticsNode,
         config: SemanticsConfiguration,
         children: List<SemanticsNode>,
-        htmlParent: HTMLElement,
+        htmlNode: HTMLElement,
         rootPosition: Offset,
-    ): HTMLElement {
+    ) {
         val texts = config[SemanticsProperties.Text]
         val linksCount = children.count { it.config.contains(SemanticsProperties.LinkTestMarker) }
 
@@ -559,12 +567,7 @@ internal class ComposeWebSemanticsListener(
         val textParts = split?.textParts?.takeIf { split.matchesLinksCount(linksCount) }
 
         val text = texts.fastJoinToString("\n") { it.text }
-        val htmlNode = syncNode(
-            semanticsNode = node,
-            config = config,
-            htmlParent = htmlParent,
-            rootPosition = rootPosition,
-        )
+
         val targetTextAndLinks = mutableListOf<Any>()
         if (textParts == null) {
             targetTextAndLinks.add(text)
@@ -611,7 +614,6 @@ internal class ComposeWebSemanticsListener(
 
         updateTextAndLinks(htmlNode, targetTextAndLinks, a11YScrollController.getScrollSizer(node))
         deferredChildren?.let { pushNodesForTraversal(it, htmlNode) }
-        return htmlNode
     }
 
     /** Updates the text fragments and semantic link elements after the optional scroll sizer. */

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11YTextFieldTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11YTextFieldTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.editableText
+import androidx.compose.ui.semantics.password
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import org.w3c.dom.HTMLElement
+
+class A11YTextFieldTest : OnCanvasTests {
+
+    @Test
+    fun textFieldWithLabelUpdatesEditableText() = runApplicationTest {
+        var text by mutableStateOf("")
+
+        createComposeWindow {
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("Paste here") },
+                modifier = Modifier.testTag("textFieldTag"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val textField = getShadowRoot().getElementById("textFieldTag") as? HTMLElement
+        assertNotNull(textField)
+        assertEquals("Paste here", textField.getAttribute("aria-label"))
+
+        text = "Entered text"
+        awaitA11YChanges()
+
+        assertEquals("Entered text", textField.innerText)
+        assertEquals("Paste here", textField.getAttribute("aria-label"))
+    }
+
+    @Test
+    fun textFieldWithPlaceholderUpdatesEditableText() = runApplicationTest {
+        var text by mutableStateOf("")
+
+        createComposeWindow {
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                placeholder = { Text("Paste here") },
+                modifier = Modifier.testTag("textFieldTag"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val textField = getShadowRoot().getElementById("textFieldTag") as? HTMLElement
+        assertNotNull(textField)
+
+        text = "Entered text"
+        awaitA11YChanges()
+
+        assertEquals("Entered text", textField.innerText)
+    }
+
+    @Test
+    fun textFieldWithLabelKeepsInteractiveChildren() = runApplicationTest {
+        var text by mutableStateOf("")
+        var trailingIconClicks = 0
+
+        createComposeWindow {
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("Paste here") },
+                trailingIcon = {
+                    IconButton(
+                        onClick = { trailingIconClicks++ },
+                        modifier = Modifier.testTag("trailingIconTag"),
+                    ) {
+                        Text("Clear")
+                    }
+                },
+                modifier = Modifier.testTag("textFieldTag"),
+            )
+        }
+
+        awaitA11YChanges()
+
+        val trailingIcon = getShadowRoot().getElementById("trailingIconTag") as? HTMLElement
+        assertNotNull(trailingIcon)
+        assertEquals("button", trailingIcon.getAttribute("role"))
+
+        text = "Entered text"
+        awaitA11YChanges()
+
+        val trailingIconAfterTextUpdate =
+            getShadowRoot().getElementById("trailingIconTag") as? HTMLElement
+        assertSame(trailingIcon, trailingIconAfterTextUpdate)
+        trailingIcon.click()
+        assertEquals(1, trailingIconClicks)
+    }
+
+    @Test
+    fun passwordTextIsMaskedByDefaultAndCanBeExplicitlyRevealed() = runApplicationTest {
+        val password = "secret"
+        var revealPassword by mutableStateOf(false)
+
+        createComposeWindow {
+            Box(
+                modifier = Modifier
+                    .size(100.dp)
+                    .testTag("passwordFieldTag")
+                    .semantics {
+                        editableText = AnnotatedString(password)
+                        password(isPasswordObfuscated = !revealPassword)
+                    }
+            )
+        }
+
+        awaitA11YChanges()
+
+        val passwordField = getShadowRoot().getElementById("passwordFieldTag") as? HTMLElement
+        assertNotNull(passwordField)
+        assertEquals("textbox", passwordField.getAttribute("role"))
+        assertEquals("••••••", passwordField.innerText)
+        assertFalse(passwordField.innerText.contains(password))
+
+        revealPassword = true
+        awaitA11YChanges()
+
+        assertEquals(password, passwordField.innerText)
+    }
+}


### PR DESCRIPTION
- Keep editable values separate from merged label text, expose labels through aria-label, and preserve independently focusable text field children.
- Mask obfuscated password values in the accessibility DOM and add JS/Wasm regression coverage.


Fixes https://youtrack.jetbrains.com/issue/CMP-10745/Web-A11y.-Entered-text-value-is-not-updated-inside-the-TextFields-div
Fixes https://youtrack.jetbrains.com/issue/CMP-10652/Compose-Web-accessibility-DOM-password-leak

**Demo (after fix)**
<img width="1049" height="474" alt="Screenshot 2026-09-09 at 09 37 54" src="https://github.com/user-attachments/assets/43697883-4fb4-4e54-82cb-e2188e02eacc" />


## Testing
- This should be tested by QA
- added new tests

## Release Notes
### Fixes - Web
- _(prerelease fix)_ Fix stale editable text value in A11Y tree
- Fix password obfuscation in A11Y tree

## Google CLA
Sign the Google Contributor's License Agreement at https://cla.developers.google.com to let us upstream your code to Google's AOSP repository
