### PR TITLE
Web A11Y: Make fully clipped elements inert unless reachable by scrolling (in a scroll container)

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalNavigationDrawerExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalNavigationDrawerExample.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -83,7 +84,7 @@ fun ModalNavigationDrawerExample() {
 
     ModalNavigationDrawer(
         drawerContent = {
-            ModalDrawerSheet {
+            ModalDrawerSheet(modifier = Modifier.testTag("modalNavDrawer")) {
                 Text(
                     text = "Drawer content",
                     fontSize = 24.sp,

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YExposureUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YExposureUtils.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.accessibility
+
+import androidx.compose.ui.semantics.SemanticsNode
+
+/**
+ * Whether this non-zero-sized semantics node is fully clipped in the Compose root.
+ *
+ * Zero-sized semantics retain their existing exposure. A hidden ancestor is handled separately by
+ * the accessibility traversal and still hides zero-sized descendants.
+ */
+internal fun SemanticsNode.isFullyClippedForA11Y(): Boolean =
+    size.width != 0 && size.height != 0 && boundsInRoot.isEmpty

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/A11YScrollUtils.kt
@@ -32,6 +32,11 @@ import kotlinx.browser.document
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.Event
 
+internal fun SemanticsConfiguration.isScrollContainer(): Boolean =
+    (getOrNull(SemanticsProperties.VerticalScrollAxisRange) != null ||
+        getOrNull(SemanticsProperties.HorizontalScrollAxisRange) != null) &&
+        getOrNull(SemanticsActions.ScrollBy)?.action != null
+
 /**
  * Responsibilities:
  * 1. For Compose nodes with scrollable semantics,
@@ -119,8 +124,7 @@ internal class A11YScrollController(
         val nodeId = semanticsNode.id
         val verticalRange = config.getOrNull(SemanticsProperties.VerticalScrollAxisRange)
         val horizontalRange = config.getOrNull(SemanticsProperties.HorizontalScrollAxisRange)
-        val canScroll = (verticalRange != null || horizontalRange != null) &&
-            config.getOrNull(SemanticsActions.ScrollBy)?.action != null
+        val canScroll = config.isScrollContainer()
 
         if (!canScroll) {
             if (scrollListenersAttached.remove(nodeId)) {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -23,7 +23,6 @@ import androidx.collection.mutableObjectListOf
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.PlatformContext
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -170,9 +169,15 @@ internal class ComposeWebSemanticsListener(
         invalidationChannel.trySend(Unit)
     }
 
-    // Two array deques for dfs traversal / tree sync:
+    // Three array deques for dfs traversal / tree sync:
     private val dfsSemanticsNodes = ArrayDeque<SemanticsNode>()
     private val dfsA11YParents = ArrayDeque<HTMLElement>()
+    private val dfsExposureContexts = ArrayDeque<ExposureContext>()
+
+    private data class ExposureContext(
+        val hidden: Boolean = false,
+        val insideScrollContainer: Boolean = false,
+    )
 
     // Lookup maps between semantics nodes and corresponding A11Y DOM elements:
     private val idToA11YNode = MutableIntObjectMap<HTMLElement>()
@@ -286,8 +291,10 @@ internal class ComposeWebSemanticsListener(
 
         dfsSemanticsNodes.clear()
         dfsA11YParents.clear()
+        dfsExposureContexts.clear()
         dfsSemanticsNodes.addLast(root)
         dfsA11YParents.addLast(webSemanticsRoot)
+        dfsExposureContexts.addLast(ExposureContext())
 
         val rootPosition = webSemanticsRoot.getBoundingClientRect().let {
             Offset(it.left.toFloat(), it.top.toFloat())
@@ -296,21 +303,42 @@ internal class ComposeWebSemanticsListener(
         while (!dfsSemanticsNodes.isEmpty()) {
             val node = dfsSemanticsNodes.removeLast()
             val htmlParent = dfsA11YParents.removeLast()
+            val exposureContext = dfsExposureContexts.removeLast()
 
             // `config` recreates the merged subtree on every call, so read it once
             val config = node.config
             val children = node.replacedChildren
+            val isHidden = exposureContext.hidden ||
+                    (!exposureContext.insideScrollContainer && node.isFullyClippedForA11Y())
+            val childrenContext = when {
+                isHidden -> if (exposureContext.hidden) {
+                    exposureContext
+                } else {
+                    ExposureContext(hidden = true)
+                }
 
-            val htmlNode = syncNode(node, config, htmlParent, rootPosition)
+                exposureContext.insideScrollContainer -> exposureContext
+                config.isScrollContainer() -> ExposureContext(insideScrollContainer = true)
+                else -> exposureContext
+            }
+
+            val htmlNode = syncNode(node, config, htmlParent, rootPosition, isHidden = isHidden)
             if (config.hasNonEditableText()) {
                 // Usually, the order of SemanticsNode children matches the mirroring a11y HTML.
                 // But for text with links we have to interleave text parts with links.
                 // We split text into parts: plain text fragments and links.
                 // That's why a text node doesn't push its children to the traversal queue.
                 // It handles its link children itself:
-                syncTextContentAndChildren(node, config, children, htmlNode, rootPosition)
+                syncTextContentAndChildren(
+                    node,
+                    config,
+                    children,
+                    htmlNode,
+                    rootPosition,
+                    childrenContext,
+                )
             } else {
-                pushNodesForTraversal(children, htmlNode)
+                pushNodesForTraversal(children, htmlNode, childrenContext)
             }
             check(htmlNode !== htmlParent) { "A11Y node ${node.id} cannot be its own parent" }
             targetParentToChildren.getOrPut(htmlParent) { mutableListOf() }.add(htmlNode)
@@ -322,11 +350,16 @@ internal class ComposeWebSemanticsListener(
      * @param children - the nodes to be added for traversal during the sync
      * @param htmlParent - the a11y (dom) parent element to contain the children a11y elements
      */
-    private fun pushNodesForTraversal(children: List<SemanticsNode>, htmlParent: HTMLElement) {
+    private fun pushNodesForTraversal(
+        children: List<SemanticsNode>,
+        htmlParent: HTMLElement,
+        exposureContext: ExposureContext,
+    ) {
         val reversedChildren = children.asReversed()
         dfsSemanticsNodes.addAll(reversedChildren)
         repeat(reversedChildren.size) {
             dfsA11YParents.addLast(htmlParent)
+            dfsExposureContexts.addLast(exposureContext)
         }
     }
 
@@ -340,12 +373,21 @@ internal class ComposeWebSemanticsListener(
         htmlParent: HTMLElement,
         rootPosition: Offset,
         text: String? = null,
+        isHidden: Boolean = false,
     ): HTMLElement {
         val currentId = semanticsNode.id
 
         var htmlNode = idToA11YNode[currentId]
         if (htmlNode != null) {
-            syncNodeProperties(semanticsNode, config, htmlNode, htmlParent, rootPosition, text)
+            syncNodeProperties(
+                semanticsNode,
+                config,
+                htmlNode,
+                htmlParent,
+                rootPosition,
+                text,
+                isHidden = isHidden,
+            )
         } else {
             htmlNode = document.createElement("div") as HTMLElement
             htmlNode.style.apply {
@@ -362,6 +404,7 @@ internal class ComposeWebSemanticsListener(
                 rootPosition,
                 text,
                 justCreated = true,
+                isHidden = isHidden,
             )
         }
 
@@ -408,7 +451,9 @@ internal class ComposeWebSemanticsListener(
         rootOffset: Offset,
         text: String?,
         justCreated: Boolean = false,
+        isHidden: Boolean = false,
     ) {
+        htmlNode.setInert(isHidden)
         if (text != null && htmlNode.textContent != text) {
             htmlNode.textContent = text
         }
@@ -589,6 +634,7 @@ internal class ComposeWebSemanticsListener(
         children: List<SemanticsNode>,
         htmlNode: HTMLElement,
         rootPosition: Offset,
+        childrenContext: ExposureContext,
     ) {
         val texts = config[SemanticsProperties.Text]
         val linksCount = children.count { it.config.contains(SemanticsProperties.LinkTestMarker) }
@@ -634,7 +680,7 @@ internal class ComposeWebSemanticsListener(
             targetParentToChildren.getOrPut(htmlNode) { mutableListOf() }.add(linkHtmlNode)
             targetChildToParent[linkHtmlNode] = htmlNode
             // A link node is expected to be a leaf, but don't rely on it.
-            pushNodesForTraversal(linkChildren, linkHtmlNode)
+            pushNodesForTraversal(linkChildren, linkHtmlNode, childrenContext)
 
             linkIndex++
         }
@@ -644,7 +690,7 @@ internal class ComposeWebSemanticsListener(
         }
 
         updateTextAndLinks(htmlNode, targetTextAndLinks, a11YScrollController.getScrollSizer(node))
-        deferredChildren?.let { pushNodesForTraversal(it, htmlNode) }
+        deferredChildren?.let { pushNodesForTraversal(it, htmlNode, childrenContext) }
     }
 
     /** Updates the text fragments and semantic link elements after the optional scroll sizer. */
@@ -706,6 +752,7 @@ internal class ComposeWebSemanticsListener(
 
         dfsSemanticsNodes.clear()
         dfsA11YParents.clear()
+        dfsExposureContexts.clear()
         idToA11YNode.clear()
         a11yNodeToSemanticsNode.clear()
         targetParentToChildren.clear()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yExposureTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/A11yExposureTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform.a11y
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.WebApplicationScope
+import androidx.compose.ui.currentTimeMillis
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.w3c.dom.HTMLElement
+
+/** Regression coverage for basic Web A11Y exposure independently from DOM geometry. */
+class A11yExposureTest : OnCanvasTests {
+    private fun element(tag: String): HTMLElement =
+        assertNotNull(
+            getShadowRoot().getElementById(tag) as? HTMLElement,
+            "No A11Y element for '$tag'",
+        )
+
+    private suspend fun WebApplicationScope.awaitCondition(
+        message: String,
+        condition: () -> Boolean,
+    ) {
+        val start = currentTimeMillis()
+        while (!condition()) {
+            assertTrue(currentTimeMillis() - start < 5_000, "Timed out waiting for: $message")
+            awaitAnimationFrame()
+        }
+    }
+
+    @Test
+    fun fullyClippedNonScrollNodeIsInertButRetainsMeasuredSize() = runApplicationTest {
+        createComposeWindow {
+            Box(Modifier.size(100.dp).clipToBounds()) {
+                Box(Modifier.offset(200.dp, 0.dp).size(40.dp).testTag("panel"))
+            }
+        }
+        awaitA11YChanges()
+
+        val panel = element("panel")
+        assertTrue(panel.hasAttribute("inert"))
+        assertTrue(panel.getBoundingClientRect().width > 0.0)
+        assertTrue(panel.getBoundingClientRect().height > 0.0)
+    }
+
+    @Test
+    fun clippingTransitionTogglesInertnessWithoutReplacingElement() = runApplicationTest {
+        var hidden by mutableStateOf(true)
+        createComposeWindow {
+            Box(Modifier.size(100.dp).clipToBounds()) {
+                Box(
+                    Modifier.offset(if (hidden) 200.dp else 0.dp, 0.dp)
+                        .size(40.dp)
+                        .testTag("panel")
+                )
+            }
+        }
+        awaitA11YChanges()
+        val panel = element("panel")
+        assertTrue(panel.hasAttribute("inert"))
+
+        hidden = false
+        awaitA11YChanges()
+        assertSame(panel, element("panel"))
+        assertFalse(panel.hasAttribute("inert"))
+
+        hidden = true
+        awaitA11YChanges()
+        assertSame(panel, element("panel"))
+        assertTrue(panel.hasAttribute("inert"))
+    }
+
+    @Test
+    fun descendantOfVisibleScrollContainerRemainsExposed() = runApplicationTest {
+        val scrollState = ScrollState(0)
+        createComposeWindow {
+            Column(Modifier.size(100.dp).verticalScroll(scrollState).testTag("scroller")) {
+                Box(Modifier.size(100.dp))
+                Box(Modifier.size(40.dp).testTag("item"))
+            }
+        }
+        awaitA11YChanges()
+
+        val scroller = element("scroller")
+        val item = element("item")
+        assertFalse(scroller.hasAttribute("inert"))
+        assertFalse(item.hasAttribute("inert"))
+        assertTrue(item.getBoundingClientRect().height > 0.0)
+
+        scrollIntoView(item)
+        awaitCondition("Browser scrolling must reach the exposed offscreen item") {
+            scrollState.value > 0
+        }
+        assertSame(item, element("item"))
+    }
+
+    @Test
+    fun hiddenScrollableSubtreeCannotReactivateDescendants() = runApplicationTest {
+        createComposeWindow {
+            Box(Modifier.size(100.dp).clipToBounds()) {
+                Column(
+                    Modifier.offset(200.dp, 0.dp)
+                        .size(100.dp)
+                        .verticalScroll(ScrollState(0))
+                        .testTag("hiddenScroller")
+                ) {
+                    Box(Modifier.size(40.dp).testTag("hiddenItem"))
+                }
+            }
+        }
+        awaitA11YChanges()
+
+        assertTrue(element("hiddenScroller").hasAttribute("inert"))
+        assertTrue(element("hiddenItem").hasAttribute("inert"))
+    }
+
+    @Test
+    fun partiallyClippedAndZeroSizedNodesRemainExposed() = runApplicationTest {
+        createComposeWindow {
+            Box(Modifier.size(100.dp).clipToBounds()) {
+                Box(Modifier.offset(80.dp, 0.dp).size(40.dp).testTag("partial"))
+                Box(Modifier.size(0.dp).testTag("zero"))
+                Box(Modifier.offset(200.dp, 0.dp).size(40.dp).testTag("hidden")) {
+                    Box(Modifier.size(0.dp).testTag("hiddenZero"))
+                }
+            }
+        }
+        awaitA11YChanges()
+
+        assertNull(element("partial").closest("[inert]"))
+        assertEquals("40px", element("partial").style.width)
+        assertEquals("40px", element("partial").style.height)
+        assertNull(element("zero").closest("[inert]"))
+        assertNotNull(element("hiddenZero").closest("[inert]"))
+    }
+}
+
+private fun scrollIntoView(element: HTMLElement) {
+    js("element.scrollIntoView({ block: 'nearest', inline: 'nearest' })")
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10793/Web-A11Y-fully-clipped-elements-are-reachable-with-A11Y


Thanks to `inert` the AT won't interact with the closed navigation drawer.
<img width="1343" height="677" alt="Screenshot 2026-09-15 at 15 26 13" src="https://github.com/user-attachments/assets/d816a09c-2f8d-4c36-92d5-25bffda3b19b" />

And when it's open, there is no `inert` attribute:
<img width="1345" height="672" alt="Screenshot 2026-09-15 at 15 26 23" src="https://github.com/user-attachments/assets/c79e27ca-e1e9-4b2b-a04a-547daa12fdbc" />



## Testing
- Added new tests

## Release Notes
N/A

