### PR TITLE
Convert Value classes companion fields to getters to avoid startup overhead

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuIcons.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuIcons.skiko.kt
@@ -23,10 +23,15 @@ import kotlin.jvm.JvmInline
 @JvmInline
 internal actual value class ContextMenuIcons actual constructor(actual val value: Int) {
     actual companion object {
-        actual val ActionModeCutDrawable = ContextMenuIcons(0)
-        actual val ActionModeCopyDrawable = ContextMenuIcons(1)
-        actual val ActionModePasteDrawable = ContextMenuIcons(2)
-        actual val ActionModeSelectAllDrawable = ContextMenuIcons(3)
-        actual val ID_NULL = ContextMenuIcons(-1)
+        actual inline val ActionModeCutDrawable: ContextMenuIcons
+            get() = ContextMenuIcons(0)
+        actual inline val ActionModeCopyDrawable: ContextMenuIcons
+            get() = ContextMenuIcons(1)
+        actual inline val ActionModePasteDrawable: ContextMenuIcons
+            get() = ContextMenuIcons(2)
+        actual inline val ActionModeSelectAllDrawable: ContextMenuIcons
+            get() = ContextMenuIcons(3)
+        actual inline val ID_NULL: ContextMenuIcons
+            get() = ContextMenuIcons(-1)
     }
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuStrings.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuStrings.skiko.kt
@@ -27,11 +27,16 @@ import kotlin.jvm.JvmInline
 @JvmInline
 internal actual value class ContextMenuStrings actual constructor(actual val value: Int) {
     actual companion object {
-        actual val Cut = ContextMenuStrings(0)
-        actual val Copy = ContextMenuStrings(1)
-        actual val Paste = ContextMenuStrings(2)
-        actual val SelectAll = ContextMenuStrings(3)
-        actual val Autofill = ContextMenuStrings(4)
+        actual inline val Cut: ContextMenuStrings
+            get() = ContextMenuStrings(0)
+        actual inline val Copy: ContextMenuStrings
+            get() = ContextMenuStrings(1)
+        actual inline val Paste: ContextMenuStrings
+            get() = ContextMenuStrings(2)
+        actual inline val SelectAll: ContextMenuStrings
+            get() = ContextMenuStrings(3)
+        actual inline val Autofill: ContextMenuStrings
+            get() = ContextMenuStrings(4)
     }
 }
 

--- a/compose/material3/adaptive/adaptive-layout/src/skikoMain/kotlin/androidx/compose/material3/adaptive/layout/internal/Strings.skiko.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/skikoMain/kotlin/androidx/compose/material3/adaptive/layout/internal/Strings.skiko.kt
@@ -29,21 +29,36 @@ import kotlin.jvm.JvmInline
 @Immutable
 internal actual value class Strings(val value: Int) {
     actual companion object {
-        actual val defaultPaneTitlePrimary = Strings(0)
-        actual val defaultPaneTitleSecondary = Strings(1)
-        actual val defaultPaneTitleTertiary = Strings(2)
-        actual val defaultPaneExpansionDragHandleContentDescription = Strings(3)
-        actual val defaultPaneExpansionDragHandleStateDescription = Strings(4)
-        actual val defaultPaneExpansionDragHandleActionDescription = Strings(5)
-        actual val defaultPaneExpansionProportionAnchorDescription = Strings(6)
-        actual val defaultPaneExpansionStartOffsetAnchorDescription = Strings(7)
-        actual val defaultPaneExpansionEndOffsetAnchorDescription = Strings(8)
-        actual val dragToResizeClickToExpandDescription = Strings(9)
-        actual val dragToResizeClickToCollapseDescription = Strings(10)
-        actual val dragToResizeClickToPartiallyExpandDescription = Strings(11)
-        actual val dragToResizeExpandedStateDescription = Strings(12)
-        actual val dragToResizeCollapsedStateDescription = Strings(13)
-        actual val dragToResizePartiallyExpandedStateDescription = Strings(14)
+        actual inline val defaultPaneTitlePrimary: Strings
+            get() = Strings(0)
+        actual inline val defaultPaneTitleSecondary: Strings
+            get() = Strings(1)
+        actual inline val defaultPaneTitleTertiary: Strings
+            get() = Strings(2)
+        actual inline val defaultPaneExpansionDragHandleContentDescription: Strings
+            get() = Strings(3)
+        actual inline val defaultPaneExpansionDragHandleStateDescription: Strings
+            get() = Strings(4)
+        actual inline val defaultPaneExpansionDragHandleActionDescription: Strings
+            get() = Strings(5)
+        actual inline val defaultPaneExpansionProportionAnchorDescription: Strings
+            get() = Strings(6)
+        actual inline val defaultPaneExpansionStartOffsetAnchorDescription: Strings
+            get() = Strings(7)
+        actual inline val defaultPaneExpansionEndOffsetAnchorDescription: Strings
+            get() = Strings(8)
+        actual inline val dragToResizeClickToExpandDescription: Strings
+            get() = Strings(9)
+        actual inline val dragToResizeClickToCollapseDescription: Strings
+            get() = Strings(10)
+        actual inline val dragToResizeClickToPartiallyExpandDescription: Strings
+            get() = Strings(11)
+        actual inline val dragToResizeExpandedStateDescription: Strings
+            get() = Strings(12)
+        actual inline val dragToResizeCollapsedStateDescription: Strings
+            get() = Strings(13)
+        actual inline val dragToResizePartiallyExpandedStateDescription: Strings
+            get() = Strings(14)
     }
 }
 

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/Strings.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/Strings.skiko.kt
@@ -28,86 +28,166 @@ import kotlin.jvm.JvmInline
 @JvmInline
 internal actual value class Strings(val value: Int) {
     actual companion object {
-        actual val NavigationMenu = Strings(0)
-        actual val CloseDrawer = Strings(1)
-        actual val CloseRail = Strings(2)
-        actual val CloseSheet = Strings(3)
-        actual val DefaultErrorMessage = Strings(4)
-        actual val ExposedDropdownMenu = Strings(5)
-        actual val SliderRangeStart = Strings(6)
-        actual val SliderRangeEnd = Strings(7)
-        actual val Dialog = Strings(8)
-        actual val MenuExpanded = Strings(9)
-        actual val MenuCollapsed = Strings(10)
-        actual val ToggleDropdownMenu = Strings(11)
-        actual val SnackbarDismiss = Strings(12)
-        actual val SnackbarPaneTitle = Strings(13)
-        actual val SearchBarSearch = Strings(14)
-        actual val SuggestionsAvailable = Strings(15)
-        actual val DatePickerTitle = Strings(16)
-        actual val DatePickerHeadline = Strings(17)
-        actual val DatePickerYearPickerPaneTitle = Strings(18)
-        actual val DatePickerSwitchToYearSelection = Strings(19)
-        actual val DatePickerSwitchToDaySelection = Strings(20)
-        actual val DatePickerSwitchToNextMonth = Strings(21)
-        actual val DatePickerSwitchToPreviousMonth = Strings(22)
-        actual val DatePickerNavigateToYearDescription = Strings(23)
-        actual val DatePickerHeadlineDescription = Strings(24)
-        actual val DatePickerNoSelectionDescription = Strings(25)
-        actual val DatePickerTodayDescription = Strings(26)
-        actual val DatePickerScrollToShowLaterYears = Strings(27)
-        actual val DatePickerScrollToShowEarlierYears = Strings(28)
-        actual val DateInputTitle = Strings(29)
-        actual val DateInputHeadline = Strings(30)
-        actual val DateInputLabel = Strings(31)
-        actual val DateInputHeadlineDescription = Strings(32)
-        actual val DateInputNoInputDescription = Strings(33)
-        actual val DateInputInvalidNotAllowed = Strings(34)
-        actual val DateInputInvalidForPattern = Strings(35)
-        actual val DateInputInvalidYearRange = Strings(36)
-        actual val DatePickerSwitchToCalendarMode = Strings(37)
-        actual val DatePickerSwitchToInputMode = Strings(38)
-        actual val DateRangePickerTitle = Strings(39)
-        actual val DateRangePickerStartHeadline = Strings(40)
-        actual val DateRangePickerEndHeadline = Strings(41)
-        actual val DateRangePickerScrollToShowNextMonth = Strings(42)
-        actual val DateRangePickerScrollToShowPreviousMonth = Strings(43)
-        actual val DateRangePickerDayInRange = Strings(44)
-        actual val DateRangeInputTitle = Strings(45)
-        actual val DateRangeInputInvalidRangeInput = Strings(46)
-        actual val FloatingToolbarCollapse = Strings(47)
-        actual val FloatingToolbarExpand = Strings(48)
-        actual val FloatingToolbarMoreOptions = Strings(49)
-        actual val BottomSheetPaneTitle = Strings(50)
-        actual val BottomSheetDragHandleDescription = Strings(51)
-        actual val BottomSheetPartialExpandDescription = Strings(52)
-        actual val BottomSheetDismissDescription = Strings(53)
-        actual val BottomSheetExpandDescription = Strings(54)
-        actual val TooltipLongPressLabel = Strings(55)
-        actual val TimePickerAM = Strings(56)
-        actual val TimePickerPM = Strings(57)
-        actual val TimePickerPeriodToggle = Strings(58)
-        actual val TimePickerHourSelection = Strings(59)
-        actual val TimePickerMinuteSelection = Strings(60)
-        actual val TimePickerHourSuffix = Strings(61)
-        actual val TimePicker24HourSuffix = Strings(62)
-        actual val TimePickerMinuteSuffix = Strings(63)
-        actual val TimePickerHour = Strings(64)
-        actual val TimePickerMinute = Strings(65)
-        actual val TimePickerHourTextField = Strings(66)
-        actual val TimePickerMinuteTextField = Strings(67)
-        actual val TimePickerDialogTitle = Strings(68)
-        actual val TimeScrollDialogTitle = Strings(69)
-        actual val TimeInputDialogTitle = Strings(70)
-        actual val TimePickerToggleKeyboard= Strings(71)
-        actual val TimePickerToggleScroll = Strings(72)
-        actual val TimePickerToggleTouch = Strings(73)
-        actual val TimePickerMinuteError = Strings(74)
-        actual val TimePickerHourError = Strings(75)
-        actual val TimePicker24HourError = Strings(76)
-        actual val TooltipPaneDescription = Strings(77)
-        actual val WideNavigationRailPaneTitle = Strings(78)
-        actual val ButtonGroupMoreOptions = Strings(79)
+        actual inline val NavigationMenu: Strings
+            get() = Strings(0)
+        actual inline val CloseDrawer: Strings
+            get() = Strings(1)
+        actual inline val CloseRail: Strings
+            get() = Strings(2)
+        actual inline val CloseSheet: Strings
+            get() = Strings(3)
+        actual inline val DefaultErrorMessage: Strings
+            get() = Strings(4)
+        actual inline val ExposedDropdownMenu: Strings
+            get() = Strings(5)
+        actual inline val SliderRangeStart: Strings
+            get() = Strings(6)
+        actual inline val SliderRangeEnd: Strings
+            get() = Strings(7)
+        actual inline val Dialog: Strings
+            get() = Strings(8)
+        actual inline val MenuExpanded: Strings
+            get() = Strings(9)
+        actual inline val MenuCollapsed: Strings
+            get() = Strings(10)
+        actual inline val ToggleDropdownMenu: Strings
+            get() = Strings(11)
+        actual inline val SnackbarDismiss: Strings
+            get() = Strings(12)
+        actual inline val SnackbarPaneTitle: Strings
+            get() = Strings(13)
+        actual inline val SearchBarSearch: Strings
+            get() = Strings(14)
+        actual inline val SuggestionsAvailable: Strings
+            get() = Strings(15)
+        actual inline val DatePickerTitle: Strings
+            get() = Strings(16)
+        actual inline val DatePickerHeadline: Strings
+            get() = Strings(17)
+        actual inline val DatePickerYearPickerPaneTitle: Strings
+            get() = Strings(18)
+        actual inline val DatePickerSwitchToYearSelection: Strings
+            get() = Strings(19)
+        actual inline val DatePickerSwitchToDaySelection: Strings
+            get() = Strings(20)
+        actual inline val DatePickerSwitchToNextMonth: Strings
+            get() = Strings(21)
+        actual inline val DatePickerSwitchToPreviousMonth: Strings
+            get() = Strings(22)
+        actual inline val DatePickerNavigateToYearDescription: Strings
+            get() = Strings(23)
+        actual inline val DatePickerHeadlineDescription: Strings
+            get() = Strings(24)
+        actual inline val DatePickerNoSelectionDescription: Strings
+            get() = Strings(25)
+        actual inline val DatePickerTodayDescription: Strings
+            get() = Strings(26)
+        actual inline val DatePickerScrollToShowLaterYears: Strings
+            get() = Strings(27)
+        actual inline val DatePickerScrollToShowEarlierYears: Strings
+            get() = Strings(28)
+        actual inline val DateInputTitle: Strings
+            get() = Strings(29)
+        actual inline val DateInputHeadline: Strings
+            get() = Strings(30)
+        actual inline val DateInputLabel: Strings
+            get() = Strings(31)
+        actual inline val DateInputHeadlineDescription: Strings
+            get() = Strings(32)
+        actual inline val DateInputNoInputDescription: Strings
+            get() = Strings(33)
+        actual inline val DateInputInvalidNotAllowed: Strings
+            get() = Strings(34)
+        actual inline val DateInputInvalidForPattern: Strings
+            get() = Strings(35)
+        actual inline val DateInputInvalidYearRange: Strings
+            get() = Strings(36)
+        actual inline val DatePickerSwitchToCalendarMode: Strings
+            get() = Strings(37)
+        actual inline val DatePickerSwitchToInputMode: Strings
+            get() = Strings(38)
+        actual inline val DateRangePickerTitle: Strings
+            get() = Strings(39)
+        actual inline val DateRangePickerStartHeadline: Strings
+            get() = Strings(40)
+        actual inline val DateRangePickerEndHeadline: Strings
+            get() = Strings(41)
+        actual inline val DateRangePickerScrollToShowNextMonth: Strings
+            get() = Strings(42)
+        actual inline val DateRangePickerScrollToShowPreviousMonth: Strings
+            get() = Strings(43)
+        actual inline val DateRangePickerDayInRange: Strings
+            get() = Strings(44)
+        actual inline val DateRangeInputTitle: Strings
+            get() = Strings(45)
+        actual inline val DateRangeInputInvalidRangeInput: Strings
+            get() = Strings(46)
+        actual inline val FloatingToolbarCollapse: Strings
+            get() = Strings(47)
+        actual inline val FloatingToolbarExpand: Strings
+            get() = Strings(48)
+        actual inline val FloatingToolbarMoreOptions: Strings
+            get() = Strings(49)
+        actual inline val BottomSheetPaneTitle: Strings
+            get() = Strings(50)
+        actual inline val BottomSheetDragHandleDescription: Strings
+            get() = Strings(51)
+        actual inline val BottomSheetPartialExpandDescription: Strings
+            get() = Strings(52)
+        actual inline val BottomSheetDismissDescription: Strings
+            get() = Strings(53)
+        actual inline val BottomSheetExpandDescription: Strings
+            get() = Strings(54)
+        actual inline val TooltipLongPressLabel: Strings
+            get() = Strings(55)
+        actual inline val TimePickerAM: Strings
+            get() = Strings(56)
+        actual inline val TimePickerPM: Strings
+            get() = Strings(57)
+        actual inline val TimePickerPeriodToggle: Strings
+            get() = Strings(58)
+        actual inline val TimePickerHourSelection: Strings
+            get() = Strings(59)
+        actual inline val TimePickerMinuteSelection: Strings
+            get() = Strings(60)
+        actual inline val TimePickerHourSuffix: Strings
+            get() = Strings(61)
+        actual inline val TimePicker24HourSuffix: Strings
+            get() = Strings(62)
+        actual inline val TimePickerMinuteSuffix: Strings
+            get() = Strings(63)
+        actual inline val TimePickerHour: Strings
+            get() = Strings(64)
+        actual inline val TimePickerMinute: Strings
+            get() = Strings(65)
+        actual inline val TimePickerHourTextField: Strings
+            get() = Strings(66)
+        actual inline val TimePickerMinuteTextField: Strings
+            get() = Strings(67)
+        actual inline val TimePickerDialogTitle: Strings
+            get() = Strings(68)
+        actual inline val TimeScrollDialogTitle: Strings
+            get() = Strings(69)
+        actual inline val TimeInputDialogTitle: Strings
+            get() = Strings(70)
+        actual inline val TimePickerToggleKeyboard: Strings
+            get() = Strings(71)
+        actual inline val TimePickerToggleScroll: Strings
+            get() = Strings(72)
+        actual inline val TimePickerToggleTouch: Strings
+            get() = Strings(73)
+        actual inline val TimePickerMinuteError: Strings
+            get() = Strings(74)
+        actual inline val TimePickerHourError: Strings
+            get() = Strings(75)
+        actual inline val TimePicker24HourError: Strings
+            get() = Strings(76)
+        actual inline val TooltipPaneDescription: Strings
+            get() = Strings(77)
+        actual inline val WideNavigationRailPaneTitle: Strings
+            get() = Strings(78)
+        actual inline val ButtonGroupMoreOptions: Strings
+            get() = Strings(79)
         // When adding values here, make sure to also add them in material3/build-fork.gradle,
         // updateTranslations task (stringByResourceName parameter), and re-run the task
     }

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoCharHelpers.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/SkikoCharHelpers.nonAndroid.kt
@@ -38,9 +38,12 @@ internal fun findSkikoFollowingBreak(text: String, index: Int): Int {
 @JvmInline
 internal value class StrongDirectionType private constructor(val value: Int) {
     companion object {
-        val None = StrongDirectionType(0)
-        val Ltr = StrongDirectionType(1)
-        val Rtl = StrongDirectionType(2)
+        inline val None: StrongDirectionType
+            get() = StrongDirectionType(0)
+        inline val Ltr: StrongDirectionType
+            get() = StrongDirectionType(1)
+        inline val Rtl: StrongDirectionType
+            get() = StrongDirectionType(2)
     }
 }
 

--- a/compose/ui/ui-text/src/nonAndroidMain/kotlin/androidx/compose/ui/text/TextDecorationLineStyle.kt
+++ b/compose/ui/ui-text/src/nonAndroidMain/kotlin/androidx/compose/ui/text/TextDecorationLineStyle.kt
@@ -42,27 +42,32 @@ value class TextDecorationLineStyle internal constructor(val value: Int) {
         /**
          * Solid line.
          */
-        val Solid = TextDecorationLineStyle(1)
+        val Solid: TextDecorationLineStyle
+            get() = TextDecorationLineStyle(1)
 
         /**
          * Double line.
          */
-        val Double = TextDecorationLineStyle(2)
+        val Double: TextDecorationLineStyle
+            get() = TextDecorationLineStyle(2)
 
         /**
          * Dotted line.
          */
-        val Dotted = TextDecorationLineStyle(3)
+        val Dotted: TextDecorationLineStyle
+            get() = TextDecorationLineStyle(3)
 
         /**
          * Dashed line.
          */
-        val Dashed = TextDecorationLineStyle(4)
+        val Dashed: TextDecorationLineStyle
+            get() = TextDecorationLineStyle(4)
 
         /**
          * Wavy line.
          */
-        val Wavy = TextDecorationLineStyle(5)
+        val Wavy: TextDecorationLineStyle
+            get() = TextDecorationLineStyle(5)
     }
 
 }

--- a/compose/ui/ui-text/src/nonAndroidMain/kotlin/androidx/compose/ui/text/style/LineBreak.nonAndroid.kt
+++ b/compose/ui/ui-text/src/nonAndroidMain/kotlin/androidx/compose/ui/text/style/LineBreak.nonAndroid.kt
@@ -26,12 +26,16 @@ actual value class LineBreak private constructor(
     internal val mask: Int
 ) {
     actual companion object {
-        @Stable actual val Simple: LineBreak = LineBreak(1)
+        @Stable actual val Simple: LineBreak
+            get() = LineBreak(1)
 
-        @Stable actual val Heading: LineBreak = LineBreak(2)
+        @Stable actual val Heading: LineBreak
+            get() = LineBreak(2)
 
-        @Stable actual val Paragraph: LineBreak = LineBreak(3)
+        @Stable actual val Paragraph: LineBreak
+            get() = LineBreak(3)
 
-        @Stable actual val Unspecified: LineBreak = LineBreak(4)
+        @Stable actual val Unspecified: LineBreak
+            get() = LineBreak(4)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -69,7 +69,8 @@ interface DragAndDropTransferable
  * The possible actions on the transferred object in a drag-and-drop session.
  */
 @ExperimentalComposeUiApi
-class DragAndDropTransferAction private constructor(private val name: String) {
+@JvmInline
+value class DragAndDropTransferAction private constructor(private val name: String) {
     override fun toString(): String {
         return name
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -79,17 +79,20 @@ value class DragAndDropTransferAction private constructor(private val name: Stri
         /**
          * Indicates the dragged object should be copied into the target.
          */
-        val Copy = DragAndDropTransferAction("Copy")
+        val Copy: DragAndDropTransferAction
+            get() = DragAndDropTransferAction("Copy")
 
         /**
          * Indicates the dragged object should be moved ("cut" and "pasted") into the target.
          */
-        val Move = DragAndDropTransferAction("Move")
+        val Move: DragAndDropTransferAction
+            get() = DragAndDropTransferAction("Move")
 
         /**
          * Indicates the dragged object should be linked to at the target.
          */
-        val Link = DragAndDropTransferAction("Link")
+        val Link: DragAndDropTransferAction
+            get() = DragAndDropTransferAction("Link")
     }
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
@@ -38,7 +38,8 @@ import java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
 actual value class Key(val keyCode: Long) {
     actual companion object {
         /** Unknown key. */
-        actual val Unknown = Key(KeyEvent.VK_UNDEFINED)
+        actual val Unknown: Key
+            get() = Key(KeyEvent.VK_UNDEFINED)
 
         /**
          * System Home key.
@@ -52,233 +53,300 @@ actual value class Key(val keyCode: Long) {
                 "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
             level = DeprecationLevel.ERROR,
         )
-        actual val Home = Key(KeyEvent.VK_HOME)
+        actual val Home: Key
+            get() = Key(KeyEvent.VK_HOME)
 
         /**
          * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
-        actual val SystemHome: Key = Key(-1000000184)
+        actual val SystemHome: Key
+            get() = Key(-1000000184)
 
         /** Help key. */
-        actual val Help = Key(KeyEvent.VK_HELP)
+        actual val Help: Key
+            get() = Key(KeyEvent.VK_HELP)
 
         /**
          * Up Arrow Key / Directional Pad Up key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionUp = Key(KeyEvent.VK_UP)
+        actual val DirectionUp: Key
+            get() = Key(KeyEvent.VK_UP)
 
         /**
          * Down Arrow Key / Directional Pad Down key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionDown = Key(KeyEvent.VK_DOWN)
+        actual val DirectionDown: Key
+            get() = Key(KeyEvent.VK_DOWN)
 
         /**
          * Left Arrow Key / Directional Pad Left key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionLeft = Key(KeyEvent.VK_LEFT)
+        actual val DirectionLeft: Key
+            get() = Key(KeyEvent.VK_LEFT)
 
         /**
          * Right Arrow Key / Directional Pad Right key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionRight = Key(KeyEvent.VK_RIGHT)
+        actual val DirectionRight: Key
+            get() = Key(KeyEvent.VK_RIGHT)
 
         /** '0' key. */
-        actual val Zero = Key(KeyEvent.VK_0)
+        actual val Zero: Key
+            get() = Key(KeyEvent.VK_0)
 
         /** '1' key. */
-        actual val One = Key(KeyEvent.VK_1)
+        actual val One: Key
+            get() = Key(KeyEvent.VK_1)
 
         /** '2' key. */
-        actual val Two = Key(KeyEvent.VK_2)
+        actual val Two: Key
+            get() = Key(KeyEvent.VK_2)
 
         /** '3' key. */
-        actual val Three = Key(KeyEvent.VK_3)
+        actual val Three: Key
+            get() = Key(KeyEvent.VK_3)
 
         /** '4' key. */
-        actual val Four = Key(KeyEvent.VK_4)
+        actual val Four: Key
+            get() = Key(KeyEvent.VK_4)
 
         /** '5' key. */
-        actual val Five = Key(KeyEvent.VK_5)
+        actual val Five: Key
+            get() = Key(KeyEvent.VK_5)
 
         /** '6' key. */
-        actual val Six = Key(KeyEvent.VK_6)
+        actual val Six: Key
+            get() = Key(KeyEvent.VK_6)
 
         /** '7' key. */
-        actual val Seven = Key(KeyEvent.VK_7)
+        actual val Seven: Key
+            get() = Key(KeyEvent.VK_7)
 
         /** '8' key. */
-        actual val Eight = Key(KeyEvent.VK_8)
+        actual val Eight: Key
+            get() = Key(KeyEvent.VK_8)
 
         /** '9' key. */
-        actual val Nine = Key(KeyEvent.VK_9)
+        actual val Nine: Key
+            get() = Key(KeyEvent.VK_9)
 
         /** '+' key. */
-        actual val Plus = Key(KeyEvent.VK_PLUS)
+        actual val Plus: Key
+            get() = Key(KeyEvent.VK_PLUS)
 
         /** '-' key. */
-        actual val Minus = Key(KeyEvent.VK_MINUS)
+        actual val Minus: Key
+            get() = Key(KeyEvent.VK_MINUS)
 
         /** '*' key. */
-        actual val Multiply = Key(KeyEvent.VK_MULTIPLY)
+        actual val Multiply: Key
+            get() = Key(KeyEvent.VK_MULTIPLY)
 
         /** '=' key. */
-        actual val Equals = Key(KeyEvent.VK_EQUALS)
+        actual val Equals: Key
+            get() = Key(KeyEvent.VK_EQUALS)
 
         /** '#' key. */
-        actual val Pound = Key(KeyEvent.VK_NUMBER_SIGN)
+        actual val Pound: Key
+            get() = Key(KeyEvent.VK_NUMBER_SIGN)
 
         /** 'A' key. */
-        actual val A = Key(KeyEvent.VK_A)
+        actual val A: Key
+            get() = Key(KeyEvent.VK_A)
 
         /** 'B' key. */
-        actual val B = Key(KeyEvent.VK_B)
+        actual val B: Key
+            get() = Key(KeyEvent.VK_B)
 
         /** 'C' key. */
-        actual val C = Key(KeyEvent.VK_C)
+        actual val C: Key
+            get() = Key(KeyEvent.VK_C)
 
         /** 'D' key. */
-        actual val D = Key(KeyEvent.VK_D)
+        actual val D: Key
+            get() = Key(KeyEvent.VK_D)
 
         /** 'E' key. */
-        actual val E = Key(KeyEvent.VK_E)
+        actual val E: Key
+            get() = Key(KeyEvent.VK_E)
 
         /** 'F' key. */
-        actual val F = Key(KeyEvent.VK_F)
+        actual val F: Key
+            get() = Key(KeyEvent.VK_F)
 
         /** 'G' key. */
-        actual val G = Key(KeyEvent.VK_G)
+        actual val G: Key
+            get() = Key(KeyEvent.VK_G)
 
         /** 'H' key. */
-        actual val H = Key(KeyEvent.VK_H)
+        actual val H: Key
+            get() = Key(KeyEvent.VK_H)
 
         /** 'I' key. */
-        actual val I = Key(KeyEvent.VK_I)
+        actual val I: Key
+            get() = Key(KeyEvent.VK_I)
 
         /** 'J' key. */
-        actual val J = Key(KeyEvent.VK_J)
+        actual val J: Key
+            get() = Key(KeyEvent.VK_J)
 
         /** 'K' key. */
-        actual val K = Key(KeyEvent.VK_K)
+        actual val K: Key
+            get() = Key(KeyEvent.VK_K)
 
         /** 'L' key. */
-        actual val L = Key(KeyEvent.VK_L)
+        actual val L: Key
+            get() = Key(KeyEvent.VK_L)
 
         /** 'M' key. */
-        actual val M = Key(KeyEvent.VK_M)
+        actual val M: Key
+            get() = Key(KeyEvent.VK_M)
 
         /** 'N' key. */
-        actual val N = Key(KeyEvent.VK_N)
+        actual val N: Key
+            get() = Key(KeyEvent.VK_N)
 
         /** 'O' key. */
-        actual val O = Key(KeyEvent.VK_O)
+        actual val O: Key
+            get() = Key(KeyEvent.VK_O)
 
         /** 'P' key. */
-        actual val P = Key(KeyEvent.VK_P)
+        actual val P: Key
+            get() = Key(KeyEvent.VK_P)
 
         /** 'Q' key. */
-        actual val Q = Key(KeyEvent.VK_Q)
+        actual val Q: Key
+            get() = Key(KeyEvent.VK_Q)
 
         /** 'R' key. */
-        actual val R = Key(KeyEvent.VK_R)
+        actual val R: Key
+            get() = Key(KeyEvent.VK_R)
 
         /** 'S' key. */
-        actual val S = Key(KeyEvent.VK_S)
+        actual val S: Key
+            get() = Key(KeyEvent.VK_S)
 
         /** 'T' key. */
-        actual val T = Key(KeyEvent.VK_T)
+        actual val T: Key
+            get() = Key(KeyEvent.VK_T)
 
         /** 'U' key. */
-        actual val U = Key(KeyEvent.VK_U)
+        actual val U: Key
+            get() = Key(KeyEvent.VK_U)
 
         /** 'V' key. */
-        actual val V = Key(KeyEvent.VK_V)
+        actual val V: Key
+            get() = Key(KeyEvent.VK_V)
 
         /** 'W' key. */
-        actual val W = Key(KeyEvent.VK_W)
+        actual val W: Key
+            get() = Key(KeyEvent.VK_W)
 
         /** 'X' key. */
-        actual val X = Key(KeyEvent.VK_X)
+        actual val X: Key
+            get() = Key(KeyEvent.VK_X)
 
         /** 'Y' key. */
-        actual val Y = Key(KeyEvent.VK_Y)
+        actual val Y: Key
+            get() = Key(KeyEvent.VK_Y)
 
         /** 'Z' key. */
-        actual val Z = Key(KeyEvent.VK_Z)
+        actual val Z: Key
+            get() = Key(KeyEvent.VK_Z)
 
         /** ',' key. */
-        actual val Comma = Key(KeyEvent.VK_COMMA)
+        actual val Comma: Key
+            get() = Key(KeyEvent.VK_COMMA)
 
         /** '.' key. */
-        actual val Period = Key(KeyEvent.VK_PERIOD)
+        actual val Period: Key
+            get() = Key(KeyEvent.VK_PERIOD)
 
         /** Left Alt modifier key. */
-        actual val AltLeft = Key(KeyEvent.VK_ALT, KEY_LOCATION_LEFT)
+        actual val AltLeft: Key
+            get() = Key(KeyEvent.VK_ALT, KEY_LOCATION_LEFT)
 
         /** Right Alt modifier key. */
-        actual val AltRight = Key(KeyEvent.VK_ALT, KEY_LOCATION_RIGHT)
+        actual val AltRight: Key
+            get() = Key(KeyEvent.VK_ALT, KEY_LOCATION_RIGHT)
 
         /** Left Shift modifier key. */
-        actual val ShiftLeft = Key(KeyEvent.VK_SHIFT, KEY_LOCATION_LEFT)
+        actual val ShiftLeft: Key
+            get() = Key(KeyEvent.VK_SHIFT, KEY_LOCATION_LEFT)
 
         /** Right Shift modifier key. */
-        actual val ShiftRight = Key(KeyEvent.VK_SHIFT, KEY_LOCATION_RIGHT)
+        actual val ShiftRight: Key
+            get() = Key(KeyEvent.VK_SHIFT, KEY_LOCATION_RIGHT)
 
         /** Tab key. */
-        actual val Tab = Key(KeyEvent.VK_TAB)
+        actual val Tab: Key
+            get() = Key(KeyEvent.VK_TAB)
 
         /** Space key. */
-        actual val Spacebar = Key(KeyEvent.VK_SPACE)
+        actual val Spacebar: Key
+            get() = Key(KeyEvent.VK_SPACE)
 
         /** Enter key. */
-        actual val Enter = Key(KeyEvent.VK_ENTER)
+        actual val Enter: Key
+            get() = Key(KeyEvent.VK_ENTER)
 
         /**
          * Backspace key.
          *
          * Deletes characters before the insertion point, unlike [Delete].
          */
-        actual val Backspace = Key(KeyEvent.VK_BACK_SPACE)
+        actual val Backspace: Key
+            get() = Key(KeyEvent.VK_BACK_SPACE)
 
         /**
          * Delete key.
          *
          * Deletes characters ahead of the insertion point, unlike [Backspace].
          */
-        actual val Delete = Key(KeyEvent.VK_DELETE)
+        actual val Delete: Key
+            get() = Key(KeyEvent.VK_DELETE)
 
         /** Escape key. */
-        actual val Escape = Key(KeyEvent.VK_ESCAPE)
+        actual val Escape: Key
+            get() = Key(KeyEvent.VK_ESCAPE)
 
         /** Left Control modifier key. */
-        actual val CtrlLeft = Key(KeyEvent.VK_CONTROL, KEY_LOCATION_LEFT)
+        actual val CtrlLeft: Key
+            get() = Key(KeyEvent.VK_CONTROL, KEY_LOCATION_LEFT)
 
         /** Right Control modifier key. */
-        actual val CtrlRight = Key(KeyEvent.VK_CONTROL, KEY_LOCATION_RIGHT)
+        actual val CtrlRight: Key
+            get() = Key(KeyEvent.VK_CONTROL, KEY_LOCATION_RIGHT)
 
         /** Caps Lock key. */
-        actual val CapsLock = Key(KeyEvent.VK_CAPS_LOCK)
+        actual val CapsLock: Key
+            get() = Key(KeyEvent.VK_CAPS_LOCK)
 
         /** Scroll Lock key. */
-        actual val ScrollLock = Key(KeyEvent.VK_SCROLL_LOCK)
+        actual val ScrollLock: Key
+            get() = Key(KeyEvent.VK_SCROLL_LOCK)
 
         /** Left Meta modifier key. */
-        actual val MetaLeft = Key(KeyEvent.VK_META, KEY_LOCATION_LEFT)
+        actual val MetaLeft: Key
+            get() = Key(KeyEvent.VK_META, KEY_LOCATION_LEFT)
 
         /** Right Meta modifier key. */
-        actual val MetaRight = Key(KeyEvent.VK_META, KEY_LOCATION_RIGHT)
+        actual val MetaRight: Key
+            get() = Key(KeyEvent.VK_META, KEY_LOCATION_RIGHT)
 
         /** System Request / Print Screen key. */
-        actual val PrintScreen = Key(KeyEvent.VK_PRINTSCREEN)
+        actual val PrintScreen: Key
+            get() = Key(KeyEvent.VK_PRINTSCREEN)
 
         /**
          * Home Movement key.
@@ -286,7 +354,8 @@ actual value class Key(val keyCode: Long) {
          * Used for scrolling or moving the cursor around to the start of a line or to the top of a
          * list.
          */
-        actual val MoveHome = Key(KeyEvent.VK_HOME)
+        actual val MoveHome: Key
+            get() = Key(KeyEvent.VK_HOME)
 
         /**
          * End Movement key.
@@ -294,89 +363,116 @@ actual value class Key(val keyCode: Long) {
          * Used for scrolling or moving the cursor around to the end of a line or to the bottom of a
          * list.
          */
-        actual val MoveEnd = Key(KeyEvent.VK_END)
+        actual val MoveEnd: Key
+            get() = Key(KeyEvent.VK_END)
 
         /**
          * Insert key.
          *
          * Toggles insert / overwrite edit mode.
          */
-        actual val Insert = Key(KeyEvent.VK_INSERT)
+        actual val Insert: Key
+            get() = Key(KeyEvent.VK_INSERT)
 
         /** Cut key. */
-        actual val Cut = Key(KeyEvent.VK_CUT)
+        actual val Cut: Key
+            get() = Key(KeyEvent.VK_CUT)
 
         /** Copy key. */
-        actual val Copy = Key(KeyEvent.VK_COPY)
+        actual val Copy: Key
+            get() = Key(KeyEvent.VK_COPY)
 
         /** Paste key. */
-        actual val Paste = Key(KeyEvent.VK_PASTE)
+        actual val Paste: Key
+            get() = Key(KeyEvent.VK_PASTE)
 
         /** '`' (backtick) key. */
-        actual val Grave = Key(KeyEvent.VK_BACK_QUOTE)
+        actual val Grave: Key
+            get() = Key(KeyEvent.VK_BACK_QUOTE)
 
         /** '[' key. */
-        actual val LeftBracket = Key(KeyEvent.VK_OPEN_BRACKET)
+        actual val LeftBracket: Key
+            get() = Key(KeyEvent.VK_OPEN_BRACKET)
 
         /** ']' key. */
-        actual val RightBracket = Key(KeyEvent.VK_CLOSE_BRACKET)
+        actual val RightBracket: Key
+            get() = Key(KeyEvent.VK_CLOSE_BRACKET)
 
         /** '/' key. */
-        actual val Slash = Key(KeyEvent.VK_SLASH)
+        actual val Slash: Key
+            get() = Key(KeyEvent.VK_SLASH)
 
         /** '\' key. */
-        actual val Backslash = Key(KeyEvent.VK_BACK_SLASH)
+        actual val Backslash: Key
+            get() = Key(KeyEvent.VK_BACK_SLASH)
 
         /** ';' key. */
-        actual val Semicolon = Key(KeyEvent.VK_SEMICOLON)
+        actual val Semicolon: Key
+            get() = Key(KeyEvent.VK_SEMICOLON)
 
         /** ''' (apostrophe) key. */
-        actual val Apostrophe = Key(KeyEvent.VK_QUOTE)
+        actual val Apostrophe: Key
+            get() = Key(KeyEvent.VK_QUOTE)
 
         /** '@' key. */
-        actual val At = Key(KeyEvent.VK_AT)
+        actual val At: Key
+            get() = Key(KeyEvent.VK_AT)
 
         /** Page Up key. */
-        actual val PageUp = Key(KeyEvent.VK_PAGE_UP)
+        actual val PageUp: Key
+            get() = Key(KeyEvent.VK_PAGE_UP)
 
         /** Page Down key. */
-        actual val PageDown = Key(KeyEvent.VK_PAGE_DOWN)
+        actual val PageDown: Key
+            get() = Key(KeyEvent.VK_PAGE_DOWN)
 
         /** F1 key. */
-        actual val F1 = Key(KeyEvent.VK_F1)
+        actual val F1: Key
+            get() = Key(KeyEvent.VK_F1)
 
         /** F2 key. */
-        actual val F2 = Key(KeyEvent.VK_F2)
+        actual val F2: Key
+            get() = Key(KeyEvent.VK_F2)
 
         /** F3 key. */
-        actual val F3 = Key(KeyEvent.VK_F3)
+        actual val F3: Key
+            get() = Key(KeyEvent.VK_F3)
 
         /** F4 key. */
-        actual val F4 = Key(KeyEvent.VK_F4)
+        actual val F4: Key
+            get() = Key(KeyEvent.VK_F4)
 
         /** F5 key. */
-        actual val F5 = Key(KeyEvent.VK_F5)
+        actual val F5: Key
+            get() = Key(KeyEvent.VK_F5)
 
         /** F6 key. */
-        actual val F6 = Key(KeyEvent.VK_F6)
+        actual val F6: Key
+            get() = Key(KeyEvent.VK_F6)
 
         /** F7 key. */
-        actual val F7 = Key(KeyEvent.VK_F7)
+        actual val F7: Key
+            get() = Key(KeyEvent.VK_F7)
 
         /** F8 key. */
-        actual val F8 = Key(KeyEvent.VK_F8)
+        actual val F8: Key
+            get() = Key(KeyEvent.VK_F8)
 
         /** F9 key. */
-        actual val F9 = Key(KeyEvent.VK_F9)
+        actual val F9: Key
+            get() = Key(KeyEvent.VK_F9)
 
         /** F10 key. */
-        actual val F10 = Key(KeyEvent.VK_F10)
+        actual val F10: Key
+            get() = Key(KeyEvent.VK_F10)
 
         /** F11 key. */
-        actual val F11 = Key(KeyEvent.VK_F11)
+        actual val F11: Key
+            get() = Key(KeyEvent.VK_F11)
 
         /** F12 key. */
-        actual val F12 = Key(KeyEvent.VK_F12)
+        actual val F12: Key
+            get() = Key(KeyEvent.VK_F12)
 
         /**
          * Num Lock key.
@@ -384,271 +480,473 @@ actual value class Key(val keyCode: Long) {
          * This is the Num Lock key; it is different from [Number].
          * This key alters the behavior of other keys on the numeric keypad.
          */
-        actual val NumLock = Key(KeyEvent.VK_NUM_LOCK, KEY_LOCATION_NUMPAD)
+        actual val NumLock: Key
+            get() = Key(KeyEvent.VK_NUM_LOCK, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '0' key. */
-        actual val NumPad0 = Key(KeyEvent.VK_NUMPAD0, KEY_LOCATION_NUMPAD)
+        actual val NumPad0: Key
+            get() = Key(KeyEvent.VK_NUMPAD0, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '1' key. */
-        actual val NumPad1 = Key(KeyEvent.VK_NUMPAD1, KEY_LOCATION_NUMPAD)
+        actual val NumPad1: Key
+            get() = Key(KeyEvent.VK_NUMPAD1, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '2' key. */
-        actual val NumPad2 = Key(KeyEvent.VK_NUMPAD2, KEY_LOCATION_NUMPAD)
+        actual val NumPad2: Key
+            get() = Key(KeyEvent.VK_NUMPAD2, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '3' key. */
-        actual val NumPad3 = Key(KeyEvent.VK_NUMPAD3, KEY_LOCATION_NUMPAD)
+        actual val NumPad3: Key
+            get() = Key(KeyEvent.VK_NUMPAD3, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '4' key. */
-        actual val NumPad4 = Key(KeyEvent.VK_NUMPAD4, KEY_LOCATION_NUMPAD)
+        actual val NumPad4: Key
+            get() = Key(KeyEvent.VK_NUMPAD4, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '5' key. */
-        actual val NumPad5 = Key(KeyEvent.VK_NUMPAD5, KEY_LOCATION_NUMPAD)
+        actual val NumPad5: Key
+            get() = Key(KeyEvent.VK_NUMPAD5, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '6' key. */
-        actual val NumPad6 = Key(KeyEvent.VK_NUMPAD6, KEY_LOCATION_NUMPAD)
+        actual val NumPad6: Key
+            get() = Key(KeyEvent.VK_NUMPAD6, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '7' key. */
-        actual val NumPad7 = Key(KeyEvent.VK_NUMPAD7, KEY_LOCATION_NUMPAD)
+        actual val NumPad7: Key
+            get() = Key(KeyEvent.VK_NUMPAD7, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '8' key. */
-        actual val NumPad8 = Key(KeyEvent.VK_NUMPAD8, KEY_LOCATION_NUMPAD)
+        actual val NumPad8: Key
+            get() = Key(KeyEvent.VK_NUMPAD8, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '9' key. */
-        actual val NumPad9 = Key(KeyEvent.VK_NUMPAD9, KEY_LOCATION_NUMPAD)
+        actual val NumPad9: Key
+            get() = Key(KeyEvent.VK_NUMPAD9, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '/' key (for division). */
-        actual val NumPadDivide = Key(KeyEvent.VK_DIVIDE, KEY_LOCATION_NUMPAD)
+        actual val NumPadDivide: Key
+            get() = Key(KeyEvent.VK_DIVIDE, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '*' key (for multiplication). */
-        actual val NumPadMultiply = Key(KeyEvent.VK_MULTIPLY, KEY_LOCATION_NUMPAD)
+        actual val NumPadMultiply: Key
+            get() = Key(KeyEvent.VK_MULTIPLY, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '-' key (for subtraction). */
-        actual val NumPadSubtract = Key(KeyEvent.VK_SUBTRACT, KEY_LOCATION_NUMPAD)
+        actual val NumPadSubtract: Key
+            get() = Key(KeyEvent.VK_SUBTRACT, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '+' key (for addition). */
-        actual val NumPadAdd = Key(KeyEvent.VK_ADD, KEY_LOCATION_NUMPAD)
+        actual val NumPadAdd: Key
+            get() = Key(KeyEvent.VK_ADD, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '.' key (for decimals or digit grouping). */
-        actual val NumPadDot = Key(KeyEvent.VK_DECIMAL, KEY_LOCATION_NUMPAD)
+        actual val NumPadDot: Key
+            get() = Key(KeyEvent.VK_DECIMAL, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad ',' key (for decimals or digit grouping). */
-        actual val NumPadComma = Key(KeyEvent.VK_COMMA, KEY_LOCATION_NUMPAD)
+        actual val NumPadComma: Key
+            get() = Key(KeyEvent.VK_COMMA, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Enter key. */
-        actual val NumPadEnter = Key(KeyEvent.VK_ENTER, KEY_LOCATION_NUMPAD)
+        actual val NumPadEnter: Key
+            get() = Key(KeyEvent.VK_ENTER, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '=' key. */
-        actual val NumPadEquals = Key(KeyEvent.VK_EQUALS, KEY_LOCATION_NUMPAD)
+        actual val NumPadEquals: Key
+            get() = Key(KeyEvent.VK_EQUALS, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad '(' key. */
-        actual val NumPadLeftParenthesis = Key(KeyEvent.VK_LEFT_PARENTHESIS, KEY_LOCATION_NUMPAD)
+        actual val NumPadLeftParenthesis: Key
+            get() = Key(KeyEvent.VK_LEFT_PARENTHESIS, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad ')' key. */
-        actual val NumPadRightParenthesis = Key(KeyEvent.VK_RIGHT_PARENTHESIS, KEY_LOCATION_NUMPAD)
+        actual val NumPadRightParenthesis: Key
+            get() = Key(KeyEvent.VK_RIGHT_PARENTHESIS, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Up Arrow Key. */
-        actual val NumPadDirectionUp = Key(KeyEvent.VK_UP, KEY_LOCATION_NUMPAD)
+        actual val NumPadDirectionUp: Key
+            get() = Key(KeyEvent.VK_UP, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Down Arrow Key. */
-        actual val NumPadDirectionDown = Key(KeyEvent.VK_DOWN, KEY_LOCATION_NUMPAD)
+        actual val NumPadDirectionDown: Key
+            get() = Key(KeyEvent.VK_DOWN, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Left Arrow Key. */
-        actual val NumPadDirectionLeft = Key(KeyEvent.VK_LEFT, KEY_LOCATION_NUMPAD)
+        actual val NumPadDirectionLeft: Key
+            get() = Key(KeyEvent.VK_LEFT, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Right Arrow Key. */
-        actual val NumPadDirectionRight = Key(KeyEvent.VK_RIGHT, KEY_LOCATION_NUMPAD)
+        actual val NumPadDirectionRight: Key
+            get() = Key(KeyEvent.VK_RIGHT, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Home Key. */
-        actual val NumPadMoveHome: Key = Key(KeyEvent.VK_HOME, KEY_LOCATION_NUMPAD)
+        actual val NumPadMoveHome: Key
+            get() = Key(KeyEvent.VK_HOME, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad End Key. */
-        actual val NumPadMoveEnd = Key(KeyEvent.VK_END, KEY_LOCATION_NUMPAD)
+        actual val NumPadMoveEnd: Key
+            get() = Key(KeyEvent.VK_END, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Page Up Key. */
-        actual val NumPadPageUp = Key(KeyEvent.VK_PAGE_UP, KEY_LOCATION_NUMPAD)
+        actual val NumPadPageUp: Key
+            get() = Key(KeyEvent.VK_PAGE_UP, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Page Down Key. */
-        actual val NumPadPageDown = Key(KeyEvent.VK_PAGE_DOWN, KEY_LOCATION_NUMPAD)
+        actual val NumPadPageDown: Key
+            get() = Key(KeyEvent.VK_PAGE_DOWN, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Insert Key. */
-        actual val NumPadInsert = Key(KeyEvent.VK_INSERT, KEY_LOCATION_NUMPAD)
+        actual val NumPadInsert: Key
+            get() = Key(KeyEvent.VK_INSERT, KEY_LOCATION_NUMPAD)
 
         /** Numeric keypad Delete Key. */
-        actual val NumPadDelete: Key = Key(KeyEvent.VK_DELETE, KEY_LOCATION_NUMPAD)
+        actual val NumPadDelete: Key
+            get() = Key(KeyEvent.VK_DELETE, KEY_LOCATION_NUMPAD)
 
         // Unsupported Keys. These keys will never be sent by the desktop. However we need unique
         // keycodes so that these constants can be used in a when statement without a warning.
-        actual val SoftLeft = Key(-1000000001)
-        actual val SoftRight = Key(-1000000002)
-        actual val Back = Key(-1000000003)
-        actual val NavigatePrevious = Key(-1000000004)
-        actual val NavigateNext = Key(-1000000005)
-        actual val NavigateIn = Key(-1000000006)
-        actual val NavigateOut = Key(-1000000007)
-        actual val SystemNavigationUp = Key(-1000000008)
-        actual val SystemNavigationDown = Key(-1000000009)
-        actual val SystemNavigationLeft = Key(-1000000010)
-        actual val SystemNavigationRight = Key(-1000000011)
-        actual val Call = Key(-1000000012)
-        actual val EndCall = Key(-1000000013)
-        actual val DirectionCenter = Key(-1000000014)
-        actual val DirectionUpLeft = Key(-1000000015)
-        actual val DirectionDownLeft = Key(-1000000016)
-        actual val DirectionUpRight = Key(-1000000017)
-        actual val DirectionDownRight = Key(-1000000018)
-        actual val VolumeUp = Key(-1000000019)
-        actual val VolumeDown = Key(-1000000020)
-        actual val Power = Key(-1000000021)
-        actual val Camera = Key(-1000000022)
-        actual val Clear = Key(-1000000023)
-        actual val Symbol = Key(-1000000024)
-        actual val Browser = Key(-1000000025)
-        actual val Envelope = Key(-1000000026)
-        actual val Function = Key(-1000000027)
-        actual val Break = Key(-1000000028)
-        actual val Number = Key(-1000000031)
-        actual val HeadsetHook = Key(-1000000032)
-        actual val Focus = Key(-1000000033)
-        actual val Menu = Key(-1000000034)
-        actual val Notification = Key(-1000000035)
-        actual val Search = Key(-1000000036)
-        actual val PictureSymbols = Key(-1000000037)
-        actual val SwitchCharset = Key(-1000000038)
-        actual val ButtonA = Key(-1000000039)
-        actual val ButtonB = Key(-1000000040)
-        actual val ButtonC = Key(-1000000041)
-        actual val ButtonX = Key(-1000000042)
-        actual val ButtonY = Key(-1000000043)
-        actual val ButtonZ = Key(-1000000044)
-        actual val ButtonL1 = Key(-1000000045)
-        actual val ButtonR1 = Key(-1000000046)
-        actual val ButtonL2 = Key(-1000000047)
-        actual val ButtonR2 = Key(-1000000048)
-        actual val ButtonThumbLeft = Key(-1000000049)
-        actual val ButtonThumbRight = Key(-1000000050)
-        actual val ButtonStart = Key(-1000000051)
-        actual val ButtonSelect = Key(-1000000052)
-        actual val ButtonMode = Key(-1000000053)
-        actual val Button1 = Key(-1000000054)
-        actual val Button2 = Key(-1000000055)
-        actual val Button3 = Key(-1000000056)
-        actual val Button4 = Key(-1000000057)
-        actual val Button5 = Key(-1000000058)
-        actual val Button6 = Key(-1000000059)
-        actual val Button7 = Key(-1000000060)
-        actual val Button8 = Key(-1000000061)
-        actual val Button9 = Key(-1000000062)
-        actual val Button10 = Key(-1000000063)
-        actual val Button11 = Key(-1000000064)
-        actual val Button12 = Key(-1000000065)
-        actual val Button13 = Key(-1000000066)
-        actual val Button14 = Key(-1000000067)
-        actual val Button15 = Key(-1000000068)
-        actual val Button16 = Key(-1000000069)
-        actual val Forward = Key(-1000000070)
-        actual val MediaPlay = Key(-1000000071)
-        actual val MediaPause = Key(-1000000072)
-        actual val MediaPlayPause = Key(-1000000073)
-        actual val MediaStop = Key(-1000000074)
-        actual val MediaRecord = Key(-1000000075)
-        actual val MediaNext = Key(-1000000076)
-        actual val MediaPrevious = Key(-1000000077)
-        actual val MediaRewind = Key(-1000000078)
-        actual val MediaFastForward = Key(-1000000079)
-        actual val MediaClose = Key(-1000000080)
-        actual val MediaAudioTrack = Key(-1000000081)
-        actual val MediaEject = Key(-1000000082)
-        actual val MediaTopMenu = Key(-1000000083)
-        actual val MediaSkipForward = Key(-1000000084)
-        actual val MediaSkipBackward = Key(-1000000085)
-        actual val MediaStepForward = Key(-1000000086)
-        actual val MediaStepBackward = Key(-1000000087)
-        actual val MicrophoneMute = Key(-1000000088)
-        actual val VolumeMute = Key(-1000000089)
-        actual val Info = Key(-1000000090)
-        actual val ChannelUp = Key(-1000000091)
-        actual val ChannelDown = Key(-1000000092)
-        actual val ZoomIn = Key(-1000000093)
-        actual val ZoomOut = Key(-1000000094)
-        actual val Tv = Key(-1000000095)
-        actual val Window = Key(-1000000096)
-        actual val Guide = Key(-1000000097)
-        actual val Dvr = Key(-1000000098)
-        actual val Bookmark = Key(-1000000099)
-        actual val Captions = Key(-1000000100)
-        actual val Settings = Key(-1000000101)
-        actual val TvPower = Key(-1000000102)
-        actual val TvInput = Key(-1000000103)
-        actual val SetTopBoxPower = Key(-1000000104)
-        actual val SetTopBoxInput = Key(-1000000105)
-        actual val AvReceiverPower = Key(-1000000106)
-        actual val AvReceiverInput = Key(-1000000107)
-        actual val ProgramRed = Key(-1000000108)
-        actual val ProgramGreen = Key(-1000000109)
-        actual val ProgramYellow = Key(-1000000110)
-        actual val ProgramBlue = Key(-1000000111)
-        actual val AppSwitch = Key(-1000000112)
-        actual val LanguageSwitch = Key(-1000000113)
-        actual val MannerMode = Key(-1000000114)
-        actual val Toggle2D3D = Key(-1000000125)
-        actual val Contacts = Key(-1000000126)
-        actual val Calendar = Key(-1000000127)
-        actual val Music = Key(-1000000128)
-        actual val Calculator = Key(-1000000129)
-        actual val ZenkakuHankaru = Key(-1000000130)
-        actual val Eisu = Key(-1000000131)
-        actual val Muhenkan = Key(-1000000132)
-        actual val Henkan = Key(-1000000133)
-        actual val KatakanaHiragana = Key(-1000000134)
-        actual val Yen = Key(-1000000135)
-        actual val Ro = Key(-1000000136)
-        actual val Kana = Key(-1000000137)
-        actual val Assist = Key(-1000000138)
-        actual val BrightnessDown = Key(-1000000139)
-        actual val BrightnessUp = Key(-1000000140)
-        actual val Sleep = Key(-1000000141)
-        actual val WakeUp = Key(-1000000142)
-        actual val SoftSleep = Key(-1000000143)
-        actual val Pairing = Key(-1000000144)
-        actual val LastChannel = Key(-1000000145)
-        actual val TvDataService = Key(-1000000146)
-        actual val VoiceAssist = Key(-1000000147)
-        actual val TvRadioService = Key(-1000000148)
-        actual val TvTeletext = Key(-1000000149)
-        actual val TvNumberEntry = Key(-1000000150)
-        actual val TvTerrestrialAnalog = Key(-1000000151)
-        actual val TvTerrestrialDigital = Key(-1000000152)
-        actual val TvSatellite = Key(-1000000153)
-        actual val TvSatelliteBs = Key(-1000000154)
-        actual val TvSatelliteCs = Key(-1000000155)
-        actual val TvSatelliteService = Key(-1000000156)
-        actual val TvNetwork = Key(-1000000157)
-        actual val TvAntennaCable = Key(-1000000158)
-        actual val TvInputHdmi1 = Key(-1000000159)
-        actual val TvInputHdmi2 = Key(-1000000160)
-        actual val TvInputHdmi3 = Key(-1000000161)
-        actual val TvInputHdmi4 = Key(-1000000162)
-        actual val TvInputComposite1 = Key(-1000000163)
-        actual val TvInputComposite2 = Key(-1000000164)
-        actual val TvInputComponent1 = Key(-1000000165)
-        actual val TvInputComponent2 = Key(-1000000166)
-        actual val TvInputVga1 = Key(-1000000167)
-        actual val TvAudioDescription = Key(-1000000168)
-        actual val TvAudioDescriptionMixingVolumeUp = Key(-1000000169)
-        actual val TvAudioDescriptionMixingVolumeDown = Key(-1000000170)
-        actual val TvZoomMode = Key(-1000000171)
-        actual val TvContentsMenu = Key(-1000000172)
-        actual val TvMediaContextMenu = Key(-1000000173)
-        actual val TvTimerProgramming = Key(-1000000174)
-        actual val StemPrimary = Key(-1000000175)
-        actual val Stem1 = Key(-1000000176)
-        actual val Stem2 = Key(-1000000177)
-        actual val Stem3 = Key(-1000000178)
-        actual val AllApps = Key(-1000000179)
-        actual val Refresh = Key(-1000000180)
-        actual val ThumbsUp = Key(-1000000181)
-        actual val ThumbsDown = Key(-1000000182)
-        actual val ProfileSwitch = Key(-1000000183)
+        actual val SoftLeft: Key
+            get() = Key(-1000000001)
+        actual val SoftRight: Key
+            get() = Key(-1000000002)
+        actual val Back: Key
+            get() = Key(-1000000003)
+        actual val NavigatePrevious: Key
+            get() = Key(-1000000004)
+        actual val NavigateNext: Key
+            get() = Key(-1000000005)
+        actual val NavigateIn: Key
+            get() = Key(-1000000006)
+        actual val NavigateOut: Key
+            get() = Key(-1000000007)
+        actual val SystemNavigationUp: Key
+            get() = Key(-1000000008)
+        actual val SystemNavigationDown: Key
+            get() = Key(-1000000009)
+        actual val SystemNavigationLeft: Key
+            get() = Key(-1000000010)
+        actual val SystemNavigationRight: Key
+            get() = Key(-1000000011)
+        actual val Call: Key
+            get() = Key(-1000000012)
+        actual val EndCall: Key
+            get() = Key(-1000000013)
+        actual val DirectionCenter: Key
+            get() = Key(-1000000014)
+        actual val DirectionUpLeft: Key
+            get() = Key(-1000000015)
+        actual val DirectionDownLeft: Key
+            get() = Key(-1000000016)
+        actual val DirectionUpRight: Key
+            get() = Key(-1000000017)
+        actual val DirectionDownRight: Key
+            get() = Key(-1000000018)
+        actual val VolumeUp: Key
+            get() = Key(-1000000019)
+        actual val VolumeDown: Key
+            get() = Key(-1000000020)
+        actual val Power: Key
+            get() = Key(-1000000021)
+        actual val Camera: Key
+            get() = Key(-1000000022)
+        actual val Clear: Key
+            get() = Key(-1000000023)
+        actual val Symbol: Key
+            get() = Key(-1000000024)
+        actual val Browser: Key
+            get() = Key(-1000000025)
+        actual val Envelope: Key
+            get() = Key(-1000000026)
+        actual val Function: Key
+            get() = Key(-1000000027)
+        actual val Break: Key
+            get() = Key(-1000000028)
+        actual val Number: Key
+            get() = Key(-1000000031)
+        actual val HeadsetHook: Key
+            get() = Key(-1000000032)
+        actual val Focus: Key
+            get() = Key(-1000000033)
+        actual val Menu: Key
+            get() = Key(-1000000034)
+        actual val Notification: Key
+            get() = Key(-1000000035)
+        actual val Search: Key
+            get() = Key(-1000000036)
+        actual val PictureSymbols: Key
+            get() = Key(-1000000037)
+        actual val SwitchCharset: Key
+            get() = Key(-1000000038)
+        actual val ButtonA: Key
+            get() = Key(-1000000039)
+        actual val ButtonB: Key
+            get() = Key(-1000000040)
+        actual val ButtonC: Key
+            get() = Key(-1000000041)
+        actual val ButtonX: Key
+            get() = Key(-1000000042)
+        actual val ButtonY: Key
+            get() = Key(-1000000043)
+        actual val ButtonZ: Key
+            get() = Key(-1000000044)
+        actual val ButtonL1: Key
+            get() = Key(-1000000045)
+        actual val ButtonR1: Key
+            get() = Key(-1000000046)
+        actual val ButtonL2: Key
+            get() = Key(-1000000047)
+        actual val ButtonR2: Key
+            get() = Key(-1000000048)
+        actual val ButtonThumbLeft: Key
+            get() = Key(-1000000049)
+        actual val ButtonThumbRight: Key
+            get() = Key(-1000000050)
+        actual val ButtonStart: Key
+            get() = Key(-1000000051)
+        actual val ButtonSelect: Key
+            get() = Key(-1000000052)
+        actual val ButtonMode: Key
+            get() = Key(-1000000053)
+        actual val Button1: Key
+            get() = Key(-1000000054)
+        actual val Button2: Key
+            get() = Key(-1000000055)
+        actual val Button3: Key
+            get() = Key(-1000000056)
+        actual val Button4: Key
+            get() = Key(-1000000057)
+        actual val Button5: Key
+            get() = Key(-1000000058)
+        actual val Button6: Key
+            get() = Key(-1000000059)
+        actual val Button7: Key
+            get() = Key(-1000000060)
+        actual val Button8: Key
+            get() = Key(-1000000061)
+        actual val Button9: Key
+            get() = Key(-1000000062)
+        actual val Button10: Key
+            get() = Key(-1000000063)
+        actual val Button11: Key
+            get() = Key(-1000000064)
+        actual val Button12: Key
+            get() = Key(-1000000065)
+        actual val Button13: Key
+            get() = Key(-1000000066)
+        actual val Button14: Key
+            get() = Key(-1000000067)
+        actual val Button15: Key
+            get() = Key(-1000000068)
+        actual val Button16: Key
+            get() = Key(-1000000069)
+        actual val Forward: Key
+            get() = Key(-1000000070)
+        actual val MediaPlay: Key
+            get() = Key(-1000000071)
+        actual val MediaPause: Key
+            get() = Key(-1000000072)
+        actual val MediaPlayPause: Key
+            get() = Key(-1000000073)
+        actual val MediaStop: Key
+            get() = Key(-1000000074)
+        actual val MediaRecord: Key
+            get() = Key(-1000000075)
+        actual val MediaNext: Key
+            get() = Key(-1000000076)
+        actual val MediaPrevious: Key
+            get() = Key(-1000000077)
+        actual val MediaRewind: Key
+            get() = Key(-1000000078)
+        actual val MediaFastForward: Key
+            get() = Key(-1000000079)
+        actual val MediaClose: Key
+            get() = Key(-1000000080)
+        actual val MediaAudioTrack: Key
+            get() = Key(-1000000081)
+        actual val MediaEject: Key
+            get() = Key(-1000000082)
+        actual val MediaTopMenu: Key
+            get() = Key(-1000000083)
+        actual val MediaSkipForward: Key
+            get() = Key(-1000000084)
+        actual val MediaSkipBackward: Key
+            get() = Key(-1000000085)
+        actual val MediaStepForward: Key
+            get() = Key(-1000000086)
+        actual val MediaStepBackward: Key
+            get() = Key(-1000000087)
+        actual val MicrophoneMute: Key
+            get() = Key(-1000000088)
+        actual val VolumeMute: Key
+            get() = Key(-1000000089)
+        actual val Info: Key
+            get() = Key(-1000000090)
+        actual val ChannelUp: Key
+            get() = Key(-1000000091)
+        actual val ChannelDown: Key
+            get() = Key(-1000000092)
+        actual val ZoomIn: Key
+            get() = Key(-1000000093)
+        actual val ZoomOut: Key
+            get() = Key(-1000000094)
+        actual val Tv: Key
+            get() = Key(-1000000095)
+        actual val Window: Key
+            get() = Key(-1000000096)
+        actual val Guide: Key
+            get() = Key(-1000000097)
+        actual val Dvr: Key
+            get() = Key(-1000000098)
+        actual val Bookmark: Key
+            get() = Key(-1000000099)
+        actual val Captions: Key
+            get() = Key(-1000000100)
+        actual val Settings: Key
+            get() = Key(-1000000101)
+        actual val TvPower: Key
+            get() = Key(-1000000102)
+        actual val TvInput: Key
+            get() = Key(-1000000103)
+        actual val SetTopBoxPower: Key
+            get() = Key(-1000000104)
+        actual val SetTopBoxInput: Key
+            get() = Key(-1000000105)
+        actual val AvReceiverPower: Key
+            get() = Key(-1000000106)
+        actual val AvReceiverInput: Key
+            get() = Key(-1000000107)
+        actual val ProgramRed: Key
+            get() = Key(-1000000108)
+        actual val ProgramGreen: Key
+            get() = Key(-1000000109)
+        actual val ProgramYellow: Key
+            get() = Key(-1000000110)
+        actual val ProgramBlue: Key
+            get() = Key(-1000000111)
+        actual val AppSwitch: Key
+            get() = Key(-1000000112)
+        actual val LanguageSwitch: Key
+            get() = Key(-1000000113)
+        actual val MannerMode: Key
+            get() = Key(-1000000114)
+        actual val Toggle2D3D: Key
+            get() = Key(-1000000125)
+        actual val Contacts: Key
+            get() = Key(-1000000126)
+        actual val Calendar: Key
+            get() = Key(-1000000127)
+        actual val Music: Key
+            get() = Key(-1000000128)
+        actual val Calculator: Key
+            get() = Key(-1000000129)
+        actual val ZenkakuHankaru: Key
+            get() = Key(-1000000130)
+        actual val Eisu: Key
+            get() = Key(-1000000131)
+        actual val Muhenkan: Key
+            get() = Key(-1000000132)
+        actual val Henkan: Key
+            get() = Key(-1000000133)
+        actual val KatakanaHiragana: Key
+            get() = Key(-1000000134)
+        actual val Yen: Key
+            get() = Key(-1000000135)
+        actual val Ro: Key
+            get() = Key(-1000000136)
+        actual val Kana: Key
+            get() = Key(-1000000137)
+        actual val Assist: Key
+            get() = Key(-1000000138)
+        actual val BrightnessDown: Key
+            get() = Key(-1000000139)
+        actual val BrightnessUp: Key
+            get() = Key(-1000000140)
+        actual val Sleep: Key
+            get() = Key(-1000000141)
+        actual val WakeUp: Key
+            get() = Key(-1000000142)
+        actual val SoftSleep: Key
+            get() = Key(-1000000143)
+        actual val Pairing: Key
+            get() = Key(-1000000144)
+        actual val LastChannel: Key
+            get() = Key(-1000000145)
+        actual val TvDataService: Key
+            get() = Key(-1000000146)
+        actual val VoiceAssist: Key
+            get() = Key(-1000000147)
+        actual val TvRadioService: Key
+            get() = Key(-1000000148)
+        actual val TvTeletext: Key
+            get() = Key(-1000000149)
+        actual val TvNumberEntry: Key
+            get() = Key(-1000000150)
+        actual val TvTerrestrialAnalog: Key
+            get() = Key(-1000000151)
+        actual val TvTerrestrialDigital: Key
+            get() = Key(-1000000152)
+        actual val TvSatellite: Key
+            get() = Key(-1000000153)
+        actual val TvSatelliteBs: Key
+            get() = Key(-1000000154)
+        actual val TvSatelliteCs: Key
+            get() = Key(-1000000155)
+        actual val TvSatelliteService: Key
+            get() = Key(-1000000156)
+        actual val TvNetwork: Key
+            get() = Key(-1000000157)
+        actual val TvAntennaCable: Key
+            get() = Key(-1000000158)
+        actual val TvInputHdmi1: Key
+            get() = Key(-1000000159)
+        actual val TvInputHdmi2: Key
+            get() = Key(-1000000160)
+        actual val TvInputHdmi3: Key
+            get() = Key(-1000000161)
+        actual val TvInputHdmi4: Key
+            get() = Key(-1000000162)
+        actual val TvInputComposite1: Key
+            get() = Key(-1000000163)
+        actual val TvInputComposite2: Key
+            get() = Key(-1000000164)
+        actual val TvInputComponent1: Key
+            get() = Key(-1000000165)
+        actual val TvInputComponent2: Key
+            get() = Key(-1000000166)
+        actual val TvInputVga1: Key
+            get() = Key(-1000000167)
+        actual val TvAudioDescription: Key
+            get() = Key(-1000000168)
+        actual val TvAudioDescriptionMixingVolumeUp: Key
+            get() = Key(-1000000169)
+        actual val TvAudioDescriptionMixingVolumeDown: Key
+            get() = Key(-1000000170)
+        actual val TvZoomMode: Key
+            get() = Key(-1000000171)
+        actual val TvContentsMenu: Key
+            get() = Key(-1000000172)
+        actual val TvMediaContextMenu: Key
+            get() = Key(-1000000173)
+        actual val TvTimerProgramming: Key
+            get() = Key(-1000000174)
+        actual val StemPrimary: Key
+            get() = Key(-1000000175)
+        actual val Stem1: Key
+            get() = Key(-1000000176)
+        actual val Stem2: Key
+            get() = Key(-1000000177)
+        actual val Stem3: Key
+            get() = Key(-1000000178)
+        actual val AllApps: Key
+            get() = Key(-1000000179)
+        actual val Refresh: Key
+            get() = Key(-1000000180)
+        actual val ThumbsUp: Key
+            get() = Key(-1000000181)
+        actual val ThumbsDown: Key
+            get() = Key(-1000000182)
+        actual val ProfileSwitch: Key
+            get() = Key(-1000000183)
 }
 
     actual override fun toString(): String {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Strings.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Strings.kt
@@ -24,10 +24,14 @@ import androidx.compose.ui.platform.l10n.translationFor
 @JvmInline
 internal value class Strings private constructor(@Suppress("unused") private val value: Int) {
     companion object {
-        val Copy = Strings(0)
-        val Cut = Strings(1)
-        val Paste = Strings(2)
-        val SelectAll = Strings(3)
+        inline val Copy: Strings
+            get() = Strings(0)
+        inline val Cut: Strings
+            get() = Strings(1)
+        inline val Paste: Strings
+            get() = Strings(2)
+        inline val SelectAll: Strings
+            get() = Strings(3)
         // When adding values here, make sure to also add them in ui/build.gradle,
         // updateTranslationsDesktop task (stringByResourceName parameter), and re-run the task
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
@@ -28,7 +28,8 @@ import platform.UIKit.*
 actual value class Key(val keyCode: Long) {
     actual companion object {
         /** Unknown key. */
-        actual val Unknown = Key(-1)
+        actual val Unknown: Key
+            get() = Key(-1)
 
         /**
          * System Home key.
@@ -42,543 +43,1033 @@ actual value class Key(val keyCode: Long) {
                 "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
             level = DeprecationLevel.ERROR,
         )
-        actual val Home = Key(UIKeyboardHIDUsageKeyboardHome)
+        actual val Home: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardHome)
 
         /**
          * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
-        actual val SystemHome: Key = Key(-1000000207)
+        actual val SystemHome: Key
+            get() = Key(-1000000207)
 
         /**
          * Up Arrow Key / Directional Pad Up key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionUp = Key(UIKeyboardHIDUsageKeyboardUpArrow)
+        actual val DirectionUp: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardUpArrow)
 
         /**
          * Down Arrow Key / Directional Pad Down key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionDown = Key(UIKeyboardHIDUsageKeyboardDownArrow)
+        actual val DirectionDown: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardDownArrow)
 
         /**
          * Left Arrow Key / Directional Pad Left key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionLeft = Key(UIKeyboardHIDUsageKeyboardLeftArrow)
+        actual val DirectionLeft: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardLeftArrow)
 
         /**
          * Right Arrow Key / Directional Pad Right key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionRight = Key(UIKeyboardHIDUsageKeyboardRightArrow)
+        actual val DirectionRight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardRightArrow)
 
         /** '0' key. */
-        actual val Zero = Key(UIKeyboardHIDUsageKeyboard0)
+        actual val Zero: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard0)
 
         /** '1' key. */
-        actual val One = Key(UIKeyboardHIDUsageKeyboard1)
+        actual val One: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard1)
 
         /** '2' key. */
-        actual val Two = Key(UIKeyboardHIDUsageKeyboard2)
+        actual val Two: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard2)
 
         /** '3' key. */
-        actual val Three = Key(UIKeyboardHIDUsageKeyboard3)
+        actual val Three: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard3)
 
         /** '4' key. */
-        actual val Four = Key(UIKeyboardHIDUsageKeyboard4)
+        actual val Four: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard4)
 
         /** '5' key. */
-        actual val Five = Key(UIKeyboardHIDUsageKeyboard5)
+        actual val Five: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard5)
 
         /** '6' key. */
-        actual val Six = Key(UIKeyboardHIDUsageKeyboard6)
+        actual val Six: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard6)
 
         /** '7' key. */
-        actual val Seven = Key(UIKeyboardHIDUsageKeyboard7)
+        actual val Seven: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard7)
 
         /** '8' key. */
-        actual val Eight = Key(UIKeyboardHIDUsageKeyboard8)
+        actual val Eight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard8)
 
         /** '9' key. */
-        actual val Nine = Key(UIKeyboardHIDUsageKeyboard9)
+        actual val Nine: Key
+            get() = Key(UIKeyboardHIDUsageKeyboard9)
 
         /** '-' key. */
-        actual val Minus = Key(UIKeyboardHIDUsageKeyboardHyphen)
+        actual val Minus: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardHyphen)
 
         /** '=' key. */
-        actual val Equals = Key(UIKeyboardHIDUsageKeyboardEqualSign)
+        actual val Equals: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardEqualSign)
 
         /** 'A' key. */
-        actual val A = Key(UIKeyboardHIDUsageKeyboardA)
+        actual val A: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardA)
 
         /** 'B' key. */
-        actual val B = Key(UIKeyboardHIDUsageKeyboardB)
+        actual val B: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardB)
 
         /** 'C' key. */
-        actual val C = Key(UIKeyboardHIDUsageKeyboardC)
+        actual val C: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardC)
 
         /** 'D' key. */
-        actual val D = Key(UIKeyboardHIDUsageKeyboardD)
+        actual val D: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardD)
 
         /** 'E' key. */
-        actual val E = Key(UIKeyboardHIDUsageKeyboardE)
+        actual val E: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardE)
 
         /** 'F' key. */
-        actual val F = Key(UIKeyboardHIDUsageKeyboardF)
+        actual val F: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF)
 
         /** 'G' key. */
-        actual val G = Key(UIKeyboardHIDUsageKeyboardG)
+        actual val G: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardG)
 
         /** 'H' key. */
-        actual val H = Key(UIKeyboardHIDUsageKeyboardH)
+        actual val H: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardH)
 
         /** 'I' key. */
-        actual val I = Key(UIKeyboardHIDUsageKeyboardI)
+        actual val I: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardI)
 
         /** 'J' key. */
-        actual val J = Key(UIKeyboardHIDUsageKeyboardJ)
+        actual val J: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardJ)
 
         /** 'K' key. */
-        actual val K = Key(UIKeyboardHIDUsageKeyboardK)
+        actual val K: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardK)
 
         /** 'L' key. */
-        actual val L = Key(UIKeyboardHIDUsageKeyboardL)
+        actual val L: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardL)
 
         /** 'M' key. */
-        actual val M = Key(UIKeyboardHIDUsageKeyboardM)
+        actual val M: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardM)
 
         /** 'N' key. */
-        actual val N = Key(UIKeyboardHIDUsageKeyboardN)
+        actual val N: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardN)
 
         /** 'O' key. */
-        actual val O = Key(UIKeyboardHIDUsageKeyboardO)
+        actual val O: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardO)
 
         /** 'P' key. */
-        actual val P = Key(UIKeyboardHIDUsageKeyboardP)
+        actual val P: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardP)
 
         /** 'Q' key. */
-        actual val Q = Key(UIKeyboardHIDUsageKeyboardQ)
+        actual val Q: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardQ)
 
         /** 'R' key. */
-        actual val R = Key(UIKeyboardHIDUsageKeyboardR)
+        actual val R: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardR)
 
         /** 'S' key. */
-        actual val S = Key(UIKeyboardHIDUsageKeyboardS)
+        actual val S: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardS)
 
         /** 'T' key. */
-        actual val T = Key(UIKeyboardHIDUsageKeyboardT)
+        actual val T: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardT)
 
         /** 'U' key. */
-        actual val U = Key(UIKeyboardHIDUsageKeyboardU)
+        actual val U: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardU)
 
         /** 'V' key. */
-        actual val V = Key(UIKeyboardHIDUsageKeyboardV)
+        actual val V: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardV)
 
         /** 'W' key. */
-        actual val W = Key(UIKeyboardHIDUsageKeyboardW)
+        actual val W: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardW)
 
         /** 'X' key. */
-        actual val X = Key(UIKeyboardHIDUsageKeyboardX)
+        actual val X: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardX)
 
         /** 'Y' key. */
-        actual val Y = Key(UIKeyboardHIDUsageKeyboardY)
+        actual val Y: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardY)
 
         /** 'Z' key. */
-        actual val Z = Key(UIKeyboardHIDUsageKeyboardZ)
+        actual val Z: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardZ)
 
         /** ',' key. */
-        actual val Comma = Key(UIKeyboardHIDUsageKeyboardComma)
+        actual val Comma: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardComma)
 
         /** '.' key. */
-        actual val Period = Key(UIKeyboardHIDUsageKeyboardPeriod)
+        actual val Period: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardPeriod)
 
         /** Left Alt modifier key. */
-        actual val AltLeft = Key(UIKeyboardHIDUsageKeyboardLeftAlt)
+        actual val AltLeft: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardLeftAlt)
 
         /** Right Alt modifier key. */
-        actual val AltRight = Key(UIKeyboardHIDUsageKeyboardRightAlt)
+        actual val AltRight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardRightAlt)
 
         /** Left Shift modifier key. */
-        actual val ShiftLeft = Key(UIKeyboardHIDUsageKeyboardLeftShift)
+        actual val ShiftLeft: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardLeftShift)
 
         /** Right Shift modifier key. */
-        actual val ShiftRight = Key(UIKeyboardHIDUsageKeyboardRightShift)
+        actual val ShiftRight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardRightShift)
 
         /** Tab key. */
-        actual val Tab = Key(UIKeyboardHIDUsageKeyboardTab)
+        actual val Tab: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardTab)
 
         /** Space key. */
-        actual val Spacebar = Key(UIKeyboardHIDUsageKeyboardSpacebar)
+        actual val Spacebar: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardSpacebar)
 
         /** Enter key. */
-        actual val Enter = Key(UIKeyboardHIDUsageKeyboardReturnOrEnter)
+        actual val Enter: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardReturnOrEnter)
 
         /**
          * Backspace key.
          *
          * Deletes characters before the insertion point, unlike [Delete].
          */
-        actual val Backspace: Key =
-            Key(UIKeyboardHIDUsageKeyboardDeleteOrBackspace) // Key(KeyEvent.VK_BACK_SPACE)
+        actual val Backspace: Key  // Key(KeyEvent.VK_BACK_SPACE)
+            get() = Key(UIKeyboardHIDUsageKeyboardDeleteOrBackspace)
 
         /**
          * Delete key.
          *
          * Deletes characters ahead of the insertion point, unlike [Backspace].
          */
-        actual val Delete = Key(UIKeyboardHIDUsageKeyboardDeleteForward)
+        actual val Delete: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardDeleteForward)
 
         /** Escape key. */
-        actual val Escape = Key(UIKeyboardHIDUsageKeyboardEscape)
+        actual val Escape: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardEscape)
 
         /** Left Control modifier key. */
-        actual val CtrlLeft = Key(UIKeyboardHIDUsageKeyboardLeftControl)
+        actual val CtrlLeft: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardLeftControl)
 
         /** Right Control modifier key. */
-        actual val CtrlRight = Key(UIKeyboardHIDUsageKeyboardRightControl)
+        actual val CtrlRight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardRightControl)
 
         /** Caps Lock key. */
-        actual val CapsLock = Key(UIKeyboardHIDUsageKeyboardCapsLock)
+        actual val CapsLock: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardCapsLock)
 
         /** Scroll Lock key. */
-        actual val ScrollLock = Key(UIKeyboardHIDUsageKeyboardScrollLock)
+        actual val ScrollLock: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardScrollLock)
 
         /** Left Meta modifier key. */
-        actual val MetaLeft = Key(UIKeyboardHIDUsageKeyboardLeftGUI)
+        actual val MetaLeft: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardLeftGUI)
 
         /** Right Meta modifier key. */
-        actual val MetaRight = Key(UIKeyboardHIDUsageKeyboardRightGUI)
+        actual val MetaRight: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardRightGUI)
 
         /** System Request / Print Screen key. */
-        actual val PrintScreen = Key(104)
+        actual val PrintScreen: Key
+            get() = Key(104)
 
         /**
          * Insert key.
          *
          * Toggles insert / overwrite edit mode.
          */
-        actual val Insert = Key(117)
+        actual val Insert: Key
+            get() = Key(117)
 
         /** '`' (backtick) key. */
-        actual val Grave = Key(UIKeyboardHIDUsageKeyboardGraveAccentAndTilde)
+        actual val Grave: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardGraveAccentAndTilde)
 
         /** '[' key. */
-        actual val LeftBracket = Key(UIKeyboardHIDUsageKeyboardOpenBracket)
+        actual val LeftBracket: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardOpenBracket)
 
         /** ']' key. */
-        actual val RightBracket = Key(UIKeyboardHIDUsageKeyboardCloseBracket)
+        actual val RightBracket: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardCloseBracket)
 
         /** '/' key. */
-        actual val Slash = Key(UIKeyboardHIDUsageKeyboardSlash)
+        actual val Slash: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardSlash)
 
         /** '\' key. */
-        actual val Backslash = Key(UIKeyboardHIDUsageKeyboardBackslash)
+        actual val Backslash: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardBackslash)
 
         /** ';' key. */
-        actual val Semicolon = Key(UIKeyboardHIDUsageKeyboardSemicolon)
+        actual val Semicolon: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardSemicolon)
 
         /** Page Up key. */
-        actual val PageUp = Key(UIKeyboardHIDUsageKeyboardPageUp)
+        actual val PageUp: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardPageUp)
 
         /** Page Down key. */
-        actual val PageDown = Key(UIKeyboardHIDUsageKeyboardPageDown)
+        actual val PageDown: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardPageDown)
 
         /** F1 key. */
-        actual val F1 = Key(UIKeyboardHIDUsageKeyboardF1)
+        actual val F1: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF1)
 
         /** F2 key. */
-        actual val F2 = Key(UIKeyboardHIDUsageKeyboardF2)
+        actual val F2: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF2)
 
         /** F3 key. */
-        actual val F3 = Key(UIKeyboardHIDUsageKeyboardF3)
+        actual val F3: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF3)
 
         /** F4 key. */
-        actual val F4 = Key(UIKeyboardHIDUsageKeyboardF4)
+        actual val F4: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF4)
 
         /** F5 key. */
-        actual val F5 = Key(UIKeyboardHIDUsageKeyboardF5)
+        actual val F5: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF5)
 
         /** F6 key. */
-        actual val F6 = Key(UIKeyboardHIDUsageKeyboardF6)
+        actual val F6: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF6)
 
         /** F7 key. */
-        actual val F7 = Key(UIKeyboardHIDUsageKeyboardF7)
+        actual val F7: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF7)
 
         /** F8 key. */
-        actual val F8 = Key(UIKeyboardHIDUsageKeyboardF8)
+        actual val F8: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF8)
 
         /** F9 key. */
-        actual val F9 = Key(UIKeyboardHIDUsageKeyboardF9)
+        actual val F9: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF9)
 
         /** F10 key. */
-        actual val F10 = Key(UIKeyboardHIDUsageKeyboardF10)
+        actual val F10: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF10)
 
         /** F11 key. */
-        actual val F11 = Key(UIKeyboardHIDUsageKeyboardF11)
+        actual val F11: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF11)
 
         /** F12 key. */
-        actual val F12 = Key(UIKeyboardHIDUsageKeyboardF12)
+        actual val F12: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardF12)
 
         /**
          * Num Lock key.
          *
-         * This is the Num Lock key; it is different from [Number].
-         * This key alters the behavior of other keys on the numeric keypad.
+         * This is the Num Lock key; it is different from [Number]. This key alters the behavior of
+         * other keys on the numeric keypad.
          */
-        actual val NumLock = Key(UIKeyboardHIDUsageKeypadNumLock)
+        actual val NumLock: Key
+            get() = Key(UIKeyboardHIDUsageKeypadNumLock)
 
         /** Numeric keypad '0' key. */
-        actual val NumPad0 = Key(UIKeyboardHIDUsageKeypad0)
+        actual val NumPad0: Key
+            get() = Key(UIKeyboardHIDUsageKeypad0)
 
         /** Numeric keypad '1' key. */
-        actual val NumPad1 = Key(UIKeyboardHIDUsageKeypad1)
+        actual val NumPad1: Key
+            get() = Key(UIKeyboardHIDUsageKeypad1)
 
         /** Numeric keypad '2' key. */
-        actual val NumPad2 = Key(UIKeyboardHIDUsageKeypad2)
+        actual val NumPad2: Key
+            get() = Key(UIKeyboardHIDUsageKeypad2)
 
         /** Numeric keypad '3' key. */
-        actual val NumPad3 = Key(UIKeyboardHIDUsageKeypad3)
+        actual val NumPad3: Key
+            get() = Key(UIKeyboardHIDUsageKeypad3)
 
         /** Numeric keypad '4' key. */
-        actual val NumPad4 = Key(UIKeyboardHIDUsageKeypad4)
+        actual val NumPad4: Key
+            get() = Key(UIKeyboardHIDUsageKeypad4)
 
         /** Numeric keypad '5' key. */
-        actual val NumPad5 = Key(UIKeyboardHIDUsageKeypad5)
+        actual val NumPad5: Key
+            get() = Key(UIKeyboardHIDUsageKeypad5)
 
         /** Numeric keypad '6' key. */
-        actual val NumPad6 = Key(UIKeyboardHIDUsageKeypad6)
+        actual val NumPad6: Key
+            get() = Key(UIKeyboardHIDUsageKeypad6)
 
         /** Numeric keypad '7' key. */
-        actual val NumPad7 = Key(UIKeyboardHIDUsageKeypad7)
+        actual val NumPad7: Key
+            get() = Key(UIKeyboardHIDUsageKeypad7)
 
         /** Numeric keypad '8' key. */
-        actual val NumPad8 = Key(UIKeyboardHIDUsageKeypad8)
+        actual val NumPad8: Key
+            get() = Key(UIKeyboardHIDUsageKeypad8)
 
         /** Numeric keypad '9' key. */
-        actual val NumPad9 = Key(UIKeyboardHIDUsageKeypad9)
+        actual val NumPad9: Key
+            get() = Key(UIKeyboardHIDUsageKeypad9)
 
         /** Numeric keypad '/' key (for division). */
-        actual val NumPadDivide = Key(UIKeyboardHIDUsageKeypadSlash)
+        actual val NumPadDivide: Key
+            get() = Key(UIKeyboardHIDUsageKeypadSlash)
 
         /** Numeric keypad '*' key (for multiplication). */
-        actual val NumPadMultiply = Key(UIKeyboardHIDUsageKeypadAsterisk)
+        actual val NumPadMultiply: Key
+            get() = Key(UIKeyboardHIDUsageKeypadAsterisk)
 
         /** Numeric keypad '-' key (for subtraction). */
-        actual val NumPadSubtract = Key(UIKeyboardHIDUsageKeypadHyphen)
+        actual val NumPadSubtract: Key
+            get() = Key(UIKeyboardHIDUsageKeypadHyphen)
 
         /** Numeric keypad '+' key (for addition). */
-        actual val NumPadAdd = Key(UIKeyboardHIDUsageKeypadPlus)
+        actual val NumPadAdd: Key
+            get() = Key(UIKeyboardHIDUsageKeypadPlus)
 
         /** Numeric keypad Enter key. */
-        actual val NumPadEnter = Key(UIKeyboardHIDUsageKeypadEnter)
+        actual val NumPadEnter: Key
+            get() = Key(UIKeyboardHIDUsageKeypadEnter)
 
-        actual val MoveHome = Key(UIKeyboardHIDUsageKeyboardHome)
+        actual val MoveHome: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardHome)
 
-        actual val MoveEnd = Key(UIKeyboardHIDUsageKeyboardEnd)
+        actual val MoveEnd: Key
+            get() = Key(UIKeyboardHIDUsageKeyboardEnd)
 
         // Unsupported Keys
-        actual val SoftLeft = Key(-1000000001)
-        actual val SoftRight = Key(-1000000002)
-        actual val Back = Key(-1000000003)
-        actual val NavigatePrevious = Key(-1000000004)
-        actual val NavigateNext = Key(-1000000005)
-        actual val NavigateIn = Key(-1000000006)
-        actual val NavigateOut = Key(-1000000007)
-        actual val SystemNavigationUp = Key(-1000000008)
-        actual val SystemNavigationDown = Key(-1000000009)
-        actual val SystemNavigationLeft = Key(-1000000010)
-        actual val SystemNavigationRight = Key(-1000000011)
-        actual val Call = Key(-1000000012)
-        actual val EndCall = Key(-1000000013)
-        actual val DirectionCenter = Key(-1000000014)
-        actual val DirectionUpLeft = Key(-1000000015)
-        actual val DirectionDownLeft = Key(-1000000016)
-        actual val DirectionUpRight = Key(-1000000017)
-        actual val DirectionDownRight = Key(-1000000018)
-        actual val VolumeUp = Key(-1000000019)
-        actual val VolumeDown = Key(-1000000020)
-        actual val Power = Key(-1000000021)
-        actual val Camera = Key(-1000000022)
-        actual val Clear = Key(-1000000023)
-        actual val Symbol = Key(-1000000024)
-        actual val Browser = Key(-1000000025)
-        actual val Envelope = Key(-1000000026)
-        actual val Function = Key(-1000000027)
-        actual val Break = Key(-1000000028)
-        actual val Number = Key(-1000000031)
-        actual val HeadsetHook = Key(-1000000032)
-        actual val Focus = Key(-1000000033)
-        actual val Menu = Key(-1000000034)
-        actual val Notification = Key(-1000000035)
-        actual val Search = Key(-1000000036)
-        actual val PictureSymbols = Key(-1000000037)
-        actual val SwitchCharset = Key(-1000000038)
-        actual val ButtonA = Key(-1000000039)
-        actual val ButtonB = Key(-1000000040)
-        actual val ButtonC = Key(-1000000041)
-        actual val ButtonX = Key(-1000000042)
-        actual val ButtonY = Key(-1000000043)
-        actual val ButtonZ = Key(-1000000044)
-        actual val ButtonL1 = Key(-1000000045)
-        actual val ButtonR1 = Key(-1000000046)
-        actual val ButtonL2 = Key(-1000000047)
-        actual val ButtonR2 = Key(-1000000048)
-        actual val ButtonThumbLeft = Key(-1000000049)
-        actual val ButtonThumbRight = Key(-1000000050)
-        actual val ButtonStart = Key(-1000000051)
-        actual val ButtonSelect = Key(-1000000052)
-        actual val ButtonMode = Key(-1000000053)
-        actual val Button1 = Key(-1000000054)
-        actual val Button2 = Key(-1000000055)
-        actual val Button3 = Key(-1000000056)
-        actual val Button4 = Key(-1000000057)
-        actual val Button5 = Key(-1000000058)
-        actual val Button6 = Key(-1000000059)
-        actual val Button7 = Key(-1000000060)
-        actual val Button8 = Key(-1000000061)
-        actual val Button9 = Key(-1000000062)
-        actual val Button10 = Key(-1000000063)
-        actual val Button11 = Key(-1000000064)
-        actual val Button12 = Key(-1000000065)
-        actual val Button13 = Key(-1000000066)
-        actual val Button14 = Key(-1000000067)
-        actual val Button15 = Key(-1000000068)
-        actual val Button16 = Key(-1000000069)
-        actual val Forward = Key(-1000000070)
-        actual val MediaPlay = Key(-1000000071)
-        actual val MediaPause = Key(-1000000072)
-        actual val MediaPlayPause = Key(-1000000073)
-        actual val MediaStop = Key(-1000000074)
-        actual val MediaRecord = Key(-1000000075)
-        actual val MediaNext = Key(-1000000076)
-        actual val MediaPrevious = Key(-1000000077)
-        actual val MediaRewind = Key(-1000000078)
-        actual val MediaFastForward = Key(-1000000079)
-        actual val MediaClose = Key(-1000000080)
-        actual val MediaAudioTrack = Key(-1000000081)
-        actual val MediaEject = Key(-1000000082)
-        actual val MediaTopMenu = Key(-1000000083)
-        actual val MediaSkipForward = Key(-1000000084)
-        actual val MediaSkipBackward = Key(-1000000085)
-        actual val MediaStepForward = Key(-1000000086)
-        actual val MediaStepBackward = Key(-1000000087)
-        actual val MicrophoneMute = Key(-1000000088)
-        actual val VolumeMute = Key(-1000000089)
-        actual val Info = Key(-1000000090)
-        actual val ChannelUp = Key(-1000000091)
-        actual val ChannelDown = Key(-1000000092)
-        actual val ZoomIn = Key(-1000000093)
-        actual val ZoomOut = Key(-1000000094)
-        actual val Tv = Key(-1000000095)
-        actual val Window = Key(-1000000096)
-        actual val Guide = Key(-1000000097)
-        actual val Dvr = Key(-1000000098)
-        actual val Bookmark = Key(-1000000099)
-        actual val Captions = Key(-1000000100)
-        actual val Settings = Key(-1000000101)
-        actual val TvPower = Key(-1000000102)
-        actual val TvInput = Key(-1000000103)
-        actual val SetTopBoxPower = Key(-1000000104)
-        actual val SetTopBoxInput = Key(-1000000105)
-        actual val AvReceiverPower = Key(-1000000106)
-        actual val AvReceiverInput = Key(-1000000107)
-        actual val ProgramRed = Key(-1000000108)
-        actual val ProgramGreen = Key(-1000000109)
-        actual val ProgramYellow = Key(-1000000110)
-        actual val ProgramBlue = Key(-1000000111)
-        actual val AppSwitch = Key(-1000000112)
-        actual val LanguageSwitch = Key(-1000000113)
-        actual val MannerMode = Key(-1000000114)
-        actual val Toggle2D3D = Key(-1000000125)
-        actual val Contacts = Key(-1000000126)
-        actual val Calendar = Key(-1000000127)
-        actual val Music = Key(-1000000128)
-        actual val Calculator = Key(-1000000129)
-        actual val ZenkakuHankaru = Key(-1000000130)
-        actual val Eisu = Key(-1000000131)
-        actual val Muhenkan = Key(-1000000132)
-        actual val Henkan = Key(-1000000133)
-        actual val KatakanaHiragana = Key(-1000000134)
-        actual val Yen = Key(-1000000135)
-        actual val Ro = Key(-1000000136)
-        actual val Kana = Key(-1000000137)
-        actual val Assist = Key(-1000000138)
-        actual val BrightnessDown = Key(-1000000139)
-        actual val BrightnessUp = Key(-1000000140)
-        actual val Sleep = Key(-1000000141)
-        actual val WakeUp = Key(-1000000142)
-        actual val SoftSleep = Key(-1000000143)
-        actual val Pairing = Key(-1000000144)
-        actual val LastChannel = Key(-1000000145)
-        actual val TvDataService = Key(-1000000146)
-        actual val VoiceAssist = Key(-1000000147)
-        actual val TvRadioService = Key(-1000000148)
-        actual val TvTeletext = Key(-1000000149)
-        actual val TvNumberEntry = Key(-1000000150)
-        actual val TvTerrestrialAnalog = Key(-1000000151)
-        actual val TvTerrestrialDigital = Key(-1000000152)
-        actual val TvSatellite = Key(-1000000153)
-        actual val TvSatelliteBs = Key(-1000000154)
-        actual val TvSatelliteCs = Key(-1000000155)
-        actual val TvSatelliteService = Key(-1000000156)
-        actual val TvNetwork = Key(-1000000157)
-        actual val TvAntennaCable = Key(-1000000158)
-        actual val TvInputHdmi1 = Key(-1000000159)
-        actual val TvInputHdmi2 = Key(-1000000160)
-        actual val TvInputHdmi3 = Key(-1000000161)
-        actual val TvInputHdmi4 = Key(-1000000162)
-        actual val TvInputComposite1 = Key(-1000000163)
-        actual val TvInputComposite2 = Key(-1000000164)
-        actual val TvInputComponent1 = Key(-1000000165)
-        actual val TvInputComponent2 = Key(-1000000166)
-        actual val TvInputVga1 = Key(-1000000167)
-        actual val TvAudioDescription = Key(-1000000168)
-        actual val TvAudioDescriptionMixingVolumeUp = Key(-1000000169)
-        actual val TvAudioDescriptionMixingVolumeDown = Key(-1000000170)
-        actual val TvZoomMode = Key(-1000000171)
-        actual val TvContentsMenu = Key(-1000000172)
-        actual val TvMediaContextMenu = Key(-1000000173)
-        actual val TvTimerProgramming = Key(-1000000174)
-        actual val StemPrimary = Key(-1000000175)
-        actual val Stem1 = Key(-1000000176)
-        actual val Stem2 = Key(-1000000177)
-        actual val Stem3 = Key(-1000000178)
-        actual val AllApps = Key(-1000000179)
-        actual val Refresh = Key(-1000000180)
-        actual val ThumbsUp = Key(-1000000181)
-        actual val ThumbsDown = Key(-1000000182)
-        actual val ProfileSwitch = Key(-1000000183)
-        actual val Help = Key(-1000000184)
-        actual val Plus = Key(-1000000185)
-        actual val Multiply = Key(-1000000186)
-        actual val Pound = Key(-1000000187)
-        actual val Cut = Key(-1000000188)
-        actual val Copy = Key(-1000000189)
-        actual val Paste = Key(-1000000190)
-        actual val Apostrophe = Key(-1000000191)
-        actual val At = Key(-10000001902)
-        actual val NumPadDot = Key(-1000000193)
-        actual val NumPadComma = Key(-1000000194)
-        actual val NumPadEquals = Key(-1000000195)
-        actual val NumPadLeftParenthesis = Key(-1000000196)
-        actual val NumPadRightParenthesis = Key(-1000000197)
-        actual val NumPadDirectionUp = Key(-1000000198)
-        actual val NumPadDirectionDown = Key(-1000000199)
-        actual val NumPadDirectionLeft = Key(-1000000200)
-        actual val NumPadDirectionRight = Key(-1000000201)
-        actual val NumPadMoveHome = Key(-1000000202)
-        actual val NumPadMoveEnd = Key(-1000000203)
-        actual val NumPadPageUp = Key(-1000000204)
-        actual val NumPadPageDown = Key(-1000000205)
-        actual val NumPadInsert = Key(-1000000206)
-        actual val NumPadDelete: Key = Key(-1000000208)
+        actual val SoftLeft: Key
+            get() = Key(-1000000001)
+
+        actual val SoftRight: Key
+            get() = Key(-1000000002)
+
+        actual val Back: Key
+            get() = Key(-1000000003)
+
+        actual val NavigatePrevious: Key
+            get() = Key(-1000000004)
+
+        actual val NavigateNext: Key
+            get() = Key(-1000000005)
+
+        actual val NavigateIn: Key
+            get() = Key(-1000000006)
+
+        actual val NavigateOut: Key
+            get() = Key(-1000000007)
+
+        actual val SystemNavigationUp: Key
+            get() = Key(-1000000008)
+
+        actual val SystemNavigationDown: Key
+            get() = Key(-1000000009)
+
+        actual val SystemNavigationLeft: Key
+            get() = Key(-1000000010)
+
+        actual val SystemNavigationRight: Key
+            get() = Key(-1000000011)
+
+        actual val Call: Key
+            get() = Key(-1000000012)
+
+        actual val EndCall: Key
+            get() = Key(-1000000013)
+
+        actual val DirectionCenter: Key
+            get() = Key(-1000000014)
+
+        actual val DirectionUpLeft: Key
+            get() = Key(-1000000015)
+
+        actual val DirectionDownLeft: Key
+            get() = Key(-1000000016)
+
+        actual val DirectionUpRight: Key
+            get() = Key(-1000000017)
+
+        actual val DirectionDownRight: Key
+            get() = Key(-1000000018)
+
+        actual val VolumeUp: Key
+            get() = Key(-1000000019)
+
+        actual val VolumeDown: Key
+            get() = Key(-1000000020)
+
+        actual val Power: Key
+            get() = Key(-1000000021)
+
+        actual val Camera: Key
+            get() = Key(-1000000022)
+
+        actual val Clear: Key
+            get() = Key(-1000000023)
+
+        actual val Symbol: Key
+            get() = Key(-1000000024)
+
+        actual val Browser: Key
+            get() = Key(-1000000025)
+
+        actual val Envelope: Key
+            get() = Key(-1000000026)
+
+        actual val Function: Key
+            get() = Key(-1000000027)
+
+        actual val Break: Key
+            get() = Key(-1000000028)
+
+        actual val Number: Key
+            get() = Key(-1000000031)
+
+        actual val HeadsetHook: Key
+            get() = Key(-1000000032)
+
+        actual val Focus: Key
+            get() = Key(-1000000033)
+
+        actual val Menu: Key
+            get() = Key(-1000000034)
+
+        actual val Notification: Key
+            get() = Key(-1000000035)
+
+        actual val Search: Key
+            get() = Key(-1000000036)
+
+        actual val PictureSymbols: Key
+            get() = Key(-1000000037)
+
+        actual val SwitchCharset: Key
+            get() = Key(-1000000038)
+
+        actual val ButtonA: Key
+            get() = Key(-1000000039)
+
+        actual val ButtonB: Key
+            get() = Key(-1000000040)
+
+        actual val ButtonC: Key
+            get() = Key(-1000000041)
+
+        actual val ButtonX: Key
+            get() = Key(-1000000042)
+
+        actual val ButtonY: Key
+            get() = Key(-1000000043)
+
+        actual val ButtonZ: Key
+            get() = Key(-1000000044)
+
+        actual val ButtonL1: Key
+            get() = Key(-1000000045)
+
+        actual val ButtonR1: Key
+            get() = Key(-1000000046)
+
+        actual val ButtonL2: Key
+            get() = Key(-1000000047)
+
+        actual val ButtonR2: Key
+            get() = Key(-1000000048)
+
+        actual val ButtonThumbLeft: Key
+            get() = Key(-1000000049)
+
+        actual val ButtonThumbRight: Key
+            get() = Key(-1000000050)
+
+        actual val ButtonStart: Key
+            get() = Key(-1000000051)
+
+        actual val ButtonSelect: Key
+            get() = Key(-1000000052)
+
+        actual val ButtonMode: Key
+            get() = Key(-1000000053)
+
+        actual val Button1: Key
+            get() = Key(-1000000054)
+
+        actual val Button2: Key
+            get() = Key(-1000000055)
+
+        actual val Button3: Key
+            get() = Key(-1000000056)
+
+        actual val Button4: Key
+            get() = Key(-1000000057)
+
+        actual val Button5: Key
+            get() = Key(-1000000058)
+
+        actual val Button6: Key
+            get() = Key(-1000000059)
+
+        actual val Button7: Key
+            get() = Key(-1000000060)
+
+        actual val Button8: Key
+            get() = Key(-1000000061)
+
+        actual val Button9: Key
+            get() = Key(-1000000062)
+
+        actual val Button10: Key
+            get() = Key(-1000000063)
+
+        actual val Button11: Key
+            get() = Key(-1000000064)
+
+        actual val Button12: Key
+            get() = Key(-1000000065)
+
+        actual val Button13: Key
+            get() = Key(-1000000066)
+
+        actual val Button14: Key
+            get() = Key(-1000000067)
+
+        actual val Button15: Key
+            get() = Key(-1000000068)
+
+        actual val Button16: Key
+            get() = Key(-1000000069)
+
+        actual val Forward: Key
+            get() = Key(-1000000070)
+
+        actual val MediaPlay: Key
+            get() = Key(-1000000071)
+
+        actual val MediaPause: Key
+            get() = Key(-1000000072)
+
+        actual val MediaPlayPause: Key
+            get() = Key(-1000000073)
+
+        actual val MediaStop: Key
+            get() = Key(-1000000074)
+
+        actual val MediaRecord: Key
+            get() = Key(-1000000075)
+
+        actual val MediaNext: Key
+            get() = Key(-1000000076)
+
+        actual val MediaPrevious: Key
+            get() = Key(-1000000077)
+
+        actual val MediaRewind: Key
+            get() = Key(-1000000078)
+
+        actual val MediaFastForward: Key
+            get() = Key(-1000000079)
+
+        actual val MediaClose: Key
+            get() = Key(-1000000080)
+
+        actual val MediaAudioTrack: Key
+            get() = Key(-1000000081)
+
+        actual val MediaEject: Key
+            get() = Key(-1000000082)
+
+        actual val MediaTopMenu: Key
+            get() = Key(-1000000083)
+
+        actual val MediaSkipForward: Key
+            get() = Key(-1000000084)
+
+        actual val MediaSkipBackward: Key
+            get() = Key(-1000000085)
+
+        actual val MediaStepForward: Key
+            get() = Key(-1000000086)
+
+        actual val MediaStepBackward: Key
+            get() = Key(-1000000087)
+
+        actual val MicrophoneMute: Key
+            get() = Key(-1000000088)
+
+        actual val VolumeMute: Key
+            get() = Key(-1000000089)
+
+        actual val Info: Key
+            get() = Key(-1000000090)
+
+        actual val ChannelUp: Key
+            get() = Key(-1000000091)
+
+        actual val ChannelDown: Key
+            get() = Key(-1000000092)
+
+        actual val ZoomIn: Key
+            get() = Key(-1000000093)
+
+        actual val ZoomOut: Key
+            get() = Key(-1000000094)
+
+        actual val Tv: Key
+            get() = Key(-1000000095)
+
+        actual val Window: Key
+            get() = Key(-1000000096)
+
+        actual val Guide: Key
+            get() = Key(-1000000097)
+
+        actual val Dvr: Key
+            get() = Key(-1000000098)
+
+        actual val Bookmark: Key
+            get() = Key(-1000000099)
+
+        actual val Captions: Key
+            get() = Key(-1000000100)
+
+        actual val Settings: Key
+            get() = Key(-1000000101)
+
+        actual val TvPower: Key
+            get() = Key(-1000000102)
+
+        actual val TvInput: Key
+            get() = Key(-1000000103)
+
+        actual val SetTopBoxPower: Key
+            get() = Key(-1000000104)
+
+        actual val SetTopBoxInput: Key
+            get() = Key(-1000000105)
+
+        actual val AvReceiverPower: Key
+            get() = Key(-1000000106)
+
+        actual val AvReceiverInput: Key
+            get() = Key(-1000000107)
+
+        actual val ProgramRed: Key
+            get() = Key(-1000000108)
+
+        actual val ProgramGreen: Key
+            get() = Key(-1000000109)
+
+        actual val ProgramYellow: Key
+            get() = Key(-1000000110)
+
+        actual val ProgramBlue: Key
+            get() = Key(-1000000111)
+
+        actual val AppSwitch: Key
+            get() = Key(-1000000112)
+
+        actual val LanguageSwitch: Key
+            get() = Key(-1000000113)
+
+        actual val MannerMode: Key
+            get() = Key(-1000000114)
+
+        actual val Toggle2D3D: Key
+            get() = Key(-1000000125)
+
+        actual val Contacts: Key
+            get() = Key(-1000000126)
+
+        actual val Calendar: Key
+            get() = Key(-1000000127)
+
+        actual val Music: Key
+            get() = Key(-1000000128)
+
+        actual val Calculator: Key
+            get() = Key(-1000000129)
+
+        actual val ZenkakuHankaru: Key
+            get() = Key(-1000000130)
+
+        actual val Eisu: Key
+            get() = Key(-1000000131)
+
+        actual val Muhenkan: Key
+            get() = Key(-1000000132)
+
+        actual val Henkan: Key
+            get() = Key(-1000000133)
+
+        actual val KatakanaHiragana: Key
+            get() = Key(-1000000134)
+
+        actual val Yen: Key
+            get() = Key(-1000000135)
+
+        actual val Ro: Key
+            get() = Key(-1000000136)
+
+        actual val Kana: Key
+            get() = Key(-1000000137)
+
+        actual val Assist: Key
+            get() = Key(-1000000138)
+
+        actual val BrightnessDown: Key
+            get() = Key(-1000000139)
+
+        actual val BrightnessUp: Key
+            get() = Key(-1000000140)
+
+        actual val Sleep: Key
+            get() = Key(-1000000141)
+
+        actual val WakeUp: Key
+            get() = Key(-1000000142)
+
+        actual val SoftSleep: Key
+            get() = Key(-1000000143)
+
+        actual val Pairing: Key
+            get() = Key(-1000000144)
+
+        actual val LastChannel: Key
+            get() = Key(-1000000145)
+
+        actual val TvDataService: Key
+            get() = Key(-1000000146)
+
+        actual val VoiceAssist: Key
+            get() = Key(-1000000147)
+
+        actual val TvRadioService: Key
+            get() = Key(-1000000148)
+
+        actual val TvTeletext: Key
+            get() = Key(-1000000149)
+
+        actual val TvNumberEntry: Key
+            get() = Key(-1000000150)
+
+        actual val TvTerrestrialAnalog: Key
+            get() = Key(-1000000151)
+
+        actual val TvTerrestrialDigital: Key
+            get() = Key(-1000000152)
+
+        actual val TvSatellite: Key
+            get() = Key(-1000000153)
+
+        actual val TvSatelliteBs: Key
+            get() = Key(-1000000154)
+
+        actual val TvSatelliteCs: Key
+            get() = Key(-1000000155)
+
+        actual val TvSatelliteService: Key
+            get() = Key(-1000000156)
+
+        actual val TvNetwork: Key
+            get() = Key(-1000000157)
+
+        actual val TvAntennaCable: Key
+            get() = Key(-1000000158)
+
+        actual val TvInputHdmi1: Key
+            get() = Key(-1000000159)
+
+        actual val TvInputHdmi2: Key
+            get() = Key(-1000000160)
+
+        actual val TvInputHdmi3: Key
+            get() = Key(-1000000161)
+
+        actual val TvInputHdmi4: Key
+            get() = Key(-1000000162)
+
+        actual val TvInputComposite1: Key
+            get() = Key(-1000000163)
+
+        actual val TvInputComposite2: Key
+            get() = Key(-1000000164)
+
+        actual val TvInputComponent1: Key
+            get() = Key(-1000000165)
+
+        actual val TvInputComponent2: Key
+            get() = Key(-1000000166)
+
+        actual val TvInputVga1: Key
+            get() = Key(-1000000167)
+
+        actual val TvAudioDescription: Key
+            get() = Key(-1000000168)
+
+        actual val TvAudioDescriptionMixingVolumeUp: Key
+            get() = Key(-1000000169)
+
+        actual val TvAudioDescriptionMixingVolumeDown: Key
+            get() = Key(-1000000170)
+
+        actual val TvZoomMode: Key
+            get() = Key(-1000000171)
+
+        actual val TvContentsMenu: Key
+            get() = Key(-1000000172)
+
+        actual val TvMediaContextMenu: Key
+            get() = Key(-1000000173)
+
+        actual val TvTimerProgramming: Key
+            get() = Key(-1000000174)
+
+        actual val StemPrimary: Key
+            get() = Key(-1000000175)
+
+        actual val Stem1: Key
+            get() = Key(-1000000176)
+
+        actual val Stem2: Key
+            get() = Key(-1000000177)
+
+        actual val Stem3: Key
+            get() = Key(-1000000178)
+
+        actual val AllApps: Key
+            get() = Key(-1000000179)
+
+        actual val Refresh: Key
+            get() = Key(-1000000180)
+
+        actual val ThumbsUp: Key
+            get() = Key(-1000000181)
+
+        actual val ThumbsDown: Key
+            get() = Key(-1000000182)
+
+        actual val ProfileSwitch: Key
+            get() = Key(-1000000183)
+
+        actual val Help: Key
+            get() = Key(-1000000184)
+
+        actual val Plus: Key
+            get() = Key(-1000000185)
+
+        actual val Multiply: Key
+            get() = Key(-1000000186)
+
+        actual val Pound: Key
+            get() = Key(-1000000187)
+
+        actual val Cut: Key
+            get() = Key(-1000000188)
+
+        actual val Copy: Key
+            get() = Key(-1000000189)
+
+        actual val Paste: Key
+            get() = Key(-1000000190)
+
+        actual val Apostrophe: Key
+            get() = Key(-1000000191)
+
+        actual val At: Key
+            get() = Key(-10000001902)
+
+        actual val NumPadDot: Key
+            get() = Key(-1000000193)
+
+        actual val NumPadComma: Key
+            get() = Key(-1000000194)
+
+        actual val NumPadEquals: Key
+            get() = Key(-1000000195)
+
+        actual val NumPadLeftParenthesis: Key
+            get() = Key(-1000000196)
+
+        actual val NumPadRightParenthesis: Key
+            get() = Key(-1000000197)
+
+        actual val NumPadDirectionUp: Key
+            get() = Key(-1000000198)
+
+        actual val NumPadDirectionDown: Key
+            get() = Key(-1000000199)
+
+        actual val NumPadDirectionLeft: Key
+            get() = Key(-1000000200)
+
+        actual val NumPadDirectionRight: Key
+            get() = Key(-1000000201)
+
+        actual val NumPadMoveHome: Key
+            get() = Key(-1000000202)
+
+        actual val NumPadMoveEnd: Key
+            get() = Key(-1000000203)
+
+        actual val NumPadPageUp: Key
+            get() = Key(-1000000204)
+
+        actual val NumPadPageDown: Key
+            get() = Key(-1000000205)
+
+        actual val NumPadInsert: Key
+            get() = Key(-1000000206)
+
+        actual val NumPadDelete: Key
+            get() = Key(-1000000208)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Strings.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Strings.ios.kt
@@ -23,10 +23,14 @@ import androidx.compose.ui.platform.l10n.translationFor
 @Immutable
 internal value class Strings private constructor(@Suppress("unused") private val value: Int) {
     companion object {
-        val NextPage = Strings(0)
-        val PreviousPage = Strings(1)
-        val FirstPage = Strings(2)
-        val LastPage = Strings(3)
+        inline val NextPage: Strings
+            get() = Strings(0)
+        inline val PreviousPage: Strings
+            get() = Strings(1)
+        inline val FirstPage: Strings
+            get() = Strings(2)
+        inline val LastPage: Strings
+            get() = Strings(3)
         // When adding values here, make sure to also add them in ui/build.gradle,
         // updateTranslationsIos task (stringByResourceName parameter), and re-run the task
     }

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
@@ -27,7 +27,8 @@ import androidx.compose.ui.input.key.Key.Companion.Number
 actual value class Key(val keyCode: Long) {
     actual companion object {
         /** Unknown key. */
-        actual val Unknown = Key(-1)
+        actual val Unknown: Key
+            get() = Key(-1)
 
         /**
          * System Home key.
@@ -41,288 +42,372 @@ actual value class Key(val keyCode: Long) {
                 "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
             level = DeprecationLevel.ERROR,
         )
-        actual val Home = Key(115)
+        actual val Home: Key
+            get() = Key(115)
 
         /**
          * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
-        actual val SystemHome: Key = Key(-1000000207)
+        actual val SystemHome: Key
+            get() = Key(-1000000207)
 
         /**
          * Up Arrow Key / Directional Pad Up key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionUp = Key(126)
+        actual val DirectionUp: Key
+            get() = Key(126)
 
         /**
          * Down Arrow Key / Directional Pad Down key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionDown = Key(125)
+        actual val DirectionDown: Key
+            get() = Key(125)
 
         /**
          * Left Arrow Key / Directional Pad Left key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionLeft = Key(123)
+        actual val DirectionLeft: Key
+            get() = Key(123)
 
         /**
          * Right Arrow Key / Directional Pad Right key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionRight = Key(124)
+        actual val DirectionRight: Key
+            get() = Key(124)
 
         /** '0' key. */
-        actual val Zero = Key(29)
+        actual val Zero: Key
+            get() = Key(29)
 
         /** '1' key. */
-        actual val One = Key(18)
+        actual val One: Key
+            get() = Key(18)
 
         /** '2' key. */
-        actual val Two = Key(19)
+        actual val Two: Key
+            get() = Key(19)
 
         /** '3' key. */
-        actual val Three = Key(20)
+        actual val Three: Key
+            get() = Key(20)
 
         /** '4' key. */
-        actual val Four = Key(21)
+        actual val Four: Key
+            get() = Key(21)
 
         /** '5' key. */
-        actual val Five = Key(23)
+        actual val Five: Key
+            get() = Key(23)
 
         /** '6' key. */
-        actual val Six = Key(22)
+        actual val Six: Key
+            get() = Key(22)
 
         /** '7' key. */
-        actual val Seven = Key(26)
+        actual val Seven: Key
+            get() = Key(26)
 
         /** '8' key. */
-        actual val Eight = Key(28)
+        actual val Eight: Key
+            get() = Key(28)
 
         /** '9' key. */
-        actual val Nine = Key(25)
+        actual val Nine: Key
+            get() = Key(25)
 
         /** '-' key. */
-        actual val Minus = Key(27)
+        actual val Minus: Key
+            get() = Key(27)
 
         /** '=' key. */
-        actual val Equals = Key(24)
+        actual val Equals: Key
+            get() = Key(24)
 
         /** 'A' key. */
-        actual val A = Key(0)
+        actual val A: Key
+            get() = Key(0)
 
         /** 'B' key. */
-        actual val B = Key(11)
+        actual val B: Key
+            get() = Key(11)
 
         /** 'C' key. */
-        actual val C = Key(8)
+        actual val C: Key
+            get() = Key(8)
 
         /** 'D' key. */
-        actual val D = Key(2)
+        actual val D: Key
+            get() = Key(2)
 
         /** 'E' key. */
-        actual val E = Key(14)
+        actual val E: Key
+            get() = Key(14)
 
         /** 'F' key. */
-        actual val F = Key(3)
+        actual val F: Key
+            get() = Key(3)
 
         /** 'G' key. */
-        actual val G = Key(5)
+        actual val G: Key
+            get() = Key(5)
 
         /** 'H' key. */
-        actual val H = Key(4)
+        actual val H: Key
+            get() = Key(4)
 
         /** 'I' key. */
-        actual val I = Key(34)
+        actual val I: Key
+            get() = Key(34)
 
         /** 'J' key. */
-        actual val J = Key(38)
+        actual val J: Key
+            get() = Key(38)
 
         /** 'K' key. */
-        actual val K = Key(40)
+        actual val K: Key
+            get() = Key(40)
 
         /** 'L' key. */
-        actual val L = Key(37)
+        actual val L: Key
+            get() = Key(37)
 
         /** 'M' key. */
-        actual val M = Key(46)
+        actual val M: Key
+            get() = Key(46)
 
         /** 'N' key. */
-        actual val N = Key(45)
+        actual val N: Key
+            get() = Key(45)
 
         /** 'O' key. */
-        actual val O = Key(31)
+        actual val O: Key
+            get() = Key(31)
 
         /** 'P' key. */
-        actual val P = Key(35)
+        actual val P: Key
+            get() = Key(35)
 
         /** 'Q' key. */
-        actual val Q = Key(12)
+        actual val Q: Key
+            get() = Key(12)
 
         /** 'R' key. */
-        actual val R = Key(15)
+        actual val R: Key
+            get() = Key(15)
 
         /** 'S' key. */
-        actual val S = Key(1)
+        actual val S: Key
+            get() = Key(1)
 
         /** 'T' key. */
-        actual val T = Key(17)
+        actual val T: Key
+            get() = Key(17)
 
         /** 'U' key. */
-        actual val U = Key(32)
+        actual val U: Key
+            get() = Key(32)
 
         /** 'V' key. */
-        actual val V = Key(9)
+        actual val V: Key
+            get() = Key(9)
 
         /** 'W' key. */
-        actual val W = Key(13)
+        actual val W: Key
+            get() = Key(13)
 
         /** 'X' key. */
-        actual val X = Key(7)
+        actual val X: Key
+            get() = Key(7)
 
         /** 'Y' key. */
-        actual val Y = Key(16)
+        actual val Y: Key
+            get() = Key(16)
 
         /** 'Z' key. */
-        actual val Z = Key(6)
+        actual val Z: Key
+            get() = Key(6)
 
         /** ',' key. */
-        actual val Comma = Key(43)
+        actual val Comma: Key
+            get() = Key(43)
 
         /** '.' key. */
-        actual val Period = Key(47)
+        actual val Period: Key
+            get() = Key(47)
 
         /** Left Alt modifier key. */
-        actual val AltLeft = Key(58)
+        actual val AltLeft: Key
+            get() = Key(58)
 
         /** Right Alt modifier key. */
-        actual val AltRight = Key(61)
+        actual val AltRight: Key
+            get() = Key(61)
 
         /** Left Shift modifier key. */
-        actual val ShiftLeft = Key(56)
+        actual val ShiftLeft: Key
+            get() = Key(56)
 
         /** Right Shift modifier key. */
-        actual val ShiftRight = Key(60)
+        actual val ShiftRight: Key
+            get() = Key(60)
 
         /** Tab key. */
-        actual val Tab = Key(48)
+        actual val Tab: Key
+            get() = Key(48)
 
         /** Space key. */
-        actual val Spacebar = Key(49)
+        actual val Spacebar: Key
+            get() = Key(49)
 
         /** Enter key. */
-        actual val Enter = Key(36)
+        actual val Enter: Key
+            get() = Key(36)
 
         /**
          * Backspace key.
          *
          * Deletes characters before the insertion point, unlike [Delete].
          */
-        actual val Backspace = Key(51)
+        actual val Backspace: Key
+            get() = Key(51)
 
         /**
          * Delete key.
          *
          * Deletes characters ahead of the insertion point, unlike [Backspace].
          */
-        actual val Delete = Key(117)
+        actual val Delete: Key
+            get() = Key(117)
 
         /** Escape key. */
-        actual val Escape = Key(53)
+        actual val Escape: Key
+            get() = Key(53)
 
         /** Left Control modifier key. */
-        actual val CtrlLeft = Key(59)
+        actual val CtrlLeft: Key
+            get() = Key(59)
 
         /** Right Control modifier key. */
-        actual val CtrlRight = Key(62)
+        actual val CtrlRight: Key
+            get() = Key(62)
 
         /** Caps Lock key. */
-        actual val CapsLock = Key(57)
+        actual val CapsLock: Key
+            get() = Key(57)
 
         /** Scroll Lock key. */
-        actual val ScrollLock = Key(107)
+        actual val ScrollLock: Key
+            get() = Key(107)
 
         /** Left Meta modifier key. */
-        actual val MetaLeft = Key(55)
+        actual val MetaLeft: Key
+            get() = Key(55)
 
         /** Right Meta modifier key. */
-        actual val MetaRight = Key(54)
+        actual val MetaRight: Key
+            get() = Key(54)
 
         /** System Request / Print Screen key. */
-        actual val PrintScreen = Key(105)
+        actual val PrintScreen: Key
+            get() = Key(105)
 
         /**
          * Insert key.
          *
          * Toggles insert / overwrite edit mode.
          */
-        actual val Insert = Key(114)
+        actual val Insert: Key
+            get() = Key(114)
 
         /** '`' (backtick) key. */
-        actual val Grave = Key(50)
+        actual val Grave: Key
+            get() = Key(50)
 
         /** '[' key. */
-        actual val LeftBracket = Key(33)
+        actual val LeftBracket: Key
+            get() = Key(33)
 
         /** ']' key. */
-        actual val RightBracket = Key(30)
+        actual val RightBracket: Key
+            get() = Key(30)
 
         /** '/' key. */
-        actual val Slash = Key(42)
+        actual val Slash: Key
+            get() = Key(42)
 
         /** '\' key. */
-        actual val Backslash = Key(44)
+        actual val Backslash: Key
+            get() = Key(44)
 
         /** ';' key. */
-        actual val Semicolon = Key(41)
+        actual val Semicolon: Key
+            get() = Key(41)
 
         /** Page Up key. */
-        actual val PageUp = Key(116)
+        actual val PageUp: Key
+            get() = Key(116)
 
         /** Page Down key. */
-        actual val PageDown = Key(121)
+        actual val PageDown: Key
+            get() = Key(121)
 
         /** F1 key. */
-        actual val F1 = Key(122)
+        actual val F1: Key
+            get() = Key(122)
 
         /** F2 key. */
-        actual val F2 = Key(120)
+        actual val F2: Key
+            get() = Key(120)
 
         /** F3 key. */
-        actual val F3 = Key(99)
+        actual val F3: Key
+            get() = Key(99)
 
         /** F4 key. */
-        actual val F4 = Key(118)
+        actual val F4: Key
+            get() = Key(118)
 
         /** F5 key. */
-        actual val F5 = Key(96)
+        actual val F5: Key
+            get() = Key(96)
 
         /** F6 key. */
-        actual val F6 = Key(97)
+        actual val F6: Key
+            get() = Key(97)
 
         /** F7 key. */
-        actual val F7 = Key(98)
+        actual val F7: Key
+            get() = Key(98)
 
         /** F8 key. */
-        actual val F8 = Key(100)
+        actual val F8: Key
+            get() = Key(100)
 
         /** F9 key. */
-        actual val F9 = Key(101)
+        actual val F9: Key
+            get() = Key(101)
 
         /** F10 key. */
-        actual val F10 = Key(109)
+        actual val F10: Key
+            get() = Key(109)
 
         /** F11 key. */
-        actual val F11 = Key(103)
+        actual val F11: Key
+            get() = Key(103)
 
         /** F12 key. */
-        actual val F12 = Key(111)
+        actual val F12: Key
+            get() = Key(111)
 
         /**
          * Num Lock key.
@@ -330,253 +415,466 @@ actual value class Key(val keyCode: Long) {
          * This is the Num Lock key; it is different from [Number].
          * This key alters the behavior of other keys on the numeric keypad.
          */
-        actual val NumLock = Key(71)
+        actual val NumLock: Key
+            get() = Key(71)
 
         /** Numeric keypad '0' key. */
-        actual val NumPad0 = Key(82)
+        actual val NumPad0: Key
+            get() = Key(82)
 
         /** Numeric keypad '1' key. */
-        actual val NumPad1 = Key(83)
+        actual val NumPad1: Key
+            get() = Key(83)
 
         /** Numeric keypad '2' key. */
-        actual val NumPad2 = Key(84)
+        actual val NumPad2: Key
+            get() = Key(84)
 
         /** Numeric keypad '3' key. */
-        actual val NumPad3 = Key(85)
+        actual val NumPad3: Key
+            get() = Key(85)
 
         /** Numeric keypad '4' key. */
-        actual val NumPad4 = Key(86)
+        actual val NumPad4: Key
+            get() = Key(86)
 
         /** Numeric keypad '5' key. */
-        actual val NumPad5 = Key(87)
+        actual val NumPad5: Key
+            get() = Key(87)
 
         /** Numeric keypad '6' key. */
-        actual val NumPad6 = Key(88)
+        actual val NumPad6: Key
+            get() = Key(88)
 
         /** Numeric keypad '7' key. */
-        actual val NumPad7 = Key(89)
+        actual val NumPad7: Key
+            get() = Key(89)
 
         /** Numeric keypad '8' key. */
-        actual val NumPad8 = Key(91)
+        actual val NumPad8: Key
+            get() = Key(91)
 
         /** Numeric keypad '9' key. */
-        actual val NumPad9 = Key(92)
+        actual val NumPad9: Key
+            get() = Key(92)
 
         /** Numeric keypad '/' key (for division). */
-        actual val NumPadDivide = Key(75)
+        actual val NumPadDivide: Key
+            get() = Key(75)
 
         /** Numeric keypad '*' key (for multiplication). */
-        actual val NumPadMultiply = Key(67)
+        actual val NumPadMultiply: Key
+            get() = Key(67)
 
         /** Numeric keypad '-' key (for subtraction). */
-        actual val NumPadSubtract = Key(78)
+        actual val NumPadSubtract: Key
+            get() = Key(78)
 
         /** Numeric keypad '+' key (for addition). */
-        actual val NumPadAdd = Key(69)
+        actual val NumPadAdd: Key
+            get() = Key(69)
 
         /** Numeric keypad Enter key. */
-        actual val NumPadEnter = Key(76)
+        actual val NumPadEnter: Key
+            get() = Key(76)
 
-        actual val MoveHome = Key(115)
+        actual val MoveHome: Key
+            get() = Key(115)
 
-        actual val MoveEnd = Key(119)
+        actual val MoveEnd: Key
+            get() = Key(119)
 
         // Unsupported Keys
-        actual val SoftLeft = Key(-1000000001)
-        actual val SoftRight = Key(-1000000002)
-        actual val Back = Key(-1000000003)
-        actual val NavigatePrevious = Key(-1000000004)
-        actual val NavigateNext = Key(-1000000005)
-        actual val NavigateIn = Key(-1000000006)
-        actual val NavigateOut = Key(-1000000007)
-        actual val SystemNavigationUp = Key(-1000000008)
-        actual val SystemNavigationDown = Key(-1000000009)
-        actual val SystemNavigationLeft = Key(-1000000010)
-        actual val SystemNavigationRight = Key(-1000000011)
-        actual val Call = Key(-1000000012)
-        actual val EndCall = Key(-1000000013)
-        actual val DirectionCenter = Key(-1000000014)
-        actual val DirectionUpLeft = Key(-1000000015)
-        actual val DirectionDownLeft = Key(-1000000016)
-        actual val DirectionUpRight = Key(-1000000017)
-        actual val DirectionDownRight = Key(-1000000018)
-        actual val VolumeUp = Key(-1000000019)
-        actual val VolumeDown = Key(-1000000020)
-        actual val Power = Key(-1000000021)
-        actual val Camera = Key(-1000000022)
-        actual val Clear = Key(-1000000023)
-        actual val Symbol = Key(-1000000024)
-        actual val Browser = Key(-1000000025)
-        actual val Envelope = Key(-1000000026)
-        actual val Function = Key(-1000000027)
-        actual val Break = Key(-1000000028)
-        actual val Number = Key(-1000000031)
-        actual val HeadsetHook = Key(-1000000032)
-        actual val Focus = Key(-1000000033)
-        actual val Menu = Key(-1000000034)
-        actual val Notification = Key(-1000000035)
-        actual val Search = Key(-1000000036)
-        actual val PictureSymbols = Key(-1000000037)
-        actual val SwitchCharset = Key(-1000000038)
-        actual val ButtonA = Key(-1000000039)
-        actual val ButtonB = Key(-1000000040)
-        actual val ButtonC = Key(-1000000041)
-        actual val ButtonX = Key(-1000000042)
-        actual val ButtonY = Key(-1000000043)
-        actual val ButtonZ = Key(-1000000044)
-        actual val ButtonL1 = Key(-1000000045)
-        actual val ButtonR1 = Key(-1000000046)
-        actual val ButtonL2 = Key(-1000000047)
-        actual val ButtonR2 = Key(-1000000048)
-        actual val ButtonThumbLeft = Key(-1000000049)
-        actual val ButtonThumbRight = Key(-1000000050)
-        actual val ButtonStart = Key(-1000000051)
-        actual val ButtonSelect = Key(-1000000052)
-        actual val ButtonMode = Key(-1000000053)
-        actual val Button1 = Key(-1000000054)
-        actual val Button2 = Key(-1000000055)
-        actual val Button3 = Key(-1000000056)
-        actual val Button4 = Key(-1000000057)
-        actual val Button5 = Key(-1000000058)
-        actual val Button6 = Key(-1000000059)
-        actual val Button7 = Key(-1000000060)
-        actual val Button8 = Key(-1000000061)
-        actual val Button9 = Key(-1000000062)
-        actual val Button10 = Key(-1000000063)
-        actual val Button11 = Key(-1000000064)
-        actual val Button12 = Key(-1000000065)
-        actual val Button13 = Key(-1000000066)
-        actual val Button14 = Key(-1000000067)
-        actual val Button15 = Key(-1000000068)
-        actual val Button16 = Key(-1000000069)
-        actual val Forward = Key(-1000000070)
-        actual val MediaPlay = Key(-1000000071)
-        actual val MediaPause = Key(-1000000072)
-        actual val MediaPlayPause = Key(-1000000073)
-        actual val MediaStop = Key(-1000000074)
-        actual val MediaRecord = Key(-1000000075)
-        actual val MediaNext = Key(-1000000076)
-        actual val MediaPrevious = Key(-1000000077)
-        actual val MediaRewind = Key(-1000000078)
-        actual val MediaFastForward = Key(-1000000079)
-        actual val MediaClose = Key(-1000000080)
-        actual val MediaAudioTrack = Key(-1000000081)
-        actual val MediaEject = Key(-1000000082)
-        actual val MediaTopMenu = Key(-1000000083)
-        actual val MediaSkipForward = Key(-1000000084)
-        actual val MediaSkipBackward = Key(-1000000085)
-        actual val MediaStepForward = Key(-1000000086)
-        actual val MediaStepBackward = Key(-1000000087)
-        actual val MicrophoneMute = Key(-1000000088)
-        actual val VolumeMute = Key(-1000000089)
-        actual val Info = Key(-1000000090)
-        actual val ChannelUp = Key(-1000000091)
-        actual val ChannelDown = Key(-1000000092)
-        actual val ZoomIn = Key(-1000000093)
-        actual val ZoomOut = Key(-1000000094)
-        actual val Tv = Key(-1000000095)
-        actual val Window = Key(-1000000096)
-        actual val Guide = Key(-1000000097)
-        actual val Dvr = Key(-1000000098)
-        actual val Bookmark = Key(-1000000099)
-        actual val Captions = Key(-1000000100)
-        actual val Settings = Key(-1000000101)
-        actual val TvPower = Key(-1000000102)
-        actual val TvInput = Key(-1000000103)
-        actual val SetTopBoxPower = Key(-1000000104)
-        actual val SetTopBoxInput = Key(-1000000105)
-        actual val AvReceiverPower = Key(-1000000106)
-        actual val AvReceiverInput = Key(-1000000107)
-        actual val ProgramRed = Key(-1000000108)
-        actual val ProgramGreen = Key(-1000000109)
-        actual val ProgramYellow = Key(-1000000110)
-        actual val ProgramBlue = Key(-1000000111)
-        actual val AppSwitch = Key(-1000000112)
-        actual val LanguageSwitch = Key(-1000000113)
-        actual val MannerMode = Key(-1000000114)
-        actual val Toggle2D3D = Key(-1000000125)
-        actual val Contacts = Key(-1000000126)
-        actual val Calendar = Key(-1000000127)
-        actual val Music = Key(-1000000128)
-        actual val Calculator = Key(-1000000129)
-        actual val ZenkakuHankaru = Key(-1000000130)
-        actual val Eisu = Key(-1000000131)
-        actual val Muhenkan = Key(-1000000132)
-        actual val Henkan = Key(-1000000133)
-        actual val KatakanaHiragana = Key(-1000000134)
-        actual val Yen = Key(-1000000135)
-        actual val Ro = Key(-1000000136)
-        actual val Kana = Key(-1000000137)
-        actual val Assist = Key(-1000000138)
-        actual val BrightnessDown = Key(-1000000139)
-        actual val BrightnessUp = Key(-1000000140)
-        actual val Sleep = Key(-1000000141)
-        actual val WakeUp = Key(-1000000142)
-        actual val SoftSleep = Key(-1000000143)
-        actual val Pairing = Key(-1000000144)
-        actual val LastChannel = Key(-1000000145)
-        actual val TvDataService = Key(-1000000146)
-        actual val VoiceAssist = Key(-1000000147)
-        actual val TvRadioService = Key(-1000000148)
-        actual val TvTeletext = Key(-1000000149)
-        actual val TvNumberEntry = Key(-1000000150)
-        actual val TvTerrestrialAnalog = Key(-1000000151)
-        actual val TvTerrestrialDigital = Key(-1000000152)
-        actual val TvSatellite = Key(-1000000153)
-        actual val TvSatelliteBs = Key(-1000000154)
-        actual val TvSatelliteCs = Key(-1000000155)
-        actual val TvSatelliteService = Key(-1000000156)
-        actual val TvNetwork = Key(-1000000157)
-        actual val TvAntennaCable = Key(-1000000158)
-        actual val TvInputHdmi1 = Key(-1000000159)
-        actual val TvInputHdmi2 = Key(-1000000160)
-        actual val TvInputHdmi3 = Key(-1000000161)
-        actual val TvInputHdmi4 = Key(-1000000162)
-        actual val TvInputComposite1 = Key(-1000000163)
-        actual val TvInputComposite2 = Key(-1000000164)
-        actual val TvInputComponent1 = Key(-1000000165)
-        actual val TvInputComponent2 = Key(-1000000166)
-        actual val TvInputVga1 = Key(-1000000167)
-        actual val TvAudioDescription = Key(-1000000168)
-        actual val TvAudioDescriptionMixingVolumeUp = Key(-1000000169)
-        actual val TvAudioDescriptionMixingVolumeDown = Key(-1000000170)
-        actual val TvZoomMode = Key(-1000000171)
-        actual val TvContentsMenu = Key(-1000000172)
-        actual val TvMediaContextMenu = Key(-1000000173)
-        actual val TvTimerProgramming = Key(-1000000174)
-        actual val StemPrimary = Key(-1000000175)
-        actual val Stem1 = Key(-1000000176)
-        actual val Stem2 = Key(-1000000177)
-        actual val Stem3 = Key(-1000000178)
-        actual val AllApps = Key(-1000000179)
-        actual val Refresh = Key(-1000000180)
-        actual val ThumbsUp = Key(-1000000181)
-        actual val ThumbsDown = Key(-1000000182)
-        actual val ProfileSwitch = Key(-1000000183)
-        actual val Help = Key(-1000000184)
-        actual val Plus = Key(-1000000185)
-        actual val Multiply = Key(-1000000186)
-        actual val Pound = Key(-1000000187)
-        actual val Cut = Key(-1000000188)
-        actual val Copy = Key(-1000000189)
-        actual val Paste = Key(-1000000190)
-        actual val Apostrophe = Key(-1000000191)
-        actual val At = Key(-10000001902)
-        actual val NumPadDot = Key(-1000000193)
-        actual val NumPadComma = Key(-1000000194)
-        actual val NumPadEquals = Key(-1000000195)
-        actual val NumPadLeftParenthesis = Key(-1000000196)
-        actual val NumPadRightParenthesis = Key(-1000000197)
-        actual val NumPadDirectionUp = Key(-1000000198)
-        actual val NumPadDirectionDown = Key(-1000000199)
-        actual val NumPadDirectionLeft = Key(-1000000200)
-        actual val NumPadDirectionRight = Key(-1000000201)
-        actual val NumPadMoveHome = Key(-1000000202)
-        actual val NumPadMoveEnd = Key(-1000000203)
-        actual val NumPadPageUp = Key(-1000000204)
-        actual val NumPadPageDown = Key(-1000000205)
-        actual val NumPadInsert = Key(-1000000206)
-        actual val NumPadDelete: Key = Key(-1000000208)
+        actual val SoftLeft: Key
+            get() = Key(-1000000001)
+        actual val SoftRight: Key
+            get() = Key(-1000000002)
+        actual val Back: Key
+            get() = Key(-1000000003)
+        actual val NavigatePrevious: Key
+            get() = Key(-1000000004)
+        actual val NavigateNext: Key
+            get() = Key(-1000000005)
+        actual val NavigateIn: Key
+            get() = Key(-1000000006)
+        actual val NavigateOut: Key
+            get() = Key(-1000000007)
+        actual val SystemNavigationUp: Key
+            get() = Key(-1000000008)
+        actual val SystemNavigationDown: Key
+            get() = Key(-1000000009)
+        actual val SystemNavigationLeft: Key
+            get() = Key(-1000000010)
+        actual val SystemNavigationRight: Key
+            get() = Key(-1000000011)
+        actual val Call: Key
+            get() = Key(-1000000012)
+        actual val EndCall: Key
+            get() = Key(-1000000013)
+        actual val DirectionCenter: Key
+            get() = Key(-1000000014)
+        actual val DirectionUpLeft: Key
+            get() = Key(-1000000015)
+        actual val DirectionDownLeft: Key
+            get() = Key(-1000000016)
+        actual val DirectionUpRight: Key
+            get() = Key(-1000000017)
+        actual val DirectionDownRight: Key
+            get() = Key(-1000000018)
+        actual val VolumeUp: Key
+            get() = Key(-1000000019)
+        actual val VolumeDown: Key
+            get() = Key(-1000000020)
+        actual val Power: Key
+            get() = Key(-1000000021)
+        actual val Camera: Key
+            get() = Key(-1000000022)
+        actual val Clear: Key
+            get() = Key(-1000000023)
+        actual val Symbol: Key
+            get() = Key(-1000000024)
+        actual val Browser: Key
+            get() = Key(-1000000025)
+        actual val Envelope: Key
+            get() = Key(-1000000026)
+        actual val Function: Key
+            get() = Key(-1000000027)
+        actual val Break: Key
+            get() = Key(-1000000028)
+        actual val Number: Key
+            get() = Key(-1000000031)
+        actual val HeadsetHook: Key
+            get() = Key(-1000000032)
+        actual val Focus: Key
+            get() = Key(-1000000033)
+        actual val Menu: Key
+            get() = Key(-1000000034)
+        actual val Notification: Key
+            get() = Key(-1000000035)
+        actual val Search: Key
+            get() = Key(-1000000036)
+        actual val PictureSymbols: Key
+            get() = Key(-1000000037)
+        actual val SwitchCharset: Key
+            get() = Key(-1000000038)
+        actual val ButtonA: Key
+            get() = Key(-1000000039)
+        actual val ButtonB: Key
+            get() = Key(-1000000040)
+        actual val ButtonC: Key
+            get() = Key(-1000000041)
+        actual val ButtonX: Key
+            get() = Key(-1000000042)
+        actual val ButtonY: Key
+            get() = Key(-1000000043)
+        actual val ButtonZ: Key
+            get() = Key(-1000000044)
+        actual val ButtonL1: Key
+            get() = Key(-1000000045)
+        actual val ButtonR1: Key
+            get() = Key(-1000000046)
+        actual val ButtonL2: Key
+            get() = Key(-1000000047)
+        actual val ButtonR2: Key
+            get() = Key(-1000000048)
+        actual val ButtonThumbLeft: Key
+            get() = Key(-1000000049)
+        actual val ButtonThumbRight: Key
+            get() = Key(-1000000050)
+        actual val ButtonStart: Key
+            get() = Key(-1000000051)
+        actual val ButtonSelect: Key
+            get() = Key(-1000000052)
+        actual val ButtonMode: Key
+            get() = Key(-1000000053)
+        actual val Button1: Key
+            get() = Key(-1000000054)
+        actual val Button2: Key
+            get() = Key(-1000000055)
+        actual val Button3: Key
+            get() = Key(-1000000056)
+        actual val Button4: Key
+            get() = Key(-1000000057)
+        actual val Button5: Key
+            get() = Key(-1000000058)
+        actual val Button6: Key
+            get() = Key(-1000000059)
+        actual val Button7: Key
+            get() = Key(-1000000060)
+        actual val Button8: Key
+            get() = Key(-1000000061)
+        actual val Button9: Key
+            get() = Key(-1000000062)
+        actual val Button10: Key
+            get() = Key(-1000000063)
+        actual val Button11: Key
+            get() = Key(-1000000064)
+        actual val Button12: Key
+            get() = Key(-1000000065)
+        actual val Button13: Key
+            get() = Key(-1000000066)
+        actual val Button14: Key
+            get() = Key(-1000000067)
+        actual val Button15: Key
+            get() = Key(-1000000068)
+        actual val Button16: Key
+            get() = Key(-1000000069)
+        actual val Forward: Key
+            get() = Key(-1000000070)
+        actual val MediaPlay: Key
+            get() = Key(-1000000071)
+        actual val MediaPause: Key
+            get() = Key(-1000000072)
+        actual val MediaPlayPause: Key
+            get() = Key(-1000000073)
+        actual val MediaStop: Key
+            get() = Key(-1000000074)
+        actual val MediaRecord: Key
+            get() = Key(-1000000075)
+        actual val MediaNext: Key
+            get() = Key(-1000000076)
+        actual val MediaPrevious: Key
+            get() = Key(-1000000077)
+        actual val MediaRewind: Key
+            get() = Key(-1000000078)
+        actual val MediaFastForward: Key
+            get() = Key(-1000000079)
+        actual val MediaClose: Key
+            get() = Key(-1000000080)
+        actual val MediaAudioTrack: Key
+            get() = Key(-1000000081)
+        actual val MediaEject: Key
+            get() = Key(-1000000082)
+        actual val MediaTopMenu: Key
+            get() = Key(-1000000083)
+        actual val MediaSkipForward: Key
+            get() = Key(-1000000084)
+        actual val MediaSkipBackward: Key
+            get() = Key(-1000000085)
+        actual val MediaStepForward: Key
+            get() = Key(-1000000086)
+        actual val MediaStepBackward: Key
+            get() = Key(-1000000087)
+        actual val MicrophoneMute: Key
+            get() = Key(-1000000088)
+        actual val VolumeMute: Key
+            get() = Key(-1000000089)
+        actual val Info: Key
+            get() = Key(-1000000090)
+        actual val ChannelUp: Key
+            get() = Key(-1000000091)
+        actual val ChannelDown: Key
+            get() = Key(-1000000092)
+        actual val ZoomIn: Key
+            get() = Key(-1000000093)
+        actual val ZoomOut: Key
+            get() = Key(-1000000094)
+        actual val Tv: Key
+            get() = Key(-1000000095)
+        actual val Window: Key
+            get() = Key(-1000000096)
+        actual val Guide: Key
+            get() = Key(-1000000097)
+        actual val Dvr: Key
+            get() = Key(-1000000098)
+        actual val Bookmark: Key
+            get() = Key(-1000000099)
+        actual val Captions: Key
+            get() = Key(-1000000100)
+        actual val Settings: Key
+            get() = Key(-1000000101)
+        actual val TvPower: Key
+            get() = Key(-1000000102)
+        actual val TvInput: Key
+            get() = Key(-1000000103)
+        actual val SetTopBoxPower: Key
+            get() = Key(-1000000104)
+        actual val SetTopBoxInput: Key
+            get() = Key(-1000000105)
+        actual val AvReceiverPower: Key
+            get() = Key(-1000000106)
+        actual val AvReceiverInput: Key
+            get() = Key(-1000000107)
+        actual val ProgramRed: Key
+            get() = Key(-1000000108)
+        actual val ProgramGreen: Key
+            get() = Key(-1000000109)
+        actual val ProgramYellow: Key
+            get() = Key(-1000000110)
+        actual val ProgramBlue: Key
+            get() = Key(-1000000111)
+        actual val AppSwitch: Key
+            get() = Key(-1000000112)
+        actual val LanguageSwitch: Key
+            get() = Key(-1000000113)
+        actual val MannerMode: Key
+            get() = Key(-1000000114)
+        actual val Toggle2D3D: Key
+            get() = Key(-1000000125)
+        actual val Contacts: Key
+            get() = Key(-1000000126)
+        actual val Calendar: Key
+            get() = Key(-1000000127)
+        actual val Music: Key
+            get() = Key(-1000000128)
+        actual val Calculator: Key
+            get() = Key(-1000000129)
+        actual val ZenkakuHankaru: Key
+            get() = Key(-1000000130)
+        actual val Eisu: Key
+            get() = Key(-1000000131)
+        actual val Muhenkan: Key
+            get() = Key(-1000000132)
+        actual val Henkan: Key
+            get() = Key(-1000000133)
+        actual val KatakanaHiragana: Key
+            get() = Key(-1000000134)
+        actual val Yen: Key
+            get() = Key(-1000000135)
+        actual val Ro: Key
+            get() = Key(-1000000136)
+        actual val Kana: Key
+            get() = Key(-1000000137)
+        actual val Assist: Key
+            get() = Key(-1000000138)
+        actual val BrightnessDown: Key
+            get() = Key(-1000000139)
+        actual val BrightnessUp: Key
+            get() = Key(-1000000140)
+        actual val Sleep: Key
+            get() = Key(-1000000141)
+        actual val WakeUp: Key
+            get() = Key(-1000000142)
+        actual val SoftSleep: Key
+            get() = Key(-1000000143)
+        actual val Pairing: Key
+            get() = Key(-1000000144)
+        actual val LastChannel: Key
+            get() = Key(-1000000145)
+        actual val TvDataService: Key
+            get() = Key(-1000000146)
+        actual val VoiceAssist: Key
+            get() = Key(-1000000147)
+        actual val TvRadioService: Key
+            get() = Key(-1000000148)
+        actual val TvTeletext: Key
+            get() = Key(-1000000149)
+        actual val TvNumberEntry: Key
+            get() = Key(-1000000150)
+        actual val TvTerrestrialAnalog: Key
+            get() = Key(-1000000151)
+        actual val TvTerrestrialDigital: Key
+            get() = Key(-1000000152)
+        actual val TvSatellite: Key
+            get() = Key(-1000000153)
+        actual val TvSatelliteBs: Key
+            get() = Key(-1000000154)
+        actual val TvSatelliteCs: Key
+            get() = Key(-1000000155)
+        actual val TvSatelliteService: Key
+            get() = Key(-1000000156)
+        actual val TvNetwork: Key
+            get() = Key(-1000000157)
+        actual val TvAntennaCable: Key
+            get() = Key(-1000000158)
+        actual val TvInputHdmi1: Key
+            get() = Key(-1000000159)
+        actual val TvInputHdmi2: Key
+            get() = Key(-1000000160)
+        actual val TvInputHdmi3: Key
+            get() = Key(-1000000161)
+        actual val TvInputHdmi4: Key
+            get() = Key(-1000000162)
+        actual val TvInputComposite1: Key
+            get() = Key(-1000000163)
+        actual val TvInputComposite2: Key
+            get() = Key(-1000000164)
+        actual val TvInputComponent1: Key
+            get() = Key(-1000000165)
+        actual val TvInputComponent2: Key
+            get() = Key(-1000000166)
+        actual val TvInputVga1: Key
+            get() = Key(-1000000167)
+        actual val TvAudioDescription: Key
+            get() = Key(-1000000168)
+        actual val TvAudioDescriptionMixingVolumeUp: Key
+            get() = Key(-1000000169)
+        actual val TvAudioDescriptionMixingVolumeDown: Key
+            get() = Key(-1000000170)
+        actual val TvZoomMode: Key
+            get() = Key(-1000000171)
+        actual val TvContentsMenu: Key
+            get() = Key(-1000000172)
+        actual val TvMediaContextMenu: Key
+            get() = Key(-1000000173)
+        actual val TvTimerProgramming: Key
+            get() = Key(-1000000174)
+        actual val StemPrimary: Key
+            get() = Key(-1000000175)
+        actual val Stem1: Key
+            get() = Key(-1000000176)
+        actual val Stem2: Key
+            get() = Key(-1000000177)
+        actual val Stem3: Key
+            get() = Key(-1000000178)
+        actual val AllApps: Key
+            get() = Key(-1000000179)
+        actual val Refresh: Key
+            get() = Key(-1000000180)
+        actual val ThumbsUp: Key
+            get() = Key(-1000000181)
+        actual val ThumbsDown: Key
+            get() = Key(-1000000182)
+        actual val ProfileSwitch: Key
+            get() = Key(-1000000183)
+        actual val Help: Key
+            get() = Key(-1000000184)
+        actual val Plus: Key
+            get() = Key(-1000000185)
+        actual val Multiply: Key
+            get() = Key(-1000000186)
+        actual val Pound: Key
+            get() = Key(-1000000187)
+        actual val Cut: Key
+            get() = Key(-1000000188)
+        actual val Copy: Key
+            get() = Key(-1000000189)
+        actual val Paste: Key
+            get() = Key(-1000000190)
+        actual val Apostrophe: Key
+            get() = Key(-1000000191)
+        actual val At: Key
+            get() = Key(-10000001902)
+        actual val NumPadDot: Key
+            get() = Key(-1000000193)
+        actual val NumPadComma: Key
+            get() = Key(-1000000194)
+        actual val NumPadEquals: Key
+            get() = Key(-1000000195)
+        actual val NumPadLeftParenthesis: Key
+            get() = Key(-1000000196)
+        actual val NumPadRightParenthesis: Key
+            get() = Key(-1000000197)
+        actual val NumPadDirectionUp: Key
+            get() = Key(-1000000198)
+        actual val NumPadDirectionDown: Key
+            get() = Key(-1000000199)
+        actual val NumPadDirectionLeft: Key
+            get() = Key(-1000000200)
+        actual val NumPadDirectionRight: Key
+            get() = Key(-1000000201)
+        actual val NumPadMoveHome: Key
+            get() = Key(-1000000202)
+        actual val NumPadMoveEnd: Key
+            get() = Key(-1000000203)
+        actual val NumPadPageUp: Key
+            get() = Key(-1000000204)
+        actual val NumPadPageDown: Key
+            get() = Key(-1000000205)
+        actual val NumPadInsert: Key
+            get() = Key(-1000000206)
+        actual val NumPadDelete: Key
+            get() = Key(-1000000208)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
@@ -21,18 +21,23 @@ import kotlin.jvm.JvmInline
 
 // TODO replace MouseButton by this class after we upstream it
 
-@JvmInline
 /**
  * Represents the index of a pointer button.
  * See [PointerEvent.button], where [PointerButton] is used.
  */
+@JvmInline
 value class PointerButton(val index: Int) {
     companion object {
-        val Primary = PointerButton(0)
-        val Secondary = PointerButton(1)
-        val Tertiary = PointerButton(2)
-        val Back = PointerButton(3)
-        val Forward = PointerButton(4)
+        val Primary: PointerButton
+            get() = PointerButton(0)
+        val Secondary: PointerButton
+            get() = PointerButton(1)
+        val Tertiary: PointerButton
+            get() = PointerButton(2)
+        val Back: PointerButton
+            get() = PointerButton(3)
+        val Forward: PointerButton
+            get() = PointerButton(4)
     }
 }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
@@ -27,7 +27,8 @@ import androidx.compose.ui.input.key.Key.Companion.Number
 actual value class Key(val keyCode: Long) {
     actual companion object {
         /** Unknown key. */
-        actual val Unknown = Key(-1)
+        actual val Unknown: Key
+            get() = Key(-1)
 
         /**
          * System Home key.
@@ -41,288 +42,372 @@ actual value class Key(val keyCode: Long) {
                 "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
             level = DeprecationLevel.ERROR,
         )
-        actual val Home = Key(36)
+        actual val Home: Key
+            get() = Key(36)
 
         /**
          * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
-        actual val SystemHome: Key = Key(-1000000207)
+        actual val SystemHome: Key
+            get() = Key(-1000000207)
 
         /**
          * Up Arrow Key / Directional Pad Up key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionUp = Key(38)
+        actual val DirectionUp: Key
+            get() = Key(38)
 
         /**
          * Down Arrow Key / Directional Pad Down key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionDown = Key(40)
+        actual val DirectionDown: Key
+            get() = Key(40)
 
         /**
          * Left Arrow Key / Directional Pad Left key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionLeft = Key(37)
+        actual val DirectionLeft: Key
+            get() = Key(37)
 
         /**
          * Right Arrow Key / Directional Pad Right key.
          *
          * May also be synthesized from trackball motions.
          */
-        actual val DirectionRight = Key(39)
+        actual val DirectionRight: Key
+            get() = Key(39)
 
         /** '0' key. */
-        actual val Zero = Key(48)
+        actual val Zero: Key
+            get() = Key(48)
 
         /** '1' key. */
-        actual val One = Key(49)
+        actual val One: Key
+            get() = Key(49)
 
         /** '2' key. */
-        actual val Two = Key(50)
+        actual val Two: Key
+            get() = Key(50)
 
         /** '3' key. */
-        actual val Three = Key(51)
+        actual val Three: Key
+            get() = Key(51)
 
         /** '4' key. */
-        actual val Four = Key(52)
+        actual val Four: Key
+            get() = Key(52)
 
         /** '5' key. */
-        actual val Five = Key(53)
+        actual val Five: Key
+            get() = Key(53)
 
         /** '6' key. */
-        actual val Six = Key(54)
+        actual val Six: Key
+            get() = Key(54)
 
         /** '7' key. */
-        actual val Seven = Key(55)
+        actual val Seven: Key
+            get() = Key(55)
 
         /** '8' key. */
-        actual val Eight = Key(56)
+        actual val Eight: Key
+            get() = Key(56)
 
         /** '9' key. */
-        actual val Nine = Key(57)
+        actual val Nine: Key
+            get() = Key(57)
 
         /** '-' key. */
-        actual val Minus = Key(173)
+        actual val Minus: Key
+            get() = Key(173)
 
         /** '=' key. */
-        actual val Equals = Key(61)
+        actual val Equals: Key
+            get() = Key(61)
 
         /** 'A' key. */
-        actual val A = Key(65)
+        actual val A: Key
+            get() = Key(65)
 
         /** 'B' key. */
-        actual val B = Key(66)
+        actual val B: Key
+            get() = Key(66)
 
         /** 'C' key. */
-        actual val C = Key(67)
+        actual val C: Key
+            get() = Key(67)
 
         /** 'D' key. */
-        actual val D = Key(68)
+        actual val D: Key
+            get() = Key(68)
 
         /** 'E' key. */
-        actual val E = Key(69)
+        actual val E: Key
+            get() = Key(69)
 
         /** 'F' key. */
-        actual val F = Key(70)
+        actual val F: Key
+            get() = Key(70)
 
         /** 'G' key. */
-        actual val G = Key(71)
+        actual val G: Key
+            get() = Key(71)
 
         /** 'H' key. */
-        actual val H = Key(72)
+        actual val H: Key
+            get() = Key(72)
 
         /** 'I' key. */
-        actual val I = Key(73)
+        actual val I: Key
+            get() = Key(73)
 
         /** 'J' key. */
-        actual val J = Key(74)
+        actual val J: Key
+            get() = Key(74)
 
         /** 'K' key. */
-        actual val K = Key(75)
+        actual val K: Key
+            get() = Key(75)
 
         /** 'L' key. */
-        actual val L = Key(76)
+        actual val L: Key
+            get() = Key(76)
 
         /** 'M' key. */
-        actual val M = Key(77)
+        actual val M: Key
+            get() = Key(77)
 
         /** 'N' key. */
-        actual val N = Key(78)
+        actual val N: Key
+            get() = Key(78)
 
         /** 'O' key. */
-        actual val O = Key(79)
+        actual val O: Key
+            get() = Key(79)
 
         /** 'P' key. */
-        actual val P = Key(80)
+        actual val P: Key
+            get() = Key(80)
 
         /** 'Q' key. */
-        actual val Q = Key(81)
+        actual val Q: Key
+            get() = Key(81)
 
         /** 'R' key. */
-        actual val R = Key(82)
+        actual val R: Key
+            get() = Key(82)
 
         /** 'S' key. */
-        actual val S = Key(83)
+        actual val S: Key
+            get() = Key(83)
 
         /** 'T' key. */
-        actual val T = Key(84)
+        actual val T: Key
+            get() = Key(84)
 
         /** 'U' key. */
-        actual val U = Key(85)
+        actual val U: Key
+            get() = Key(85)
 
         /** 'V' key. */
-        actual val V = Key(86)
+        actual val V: Key
+            get() = Key(86)
 
         /** 'W' key. */
-        actual val W = Key(87)
+        actual val W: Key
+            get() = Key(87)
 
         /** 'X' key. */
-        actual val X = Key(88)
+        actual val X: Key
+            get() = Key(88)
 
         /** 'Y' key. */
-        actual val Y = Key(89)
+        actual val Y: Key
+            get() = Key(89)
 
         /** 'Z' key. */
-        actual val Z = Key(90)
+        actual val Z: Key
+            get() = Key(90)
 
         /** ',' key. */
-        actual val Comma = Key(188)
+        actual val Comma: Key
+            get() = Key(188)
 
         /** '.' key. */
-        actual val Period = Key(190)
+        actual val Period: Key
+            get() = Key(190)
 
         /** Left Alt modifier key. */
-        actual val AltLeft = Key(18)
+        actual val AltLeft: Key
+            get() = Key(18)
 
         /** Right Alt modifier key. */
-        actual val AltRight = Key(225)
+        actual val AltRight: Key
+            get() = Key(225)
 
         /** Left Shift modifier key. */
-        actual val ShiftLeft = Key(16)
+        actual val ShiftLeft: Key
+            get() = Key(16)
 
         /** Right Shift modifier key. */
-        actual val ShiftRight = Key(-2147483632) // 0x80000000.toInt() or 16
+        actual val ShiftRight: Key
+            get() = Key(-2147483632) // 0x80000000.toInt() or 16
 
         /** Tab key. */
-        actual val Tab = Key(9)
+        actual val Tab: Key
+            get() = Key(9)
 
         /** Space key. */
-        actual val Spacebar = Key(32)
+        actual val Spacebar: Key
+            get() = Key(32)
 
         /** Enter key. */
-        actual val Enter = Key(13)
+        actual val Enter: Key
+            get() = Key(13)
 
         /**
          * Backspace key.
          *
          * Deletes characters before the insertion point, unlike [Delete].
          */
-        actual val Backspace = Key(8)
+        actual val Backspace: Key
+            get() = Key(8)
 
         /**
          * Delete key.
          *
          * Deletes characters ahead of the insertion point, unlike [Backspace].
          */
-        actual val Delete = Key(46)
+        actual val Delete: Key
+            get() = Key(46)
 
         /** Escape key. */
-        actual val Escape = Key(27)
+        actual val Escape: Key
+            get() = Key(27)
 
         /** Left Control modifier key. */
-        actual val CtrlLeft = Key(17)
+        actual val CtrlLeft: Key
+            get() = Key(17)
 
         /** Right Control modifier key. */
-        actual val CtrlRight = Key(-2147483631) // 0x80000000.toInt() or 17
+        actual val CtrlRight: Key
+            get() = Key(-2147483631) // 0x80000000.toInt() or 17
 
         /** Caps Lock key. */
-        actual val CapsLock = Key(20)
+        actual val CapsLock: Key
+            get() = Key(20)
 
         /** Scroll Lock key. */
-        actual val ScrollLock = Key(145)
+        actual val ScrollLock: Key
+            get() = Key(145)
 
         /** Left Meta modifier key. */
-        actual val MetaLeft = Key(224)
+        actual val MetaLeft: Key
+            get() = Key(224)
 
         /** Right Meta modifier key. */
-        actual val MetaRight = Key(-2147483424) // 0x80000000.toInt() or 224
+        actual val MetaRight: Key
+            get() = Key(-2147483424) // 0x80000000.toInt() or 224
 
         /** System Request / Print Screen key. */
-        actual val PrintScreen = Key(44)
+        actual val PrintScreen: Key
+            get() = Key(44)
 
         /**
          * Insert key.
          *
          * Toggles insert / overwrite edit mode.
          */
-        actual val Insert = Key(45)
+        actual val Insert: Key
+            get() = Key(45)
 
         /** '`' (backtick) key. */
-        actual val Grave = Key(192)
+        actual val Grave: Key
+            get() = Key(192)
 
         /** '[' key. */
-        actual val LeftBracket = Key(219)
+        actual val LeftBracket: Key
+            get() = Key(219)
 
         /** ']' key. */
-        actual val RightBracket = Key(221)
+        actual val RightBracket: Key
+            get() = Key(221)
 
         /** '/' key. */
-        actual val Slash = Key(191)
+        actual val Slash: Key
+            get() = Key(191)
 
         /** '\' key. */
-        actual val Backslash = Key(220)
+        actual val Backslash: Key
+            get() = Key(220)
 
         /** ';' key. */
-        actual val Semicolon = Key(59)
+        actual val Semicolon: Key
+            get() = Key(59)
 
         /** Page Up key. */
-        actual val PageUp = Key(33)
+        actual val PageUp: Key
+            get() = Key(33)
 
         /** Page Down key. */
-        actual val PageDown = Key(34)
+        actual val PageDown: Key
+            get() = Key(34)
 
         /** F1 key. */
-        actual val F1 = Key(112)
+        actual val F1: Key
+            get() = Key(112)
 
         /** F2 key. */
-        actual val F2 = Key(113)
+        actual val F2: Key
+            get() = Key(113)
 
         /** F3 key. */
-        actual val F3 = Key(114)
+        actual val F3: Key
+            get() = Key(114)
 
         /** F4 key. */
-        actual val F4 = Key(115)
+        actual val F4: Key
+            get() = Key(115)
 
         /** F5 key. */
-        actual val F5 = Key(116)
+        actual val F5: Key
+            get() = Key(116)
 
         /** F6 key. */
-        actual val F6 = Key(117)
+        actual val F6: Key
+            get() = Key(117)
 
         /** F7 key. */
-        actual val F7 = Key(118)
+        actual val F7: Key
+            get() = Key(118)
 
         /** F8 key. */
-        actual val F8 = Key(119)
+        actual val F8: Key
+            get() = Key(119)
 
         /** F9 key. */
-        actual val F9 = Key(120)
+        actual val F9: Key
+            get() = Key(120)
 
         /** F10 key. */
-        actual val F10 = Key(121)
+        actual val F10: Key
+            get() = Key(121)
 
         /** F11 key. */
-        actual val F11 = Key(122)
+        actual val F11: Key
+            get() = Key(122)
 
         /** F12 key. */
-        actual val F12 = Key(123)
+        actual val F12: Key
+            get() = Key(123)
 
         /**
          * Num Lock key.
@@ -330,254 +415,467 @@ actual value class Key(val keyCode: Long) {
          * This is the Num Lock key; it is different from [Number].
          * This key alters the behavior of other keys on the numeric keypad.
          */
-        actual val NumLock = Key(144)
+        actual val NumLock: Key
+            get() = Key(144)
 
         /** Numeric keypad '0' key. */
-        actual val NumPad0 = Key(96)
+        actual val NumPad0: Key
+            get() = Key(96)
 
         /** Numeric keypad '1' key. */
-        actual val NumPad1 = Key(97)
+        actual val NumPad1: Key
+            get() = Key(97)
 
         /** Numeric keypad '2' key. */
-        actual val NumPad2 = Key(98)
+        actual val NumPad2: Key
+            get() = Key(98)
 
         /** Numeric keypad '3' key. */
-        actual val NumPad3 = Key(99)
+        actual val NumPad3: Key
+            get() = Key(99)
 
         /** Numeric keypad '4' key. */
-        actual val NumPad4 = Key(100)
+        actual val NumPad4: Key
+            get() = Key(100)
 
         /** Numeric keypad '5' key. */
-        actual val NumPad5 = Key(101)
+        actual val NumPad5: Key
+            get() = Key(101)
 
         /** Numeric keypad '6' key. */
-        actual val NumPad6 = Key(102)
+        actual val NumPad6: Key
+            get() = Key(102)
 
         /** Numeric keypad '7' key. */
-        actual val NumPad7 = Key(103)
+        actual val NumPad7: Key
+            get() = Key(103)
 
         /** Numeric keypad '8' key. */
-        actual val NumPad8 = Key(104)
+        actual val NumPad8: Key
+            get() = Key(104)
 
         /** Numeric keypad '9' key. */
-        actual val NumPad9 = Key(105)
+        actual val NumPad9: Key
+            get() = Key(105)
 
         /** Numeric keypad '/' key (for division). */
-        actual val NumPadDivide = Key(111)
+        actual val NumPadDivide: Key
+            get() = Key(111)
 
         /** Numeric keypad '*' key (for multiplication). */
-        actual val NumPadMultiply = Key(106)
+        actual val NumPadMultiply: Key
+            get() = Key(106)
 
         /** Numeric keypad '-' key (for subtraction). */
-        actual val NumPadSubtract = Key(109)
+        actual val NumPadSubtract: Key
+            get() = Key(109)
 
         /** Numeric keypad '+' key (for addition). */
-        actual val NumPadAdd = Key(107)
+        actual val NumPadAdd: Key
+            get() = Key(107)
 
         /** Numeric keypad Enter key. */
-        actual val NumPadEnter = Key(14)
+        actual val NumPadEnter: Key
+            get() = Key(14)
 
-        actual val MoveHome = Key(36)
+        actual val MoveHome: Key
+            get() = Key(36)
 
-        actual val MoveEnd = Key(35)
+        actual val MoveEnd: Key
+            get() = Key(35)
 
-        actual val Apostrophe = Key(222)
+        actual val Apostrophe: Key
+            get() = Key(222)
 
         // Unsupported Keys
-        actual val SoftLeft = Key(-1000000001)
-        actual val SoftRight = Key(-1000000002)
-        actual val Back = Key(-1000000003)
-        actual val NavigatePrevious = Key(-1000000004)
-        actual val NavigateNext = Key(-1000000005)
-        actual val NavigateIn = Key(-1000000006)
-        actual val NavigateOut = Key(-1000000007)
-        actual val SystemNavigationUp = Key(-1000000008)
-        actual val SystemNavigationDown = Key(-1000000009)
-        actual val SystemNavigationLeft = Key(-1000000010)
-        actual val SystemNavigationRight = Key(-1000000011)
-        actual val Call = Key(-1000000012)
-        actual val EndCall = Key(-1000000013)
-        actual val DirectionCenter = Key(-1000000014)
-        actual val DirectionUpLeft = Key(-1000000015)
-        actual val DirectionDownLeft = Key(-1000000016)
-        actual val DirectionUpRight = Key(-1000000017)
-        actual val DirectionDownRight = Key(-1000000018)
-        actual val VolumeUp = Key(-1000000019)
-        actual val VolumeDown = Key(-1000000020)
-        actual val Power = Key(-1000000021)
-        actual val Camera = Key(-1000000022)
-        actual val Clear = Key(-1000000023)
-        actual val Symbol = Key(-1000000024)
-        actual val Browser = Key(-1000000025)
-        actual val Envelope = Key(-1000000026)
-        actual val Function = Key(-1000000027)
-        actual val Break = Key(-1000000028)
-        actual val Number = Key(-1000000031)
-        actual val HeadsetHook = Key(-1000000032)
-        actual val Focus = Key(-1000000033)
-        actual val Menu = Key(-1000000034)
-        actual val Notification = Key(-1000000035)
-        actual val Search = Key(-1000000036)
-        actual val PictureSymbols = Key(-1000000037)
-        actual val SwitchCharset = Key(-1000000038)
-        actual val ButtonA = Key(-1000000039)
-        actual val ButtonB = Key(-1000000040)
-        actual val ButtonC = Key(-1000000041)
-        actual val ButtonX = Key(-1000000042)
-        actual val ButtonY = Key(-1000000043)
-        actual val ButtonZ = Key(-1000000044)
-        actual val ButtonL1 = Key(-1000000045)
-        actual val ButtonR1 = Key(-1000000046)
-        actual val ButtonL2 = Key(-1000000047)
-        actual val ButtonR2 = Key(-1000000048)
-        actual val ButtonThumbLeft = Key(-1000000049)
-        actual val ButtonThumbRight = Key(-1000000050)
-        actual val ButtonStart = Key(-1000000051)
-        actual val ButtonSelect = Key(-1000000052)
-        actual val ButtonMode = Key(-1000000053)
-        actual val Button1 = Key(-1000000054)
-        actual val Button2 = Key(-1000000055)
-        actual val Button3 = Key(-1000000056)
-        actual val Button4 = Key(-1000000057)
-        actual val Button5 = Key(-1000000058)
-        actual val Button6 = Key(-1000000059)
-        actual val Button7 = Key(-1000000060)
-        actual val Button8 = Key(-1000000061)
-        actual val Button9 = Key(-1000000062)
-        actual val Button10 = Key(-1000000063)
-        actual val Button11 = Key(-1000000064)
-        actual val Button12 = Key(-1000000065)
-        actual val Button13 = Key(-1000000066)
-        actual val Button14 = Key(-1000000067)
-        actual val Button15 = Key(-1000000068)
-        actual val Button16 = Key(-1000000069)
-        actual val Forward = Key(-1000000070)
-        actual val MediaPlay = Key(-1000000071)
-        actual val MediaPause = Key(-1000000072)
-        actual val MediaPlayPause = Key(-1000000073)
-        actual val MediaStop = Key(-1000000074)
-        actual val MediaRecord = Key(-1000000075)
-        actual val MediaNext = Key(-1000000076)
-        actual val MediaPrevious = Key(-1000000077)
-        actual val MediaRewind = Key(-1000000078)
-        actual val MediaFastForward = Key(-1000000079)
-        actual val MediaClose = Key(-1000000080)
-        actual val MediaAudioTrack = Key(-1000000081)
-        actual val MediaEject = Key(-1000000082)
-        actual val MediaTopMenu = Key(-1000000083)
-        actual val MediaSkipForward = Key(-1000000084)
-        actual val MediaSkipBackward = Key(-1000000085)
-        actual val MediaStepForward = Key(-1000000086)
-        actual val MediaStepBackward = Key(-1000000087)
-        actual val MicrophoneMute = Key(-1000000088)
-        actual val VolumeMute = Key(-1000000089)
-        actual val Info = Key(-1000000090)
-        actual val ChannelUp = Key(-1000000091)
-        actual val ChannelDown = Key(-1000000092)
-        actual val ZoomIn = Key(-1000000093)
-        actual val ZoomOut = Key(-1000000094)
-        actual val Tv = Key(-1000000095)
-        actual val Window = Key(-1000000096)
-        actual val Guide = Key(-1000000097)
-        actual val Dvr = Key(-1000000098)
-        actual val Bookmark = Key(-1000000099)
-        actual val Captions = Key(-1000000100)
-        actual val Settings = Key(-1000000101)
-        actual val TvPower = Key(-1000000102)
-        actual val TvInput = Key(-1000000103)
-        actual val SetTopBoxPower = Key(-1000000104)
-        actual val SetTopBoxInput = Key(-1000000105)
-        actual val AvReceiverPower = Key(-1000000106)
-        actual val AvReceiverInput = Key(-1000000107)
-        actual val ProgramRed = Key(-1000000108)
-        actual val ProgramGreen = Key(-1000000109)
-        actual val ProgramYellow = Key(-1000000110)
-        actual val ProgramBlue = Key(-1000000111)
-        actual val AppSwitch = Key(-1000000112)
-        actual val LanguageSwitch = Key(-1000000113)
-        actual val MannerMode = Key(-1000000114)
-        actual val Toggle2D3D = Key(-1000000125)
-        actual val Contacts = Key(-1000000126)
-        actual val Calendar = Key(-1000000127)
-        actual val Music = Key(-1000000128)
-        actual val Calculator = Key(-1000000129)
-        actual val ZenkakuHankaru = Key(-1000000130)
-        actual val Eisu = Key(-1000000131)
-        actual val Muhenkan = Key(-1000000132)
-        actual val Henkan = Key(-1000000133)
-        actual val KatakanaHiragana = Key(-1000000134)
-        actual val Yen = Key(-1000000135)
-        actual val Ro = Key(-1000000136)
-        actual val Kana = Key(-1000000137)
-        actual val Assist = Key(-1000000138)
-        actual val BrightnessDown = Key(-1000000139)
-        actual val BrightnessUp = Key(-1000000140)
-        actual val Sleep = Key(-1000000141)
-        actual val WakeUp = Key(-1000000142)
-        actual val SoftSleep = Key(-1000000143)
-        actual val Pairing = Key(-1000000144)
-        actual val LastChannel = Key(-1000000145)
-        actual val TvDataService = Key(-1000000146)
-        actual val VoiceAssist = Key(-1000000147)
-        actual val TvRadioService = Key(-1000000148)
-        actual val TvTeletext = Key(-1000000149)
-        actual val TvNumberEntry = Key(-1000000150)
-        actual val TvTerrestrialAnalog = Key(-1000000151)
-        actual val TvTerrestrialDigital = Key(-1000000152)
-        actual val TvSatellite = Key(-1000000153)
-        actual val TvSatelliteBs = Key(-1000000154)
-        actual val TvSatelliteCs = Key(-1000000155)
-        actual val TvSatelliteService = Key(-1000000156)
-        actual val TvNetwork = Key(-1000000157)
-        actual val TvAntennaCable = Key(-1000000158)
-        actual val TvInputHdmi1 = Key(-1000000159)
-        actual val TvInputHdmi2 = Key(-1000000160)
-        actual val TvInputHdmi3 = Key(-1000000161)
-        actual val TvInputHdmi4 = Key(-1000000162)
-        actual val TvInputComposite1 = Key(-1000000163)
-        actual val TvInputComposite2 = Key(-1000000164)
-        actual val TvInputComponent1 = Key(-1000000165)
-        actual val TvInputComponent2 = Key(-1000000166)
-        actual val TvInputVga1 = Key(-1000000167)
-        actual val TvAudioDescription = Key(-1000000168)
-        actual val TvAudioDescriptionMixingVolumeUp = Key(-1000000169)
-        actual val TvAudioDescriptionMixingVolumeDown = Key(-1000000170)
-        actual val TvZoomMode = Key(-1000000171)
-        actual val TvContentsMenu = Key(-1000000172)
-        actual val TvMediaContextMenu = Key(-1000000173)
-        actual val TvTimerProgramming = Key(-1000000174)
-        actual val StemPrimary = Key(-1000000175)
-        actual val Stem1 = Key(-1000000176)
-        actual val Stem2 = Key(-1000000177)
-        actual val Stem3 = Key(-1000000178)
-        actual val AllApps = Key(-1000000179)
-        actual val Refresh = Key(-1000000180)
-        actual val ThumbsUp = Key(-1000000181)
-        actual val ThumbsDown = Key(-1000000182)
-        actual val ProfileSwitch = Key(-1000000183)
-        actual val Help = Key(-1000000184)
-        actual val Plus = Key(-1000000185)
-        actual val Multiply = Key(-1000000186)
-        actual val Pound = Key(-1000000187)
-        actual val Cut = Key(-1000000188)
-        actual val Copy = Key(-1000000189)
-        actual val Paste = Key(-1000000190)
-        actual val At = Key(-10000001902)
-        actual val NumPadDot = Key(-1000000193)
-        actual val NumPadComma = Key(-1000000194)
-        actual val NumPadEquals = Key(-1000000195)
-        actual val NumPadLeftParenthesis = Key(-1000000196)
-        actual val NumPadRightParenthesis = Key(-1000000197)
-        actual val NumPadDirectionUp = Key(-1000000198)
-        actual val NumPadDirectionDown = Key(-1000000199)
-        actual val NumPadDirectionLeft = Key(-1000000200)
-        actual val NumPadDirectionRight = Key(-1000000201)
-        actual val NumPadMoveHome = Key(-1000000202)
-        actual val NumPadMoveEnd = Key(-1000000203)
-        actual val NumPadPageUp = Key(-1000000204)
-        actual val NumPadPageDown = Key(-1000000205)
-        actual val NumPadInsert = Key(-1000000206)
-        actual val NumPadDelete: Key = Key(-1000000208)
+        actual val SoftLeft: Key
+            get() = Key(-1000000001)
+        actual val SoftRight: Key
+            get() = Key(-1000000002)
+        actual val Back: Key
+            get() = Key(-1000000003)
+        actual val NavigatePrevious: Key
+            get() = Key(-1000000004)
+        actual val NavigateNext: Key
+            get() = Key(-1000000005)
+        actual val NavigateIn: Key
+            get() = Key(-1000000006)
+        actual val NavigateOut: Key
+            get() = Key(-1000000007)
+        actual val SystemNavigationUp: Key
+            get() = Key(-1000000008)
+        actual val SystemNavigationDown: Key
+            get() = Key(-1000000009)
+        actual val SystemNavigationLeft: Key
+            get() = Key(-1000000010)
+        actual val SystemNavigationRight: Key
+            get() = Key(-1000000011)
+        actual val Call: Key
+            get() = Key(-1000000012)
+        actual val EndCall: Key
+            get() = Key(-1000000013)
+        actual val DirectionCenter: Key
+            get() = Key(-1000000014)
+        actual val DirectionUpLeft: Key
+            get() = Key(-1000000015)
+        actual val DirectionDownLeft: Key
+            get() = Key(-1000000016)
+        actual val DirectionUpRight: Key
+            get() = Key(-1000000017)
+        actual val DirectionDownRight: Key
+            get() = Key(-1000000018)
+        actual val VolumeUp: Key
+            get() = Key(-1000000019)
+        actual val VolumeDown: Key
+            get() = Key(-1000000020)
+        actual val Power: Key
+            get() = Key(-1000000021)
+        actual val Camera: Key
+            get() = Key(-1000000022)
+        actual val Clear: Key
+            get() = Key(-1000000023)
+        actual val Symbol: Key
+            get() = Key(-1000000024)
+        actual val Browser: Key
+            get() = Key(-1000000025)
+        actual val Envelope: Key
+            get() = Key(-1000000026)
+        actual val Function: Key
+            get() = Key(-1000000027)
+        actual val Break: Key
+            get() = Key(-1000000028)
+        actual val Number: Key
+            get() = Key(-1000000031)
+        actual val HeadsetHook: Key
+            get() = Key(-1000000032)
+        actual val Focus: Key
+            get() = Key(-1000000033)
+        actual val Menu: Key
+            get() = Key(-1000000034)
+        actual val Notification: Key
+            get() = Key(-1000000035)
+        actual val Search: Key
+            get() = Key(-1000000036)
+        actual val PictureSymbols: Key
+            get() = Key(-1000000037)
+        actual val SwitchCharset: Key
+            get() = Key(-1000000038)
+        actual val ButtonA: Key
+            get() = Key(-1000000039)
+        actual val ButtonB: Key
+            get() = Key(-1000000040)
+        actual val ButtonC: Key
+            get() = Key(-1000000041)
+        actual val ButtonX: Key
+            get() = Key(-1000000042)
+        actual val ButtonY: Key
+            get() = Key(-1000000043)
+        actual val ButtonZ: Key
+            get() = Key(-1000000044)
+        actual val ButtonL1: Key
+            get() = Key(-1000000045)
+        actual val ButtonR1: Key
+            get() = Key(-1000000046)
+        actual val ButtonL2: Key
+            get() = Key(-1000000047)
+        actual val ButtonR2: Key
+            get() = Key(-1000000048)
+        actual val ButtonThumbLeft: Key
+            get() = Key(-1000000049)
+        actual val ButtonThumbRight: Key
+            get() = Key(-1000000050)
+        actual val ButtonStart: Key
+            get() = Key(-1000000051)
+        actual val ButtonSelect: Key
+            get() = Key(-1000000052)
+        actual val ButtonMode: Key
+            get() = Key(-1000000053)
+        actual val Button1: Key
+            get() = Key(-1000000054)
+        actual val Button2: Key
+            get() = Key(-1000000055)
+        actual val Button3: Key
+            get() = Key(-1000000056)
+        actual val Button4: Key
+            get() = Key(-1000000057)
+        actual val Button5: Key
+            get() = Key(-1000000058)
+        actual val Button6: Key
+            get() = Key(-1000000059)
+        actual val Button7: Key
+            get() = Key(-1000000060)
+        actual val Button8: Key
+            get() = Key(-1000000061)
+        actual val Button9: Key
+            get() = Key(-1000000062)
+        actual val Button10: Key
+            get() = Key(-1000000063)
+        actual val Button11: Key
+            get() = Key(-1000000064)
+        actual val Button12: Key
+            get() = Key(-1000000065)
+        actual val Button13: Key
+            get() = Key(-1000000066)
+        actual val Button14: Key
+            get() = Key(-1000000067)
+        actual val Button15: Key
+            get() = Key(-1000000068)
+        actual val Button16: Key
+            get() = Key(-1000000069)
+        actual val Forward: Key
+            get() = Key(-1000000070)
+        actual val MediaPlay: Key
+            get() = Key(-1000000071)
+        actual val MediaPause: Key
+            get() = Key(-1000000072)
+        actual val MediaPlayPause: Key
+            get() = Key(-1000000073)
+        actual val MediaStop: Key
+            get() = Key(-1000000074)
+        actual val MediaRecord: Key
+            get() = Key(-1000000075)
+        actual val MediaNext: Key
+            get() = Key(-1000000076)
+        actual val MediaPrevious: Key
+            get() = Key(-1000000077)
+        actual val MediaRewind: Key
+            get() = Key(-1000000078)
+        actual val MediaFastForward: Key
+            get() = Key(-1000000079)
+        actual val MediaClose: Key
+            get() = Key(-1000000080)
+        actual val MediaAudioTrack: Key
+            get() = Key(-1000000081)
+        actual val MediaEject: Key
+            get() = Key(-1000000082)
+        actual val MediaTopMenu: Key
+            get() = Key(-1000000083)
+        actual val MediaSkipForward: Key
+            get() = Key(-1000000084)
+        actual val MediaSkipBackward: Key
+            get() = Key(-1000000085)
+        actual val MediaStepForward: Key
+            get() = Key(-1000000086)
+        actual val MediaStepBackward: Key
+            get() = Key(-1000000087)
+        actual val MicrophoneMute: Key
+            get() = Key(-1000000088)
+        actual val VolumeMute: Key
+            get() = Key(-1000000089)
+        actual val Info: Key
+            get() = Key(-1000000090)
+        actual val ChannelUp: Key
+            get() = Key(-1000000091)
+        actual val ChannelDown: Key
+            get() = Key(-1000000092)
+        actual val ZoomIn: Key
+            get() = Key(-1000000093)
+        actual val ZoomOut: Key
+            get() = Key(-1000000094)
+        actual val Tv: Key
+            get() = Key(-1000000095)
+        actual val Window: Key
+            get() = Key(-1000000096)
+        actual val Guide: Key
+            get() = Key(-1000000097)
+        actual val Dvr: Key
+            get() = Key(-1000000098)
+        actual val Bookmark: Key
+            get() = Key(-1000000099)
+        actual val Captions: Key
+            get() = Key(-1000000100)
+        actual val Settings: Key
+            get() = Key(-1000000101)
+        actual val TvPower: Key
+            get() = Key(-1000000102)
+        actual val TvInput: Key
+            get() = Key(-1000000103)
+        actual val SetTopBoxPower: Key
+            get() = Key(-1000000104)
+        actual val SetTopBoxInput: Key
+            get() = Key(-1000000105)
+        actual val AvReceiverPower: Key
+            get() = Key(-1000000106)
+        actual val AvReceiverInput: Key
+            get() = Key(-1000000107)
+        actual val ProgramRed: Key
+            get() = Key(-1000000108)
+        actual val ProgramGreen: Key
+            get() = Key(-1000000109)
+        actual val ProgramYellow: Key
+            get() = Key(-1000000110)
+        actual val ProgramBlue: Key
+            get() = Key(-1000000111)
+        actual val AppSwitch: Key
+            get() = Key(-1000000112)
+        actual val LanguageSwitch: Key
+            get() = Key(-1000000113)
+        actual val MannerMode: Key
+            get() = Key(-1000000114)
+        actual val Toggle2D3D: Key
+            get() = Key(-1000000125)
+        actual val Contacts: Key
+            get() = Key(-1000000126)
+        actual val Calendar: Key
+            get() = Key(-1000000127)
+        actual val Music: Key
+            get() = Key(-1000000128)
+        actual val Calculator: Key
+            get() = Key(-1000000129)
+        actual val ZenkakuHankaru: Key
+            get() = Key(-1000000130)
+        actual val Eisu: Key
+            get() = Key(-1000000131)
+        actual val Muhenkan: Key
+            get() = Key(-1000000132)
+        actual val Henkan: Key
+            get() = Key(-1000000133)
+        actual val KatakanaHiragana: Key
+            get() = Key(-1000000134)
+        actual val Yen: Key
+            get() = Key(-1000000135)
+        actual val Ro: Key
+            get() = Key(-1000000136)
+        actual val Kana: Key
+            get() = Key(-1000000137)
+        actual val Assist: Key
+            get() = Key(-1000000138)
+        actual val BrightnessDown: Key
+            get() = Key(-1000000139)
+        actual val BrightnessUp: Key
+            get() = Key(-1000000140)
+        actual val Sleep: Key
+            get() = Key(-1000000141)
+        actual val WakeUp: Key
+            get() = Key(-1000000142)
+        actual val SoftSleep: Key
+            get() = Key(-1000000143)
+        actual val Pairing: Key
+            get() = Key(-1000000144)
+        actual val LastChannel: Key
+            get() = Key(-1000000145)
+        actual val TvDataService: Key
+            get() = Key(-1000000146)
+        actual val VoiceAssist: Key
+            get() = Key(-1000000147)
+        actual val TvRadioService: Key
+            get() = Key(-1000000148)
+        actual val TvTeletext: Key
+            get() = Key(-1000000149)
+        actual val TvNumberEntry: Key
+            get() = Key(-1000000150)
+        actual val TvTerrestrialAnalog: Key
+            get() = Key(-1000000151)
+        actual val TvTerrestrialDigital: Key
+            get() = Key(-1000000152)
+        actual val TvSatellite: Key
+            get() = Key(-1000000153)
+        actual val TvSatelliteBs: Key
+            get() = Key(-1000000154)
+        actual val TvSatelliteCs: Key
+            get() = Key(-1000000155)
+        actual val TvSatelliteService: Key
+            get() = Key(-1000000156)
+        actual val TvNetwork: Key
+            get() = Key(-1000000157)
+        actual val TvAntennaCable: Key
+            get() = Key(-1000000158)
+        actual val TvInputHdmi1: Key
+            get() = Key(-1000000159)
+        actual val TvInputHdmi2: Key
+            get() = Key(-1000000160)
+        actual val TvInputHdmi3: Key
+            get() = Key(-1000000161)
+        actual val TvInputHdmi4: Key
+            get() = Key(-1000000162)
+        actual val TvInputComposite1: Key
+            get() = Key(-1000000163)
+        actual val TvInputComposite2: Key
+            get() = Key(-1000000164)
+        actual val TvInputComponent1: Key
+            get() = Key(-1000000165)
+        actual val TvInputComponent2: Key
+            get() = Key(-1000000166)
+        actual val TvInputVga1: Key
+            get() = Key(-1000000167)
+        actual val TvAudioDescription: Key
+            get() = Key(-1000000168)
+        actual val TvAudioDescriptionMixingVolumeUp: Key
+            get() = Key(-1000000169)
+        actual val TvAudioDescriptionMixingVolumeDown: Key
+            get() = Key(-1000000170)
+        actual val TvZoomMode: Key
+            get() = Key(-1000000171)
+        actual val TvContentsMenu: Key
+            get() = Key(-1000000172)
+        actual val TvMediaContextMenu: Key
+            get() = Key(-1000000173)
+        actual val TvTimerProgramming: Key
+            get() = Key(-1000000174)
+        actual val StemPrimary: Key
+            get() = Key(-1000000175)
+        actual val Stem1: Key
+            get() = Key(-1000000176)
+        actual val Stem2: Key
+            get() = Key(-1000000177)
+        actual val Stem3: Key
+            get() = Key(-1000000178)
+        actual val AllApps: Key
+            get() = Key(-1000000179)
+        actual val Refresh: Key
+            get() = Key(-1000000180)
+        actual val ThumbsUp: Key
+            get() = Key(-1000000181)
+        actual val ThumbsDown: Key
+            get() = Key(-1000000182)
+        actual val ProfileSwitch: Key
+            get() = Key(-1000000183)
+        actual val Help: Key
+            get() = Key(-1000000184)
+        actual val Plus: Key
+            get() = Key(-1000000185)
+        actual val Multiply: Key
+            get() = Key(-1000000186)
+        actual val Pound: Key
+            get() = Key(-1000000187)
+        actual val Cut: Key
+            get() = Key(-1000000188)
+        actual val Copy: Key
+            get() = Key(-1000000189)
+        actual val Paste: Key
+            get() = Key(-1000000190)
+        actual val At: Key
+            get() = Key(-10000001902)
+        actual val NumPadDot: Key
+            get() = Key(-1000000193)
+        actual val NumPadComma: Key
+            get() = Key(-1000000194)
+        actual val NumPadEquals: Key
+            get() = Key(-1000000195)
+        actual val NumPadLeftParenthesis: Key
+            get() = Key(-1000000196)
+        actual val NumPadRightParenthesis: Key
+            get() = Key(-1000000197)
+        actual val NumPadDirectionUp: Key
+            get() = Key(-1000000198)
+        actual val NumPadDirectionDown: Key
+            get() = Key(-1000000199)
+        actual val NumPadDirectionLeft: Key
+            get() = Key(-1000000200)
+        actual val NumPadDirectionRight: Key
+            get() = Key(-1000000201)
+        actual val NumPadMoveHome: Key
+            get() = Key(-1000000202)
+        actual val NumPadMoveEnd: Key
+            get() = Key(-1000000203)
+        actual val NumPadPageUp: Key
+            get() = Key(-1000000204)
+        actual val NumPadPageDown: Key
+            get() = Key(-1000000205)
+        actual val NumPadInsert: Key
+            get() = Key(-1000000206)
+        actual val NumPadDelete: Key
+            get() = Key(-1000000208)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"


### PR DESCRIPTION
As done in common source sets value classes
See these PRs for more context:
https://android-review.googlesource.com/c/platform/frameworks/support/+/4165586
https://android-review.googlesource.com/c/platform/frameworks/support/+/4160767
https://android-review.googlesource.com/c/platform/frameworks/support/+/4169968 (internal value classes get getterized and inlined)

## Release Notes
### Migration Notes - Desktop
- Libraries using `DragAndDropTransferAction` must be recompiled because of a breaking API change.
