### PR TITLE
Fix cursor metrics in SkikoParagraph

### DIFF
--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoParagraph.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoParagraph.nonAndroid.kt
@@ -188,19 +188,33 @@ internal class SkikoParagraph(
 
         // workaround for https://bugs.chromium.org/p/skia/issues/detail?id=11321 :(
         // Otherwise it shows a big cursor on a new empty line https://youtrack.jetbrains.com/issue/CMP-1895
-        val isNewEmptyLine = offset - 1 == line.startIndex && offset == text.length
+        // use the same metrics from font
+        // so height does not change when a line receives its first character https://youtrack.jetbrains.com/issue/CMP-8371
+        val usesEmptyLineCursorMetrics =
+            (line.startIndex == line.endIndex && offset == text.length) ||
+                (text.isNotEmpty() && !layouter.textStyle.lineHeight.isUnspecified)
+        val cursorMetrics = if (usesEmptyLineCursorMetrics && text.isNotEmpty()) {
+            layouter
+                .emptyLineMetrics(paragraph)
+                .first()
+                .trimFirstAscent(defaultFont.metrics, layouter.textStyle)
+                .trimLastDescent(defaultFont.metrics, layouter.textStyle)
+        } else {
+            line
+        }
+
         val metrics = defaultFont.metrics
 
-        val asc = line.ascent.let {
-            if (isNewEmptyLine) {
+        val asc = cursorMetrics.ascent.let {
+            if (usesEmptyLineCursorMetrics) {
                 val ascent = -metrics.ascent.toDouble()
                 it.coerceAtMost(ascent)
             } else {
                 it
             }
         }
-        val desc = line.descent.let {
-            if (isNewEmptyLine) {
+        val desc = cursorMetrics.descent.let {
+            if (usesEmptyLineCursorMetrics) {
                 val descent = metrics.descent.toDouble()
                 it.coerceAtMost(descent)
             } else {

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
@@ -79,6 +79,7 @@ import org.jetbrains.skia.paragraph.ParagraphStyle
 import org.jetbrains.skia.paragraph.PlaceholderAlignment
 import org.jetbrains.skia.paragraph.PlaceholderStyle
 import org.jetbrains.skia.paragraph.Shadow as SkShadow
+import org.jetbrains.skia.paragraph.StrutStyle
 import org.jetbrains.skia.paragraph.TextBox
 import org.jetbrains.skia.paragraph.TextIndent as SkTextIndent
 import org.jetbrains.skia.paragraph.TextStyle as SkTextStyle
@@ -652,6 +653,15 @@ internal class ParagraphBuilder(
              * internal (between lines in multiline text) calculated as-is.
              */
             pStyle.heightMode = HeightMode.DISABLE_ALL
+        }
+
+        if (lineHeight != null && lineHeight <= computedStyle.fontSize) {
+            // keep empty and non-empty lines on the same baseline, without a forced strut,
+            // Skia gives an empty line a different height and then baseline changes when line receives its first glyph
+            pStyle.strutStyle = StrutStyle().apply {
+                fontSize = computedStyle.fontSize
+                isHeightForced = true
+            }
         }
 
         pStyle.direction = textDirection.toSkDirection()

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
-import kotlin.jvm.JvmName
 import org.jetbrains.skia.Font as SkFont
 import org.jetbrains.skia.FontEdging as SkFontEdging
 import org.jetbrains.skia.FontFeature
@@ -653,15 +652,6 @@ internal class ParagraphBuilder(
              * internal (between lines in multiline text) calculated as-is.
              */
             pStyle.heightMode = HeightMode.DISABLE_ALL
-        }
-
-        if (lineHeight != null && lineHeight <= computedStyle.fontSize) {
-            // keep empty and non-empty lines on the same baseline, without a forced strut,
-            // Skia gives an empty line a different height and then baseline changes when line receives its first glyph
-            pStyle.strutStyle = StrutStyle().apply {
-                fontSize = computedStyle.fontSize
-                isHeightForced = true
-            }
         }
 
         pStyle.direction = textDirection.toSkDirection()

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.clearSkikoComposeImplementation
 import androidx.compose.ui.platform.registerSkikoComposeImplementation
 import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextIndent
@@ -506,6 +507,29 @@ class SkikoParagraphTest {
                 paragraph.getCursorRect(offset)
             }
         }
+    }
+
+    // Regression test for https://youtrack.jetbrains.com/issue/CMP-8371
+    @Test
+    fun getCursorRect_hasSameHeightForEmptyAndNonEmptyText() {
+        val style = TextStyle(
+            fontSize = 64.sp,
+            letterSpacing = 0.5.sp,
+            lineHeight = 24.sp,
+            lineHeightStyle = LineHeightStyle(
+                alignment = LineHeightStyle.Alignment.Center,
+                trim = LineHeightStyle.Trim.None,
+                mode = LineHeightStyle.Mode.Fixed,
+            ),
+        )
+        val emptyParagraph = simpleParagraph(text = "", textStyle = style)
+        val nonEmptyText = "q"
+        val nonEmptyParagraph = simpleParagraph(text = nonEmptyText, textStyle = style)
+
+        val emptyCursor = emptyParagraph.getCursorRect(0)
+        val nonEmptyCursor = nonEmptyParagraph.getCursorRect(nonEmptyText.length)
+
+        assertEquals(emptyCursor.height, nonEmptyCursor.height)
     }
 
     private fun simpleParagraph(text: String, textStyle: TextStyle = TextStyle()) = Paragraph(

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -509,7 +509,6 @@ class SkikoParagraphTest {
         }
     }
 
-    // Regression test for https://youtrack.jetbrains.com/issue/CMP-8371
     @Test
     fun getCursorRect_hasSameHeightForEmptyAndNonEmptyText() {
         val style = TextStyle(

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -89,8 +89,7 @@ class DesktopParagraphTest : SkikoComposeTestBase() {
             val fontSizeInPx = fontSize.toPx()
 
             for (lineHeightMultiplier in listOf(
-                0f, // https://youtrack.jetbrains.com/issue/CMP-7963
-                0.1f, 0.5f, 1f, 1.5f, 2f, 10f,
+                0f, 0.1f, 0.5f, 1f, 1.5f, 2f, 10f,
             )) {
                 val paragraph = simpleParagraph(
                     text = text,

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -89,7 +89,7 @@ class DesktopParagraphTest : SkikoComposeTestBase() {
             val fontSizeInPx = fontSize.toPx()
 
             for (lineHeightMultiplier in listOf(
-                // 0f, // TODO https://youtrack.jetbrains.com/issue/CMP-7963
+                0f, // https://youtrack.jetbrains.com/issue/CMP-7963
                 0.1f, 0.5f, 1f, 1.5f, 2f, 10f,
             )) {
                 val paragraph = simpleParagraph(


### PR DESCRIPTION
Fixes [CMP-8371](https://youtrack.jetbrains.com/issue/CMP-8371) Text cursor shrinks after typing begins when a TextField
There are 2 problems fixed. 
1) cursor height is different between empty string and non-empty string

https://github.com/user-attachments/assets/ccbe9544-9711-4976-876e-1255191f4b43


2) new symbol on the second line changes the baseline when font size is larger than line height

https://github.com/user-attachments/assets/f94f61cf-98d2-44e1-b285-b49cf357db81

(fix by [SkikoParagraphBuilder.nonAndroid.kt](https://github.com/JetBrains/compose-multiplatform-core/compare/jb-main...gavr123456789:compose-multiplatform-core:gavr/CMP-8371?expand=1#diff-25de370e5aab51faee683733b321b2f0420c86b3647c3a69c04faf9eddea5baa) file) 



To reproduce:
```kotlin
 Row(
            modifier = Modifier.fillMaxWidth(),
            horizontalArrangement = Arrangement.SpaceEvenly
        ) {

            var text by remember { mutableStateOf("") }
            val textFieldStyle = LocalTextStyle.current.copy(fontSize = 64.sp)
            TextField(
                value = text,
                onValueChange = {
                    println(
                        "[TextFieldDebug] text=${it} " +
                            "length=${it.length} style=$textFieldStyle"
                    )
                    text = it
                },
                modifier = Modifier.onFocusChanged {
                    println(
                        "[TextFieldDebug] focus=" +
                            "isFocused=${it.isFocused} isCaptured=${it.isCaptured}"
                    )
                },
                textStyle = textFieldStyle,
            )

            Column(modifier = Modifier.width(340.dp)) {
                var multilineText by remember { mutableStateOf("") }
                TextField(
                    value = multilineText,
                    onValueChange = { multilineText = it },
                    label = { Text("Multiline: 48sp font / 28sp lineH") },
                    textStyle = LocalTextStyle.current.copy(fontSize = 48.sp, lineHeight = 28.sp),
                    maxLines = 4,
                    modifier = Modifier.fillMaxWidth().height(150.dp),
                )

                var monospaceText by remember { mutableStateOf("") }
                TextField(
                    value = monospaceText,
                    onValueChange = { monospaceText = it },
                    label = { Text("Monospace: 32sp font / 48sp lineH") },
                    textStyle = LocalTextStyle.current.copy(
                        fontSize = 32.sp,
                        fontFamily = FontFamily.Monospace,
                        lineHeight = 48.sp,
                    ),
                    modifier = Modifier.fillMaxWidth(),
                )

                var smallText by remember { mutableStateOf("") }
                TextField(
                    value = smallText,
                    onValueChange = { smallText = it },
                    label = { Text("Small: 14sp font / 20sp lineH") },
                    textStyle = LocalTextStyle.current.copy(fontSize = 14.sp, lineHeight = 20.sp),
                    modifier = Modifier.fillMaxWidth(),
                )
            }
        }
```



## Testing

https://github.com/user-attachments/assets/58c8d584-9d04-48ff-99c1-4bec26974f1e

<img width="1566" height="372" alt="image" src="https://github.com/user-attachments/assets/f72ff899-363c-4736-9d89-e3a275347de1" />


## Release Notes
### Fixes - Multiple Platforms
- Fixed the cursor metrics difference between empty and non-empty string
- Fixed line spacing when the line height is less than the font size. 