### PR TITLE
Perfomance: avoid stack trace allocation when cancelling RectManager per-frame callbacks

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/Actuals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/Actuals.skiko.kt
@@ -17,8 +17,8 @@
 package androidx.compose.ui
 
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -35,7 +35,11 @@ internal actual fun postDelayed(delayMillis: Long, block: () -> Unit): Any {
     }
 }
 
+// Reuse a pre-created exception to avoid capturing a new stack trace on every cancellation.
+private val PostDelayedCancellationException =
+    CancellationException("PostDelayedCancellationException")
+
 internal actual fun removePost(token: Any?) {
     val job = token as? Job?
-    job?.cancel()
+    job?.cancel(PostDelayedCancellationException)
 }


### PR DESCRIPTION
When coroutines are being canceled, usually a CancellationException is created. And it means a new call stack of the error are being collected. It takes time.
My fix avoid that by using a prepared error instance. It is safe, because it is internal process and there is no need to provide a real call side for users.

## Release Notes
### Fixes - Multiple Platforms
- Perfomance improvement: removed stack trace allocation when internal coroutines are cancelled on a hot path

